### PR TITLE
Increase core node pool machine memory

### DIFF
--- a/infrastructure/terraform/modules/aks_cluster/main.tf
+++ b/infrastructure/terraform/modules/aks_cluster/main.tf
@@ -48,7 +48,7 @@ resource "azurerm_kubernetes_cluster" "k8scluster" {
   default_node_pool {
     name                 = "core"
     node_count           = 1
-    vm_size              = "Standard_B2S"
+    vm_size              = "Standard_B2ms"
     enable_auto_scaling  = true
     min_count            = 1
     max_count            = 10


### PR DESCRIPTION
Upgrade the core node pool machine type to increase the available memory so that mino can pass around larger climate data artifacts more effectively in fan-out and fan-in workflow steps.

This is needed to test more efficient regridding in the downscaling step of the workflow. Right now, downscaling to 1/4 degree creates larger artifacts (annual NetCDF files, now ~+2.5 GiB) than we previously have dealt with.