### PR TITLE
Add intake-catalog for AZ workflow resource

### DIFF
--- a/workflows/intake-catalog.yaml
+++ b/workflows/intake-catalog.yaml
@@ -1,0 +1,69 @@
+# Intake Catalog for the workflow in-progress
+plugins:
+  source: [ module: intake_xarray ]
+sources:
+  cmip6_raw:
+    description: Catalog of raw CMIP6 GCM data to be cleaned and prepared
+    metadata:
+      title: Raw CMIP6 GCM data
+    parameters:
+      source_id:
+        description: The data source ID
+        default: "ACCESS-ESM1-5"
+        type: str
+      experiment_id:
+        description: The experiment ID
+        type: str
+        default: historical
+        allowed: [ historical, ssp126, ssp245, ssp370 ]
+      member_id:
+        description: The model member ID
+        default: "r1i1p1f1"
+        type: str
+      variable_id:
+        description: The data variable ID
+        default: tasmax
+        type: str
+        allowed: [ tasmax, tasmin, pr ]
+      grid_label:
+        description: The data grid label
+        default: gn
+        type: str
+      item_version:
+        description: The data version
+        default: "20191115"
+        type: str
+    driver: zarr
+    args:
+      urlpath: "az://raw/{{ source_id }}/{{ experiment_id }}/{{ member_id }}/{{ variable_id }}/{{ grid_label }}/{{ item_version }}.zarr"
+      storage_options:
+        account_name: dc6
+
+  cmip6_clean:
+    description: Catalog of cleaned, parsed, and prepared CMIP6 GCM data for input to workflow
+    metadata:
+      title: Cleaned, parsed, and prepared CMIP6 GCM data
+    parameters:
+      source_id:
+        description: The data source ID
+        default: "ACCESS-ESM1-5"
+        type: str
+      division:
+        description: The division or role of the data
+        type: str
+        default: historical
+        allowed: [ historical, training, ssp126, ssp245, ssp370 ]
+      member_id:
+        description: The model member ID
+        default: "r1i1p1f1"
+        type: str
+      variable_id:
+        description: The data variable ID
+        default: tasmax
+        type: str
+        allowed: [ tasmax, tasmin, pr, dtr ]
+    driver: zarr
+    args:
+      urlpath: "az://clean/{{ source_id }}/{{ division }}/{{ member_id }}/{{ variable_id }}.zarr"
+      storage_options:
+        account_name: dc6


### PR DESCRIPTION
 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

This PR adds an intake catalog for the main resources stored in containers on the Azure subscription.

If this merges I can do another PR for the CMIP6 cleaning argo workflow that uses this catalog.

Here is a quick (very engineering-centric) example in Python grabbing environment variables for data specifics in order to get an fsspec URL to the zarr store, using this catalog.
```python
          import os
          import intake

          catalog_url = os.environ.get("CATALOG_URL")
          catalog_source_name = os.environ.get("CATALOG_SOURCE_NAME")

          col = intake.open_catalog(catalog_url)
          cat = col[catalog_source_name]

          target_url = cat.get(
              experiment_id=os.environ.get("EXPERIMENT_ID"),
              variable_id=os.environ.get("VARIABLE_ID"),
              source_id=os.environ.get("SOURCE_ID"),
              member_id=os.environ.get("MEMBER_ID"),
              grid_label=os.environ.get("GRID_LABEL"),
              item_version=os.environ.get("ITEM_VERSION"),
          ).urlpath
```