### PR TITLE
add notebook for pulling cmip6 data from gcs cmip6 bucket

### DIFF
--- a/notebooks/pull_cmip6_data_from_gcs.ipynb
+++ b/notebooks/pull_cmip6_data_from_gcs.ipynb
@@ -1,0 +1,349 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import intake\n",
+    "import xarray as xr\n",
+    "import os \n",
+    "import pandas as pd\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "get some CMIP6 data from GCS"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "here we're going to get daily `tmax` from `IPSL` for historical and SSP370 runs. The ensemble member `r1i1p1f1` isn't available in GCS so we're using `r4i1p1f1` instead. \n",
+    "\n",
+    "Note that the `activity_id` for historical runs is `CMIP`, not `ScenarioMIP` as it is for the ssp-rcp scenarios. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "activity_id = 'ScenarioMIP'\n",
+    "experiment_id = 'ssp370'\n",
+    "table_id = 'day'\n",
+    "variable_id = 'tasmax'\n",
+    "source_id = 'IPSL-CM6A-LR'\n",
+    "institution_id = 'NCAR'\n",
+    "member_id = 'r4i1p1f1'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "first we'll take a look at what our options are"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "351331"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_cmip6 = pd.read_csv('https://cmip6.storage.googleapis.com/cmip6-zarr-consolidated-stores-noQC.csv', dtype={'version': 'unicode'})\n",
+    "len(df_cmip6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_subset_future = df_cmip6.loc[(df_cmip6['activity_id'] == activity_id) & (df_cmip6['experiment_id'] == experiment_id) \n",
+    "             & (df_cmip6['table_id'] == table_id) & (df_cmip6['variable_id'] == variable_id)\n",
+    "             & (df_cmip6['source_id'] == source_id) & (df_cmip6['member_id'] == member_id)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>activity_id</th>\n",
+       "      <th>institution_id</th>\n",
+       "      <th>source_id</th>\n",
+       "      <th>experiment_id</th>\n",
+       "      <th>member_id</th>\n",
+       "      <th>table_id</th>\n",
+       "      <th>variable_id</th>\n",
+       "      <th>grid_label</th>\n",
+       "      <th>zstore</th>\n",
+       "      <th>dcpp_init_year</th>\n",
+       "      <th>version</th>\n",
+       "      <th>status</th>\n",
+       "      <th>severity</th>\n",
+       "      <th>issue_url</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>319665</th>\n",
+       "      <td>ScenarioMIP</td>\n",
+       "      <td>IPSL</td>\n",
+       "      <td>IPSL-CM6A-LR</td>\n",
+       "      <td>ssp370</td>\n",
+       "      <td>r4i1p1f1</td>\n",
+       "      <td>day</td>\n",
+       "      <td>tasmax</td>\n",
+       "      <td>gr</td>\n",
+       "      <td>gs://cmip6/ScenarioMIP/IPSL/IPSL-CM6A-LR/ssp37...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>20190614</td>\n",
+       "      <td>good</td>\n",
+       "      <td>none</td>\n",
+       "      <td>none</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        activity_id institution_id     source_id experiment_id member_id  \\\n",
+       "319665  ScenarioMIP           IPSL  IPSL-CM6A-LR        ssp370  r4i1p1f1   \n",
+       "\n",
+       "       table_id variable_id grid_label  \\\n",
+       "319665      day      tasmax         gr   \n",
+       "\n",
+       "                                                   zstore  dcpp_init_year  \\\n",
+       "319665  gs://cmip6/ScenarioMIP/IPSL/IPSL-CM6A-LR/ssp37...             NaN   \n",
+       "\n",
+       "         version status severity issue_url  \n",
+       "319665  20190614   good     none      none  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_subset_future "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_subset_hist = df_cmip6.loc[(df_cmip6['experiment_id'] == 'historical') \n",
+    "             & (df_cmip6['table_id'] == table_id) & (df_cmip6['variable_id'] == variable_id) \n",
+    "             & (df_cmip6['source_id'] == source_id) & (df_cmip6['member_id'] == member_id)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>activity_id</th>\n",
+       "      <th>institution_id</th>\n",
+       "      <th>source_id</th>\n",
+       "      <th>experiment_id</th>\n",
+       "      <th>member_id</th>\n",
+       "      <th>table_id</th>\n",
+       "      <th>variable_id</th>\n",
+       "      <th>grid_label</th>\n",
+       "      <th>zstore</th>\n",
+       "      <th>dcpp_init_year</th>\n",
+       "      <th>version</th>\n",
+       "      <th>status</th>\n",
+       "      <th>severity</th>\n",
+       "      <th>issue_url</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>53406</th>\n",
+       "      <td>CMIP</td>\n",
+       "      <td>IPSL</td>\n",
+       "      <td>IPSL-CM6A-LR</td>\n",
+       "      <td>historical</td>\n",
+       "      <td>r4i1p1f1</td>\n",
+       "      <td>day</td>\n",
+       "      <td>tasmax</td>\n",
+       "      <td>gr</td>\n",
+       "      <td>gs://cmip6/CMIP/IPSL/IPSL-CM6A-LR/historical/r...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>20190614</td>\n",
+       "      <td>good</td>\n",
+       "      <td>none</td>\n",
+       "      <td>none</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      activity_id institution_id     source_id experiment_id member_id  \\\n",
+       "53406        CMIP           IPSL  IPSL-CM6A-LR    historical  r4i1p1f1   \n",
+       "\n",
+       "      table_id variable_id grid_label  \\\n",
+       "53406      day      tasmax         gr   \n",
+       "\n",
+       "                                                  zstore  dcpp_init_year  \\\n",
+       "53406  gs://cmip6/CMIP/IPSL/IPSL-CM6A-LR/historical/r...             NaN   \n",
+       "\n",
+       "        version status severity issue_url  \n",
+       "53406  20190614   good     none      none  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_subset_hist"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "now let's actually pull the data "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# search the cmip6 catalog\n",
+    "col = intake.open_esm_datastore(\"https://storage.googleapis.com/cmip6/pangeo-cmip6.json\")\n",
+    "\n",
+    "cat = col.search(activity_id=['CMIP', activity_id], \n",
+    "                 experiment_id=['historical', experiment_id], table_id=table_id, variable_id=variable_id,\n",
+    "                 source_id=source_id, member_id=member_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_model = {}\n",
+    "ds_model['historical'] = cat['CMIP.IPSL.IPSL-CM6A-LR.historical.day.gr'].to_dask().isel(member_id=0\n",
+    "                                                                                       ).squeeze(drop=True).drop(['member_id', \n",
+    "                                                                                                                  'height',\n",
+    "                                                                                                                  'time_bounds'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_model['ssp370'] = cat['ScenarioMIP.IPSL.IPSL-CM6A-LR.ssp370.day.gr'].to_dask().isel(member_id=0\n",
+    "                                                                                       ).squeeze(drop=True).drop(['member_id',\n",
+    "                                                                                                                  'height',\n",
+    "                                                                                                                  'time_bounds'])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR adds a quick example notebook for querying the CMIP6 GCS catalog and pulling CMIP6 data into dask arrays locally. 