### PR TITLE
Pin floating dodola:dev tags to new 0.3.0 release

### DIFF
--- a/workflows/clean-cmip6-workflow.yaml
+++ b/workflows/clean-cmip6-workflow.yaml
@@ -372,8 +372,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:dev
-        imagePullPolicy: Always
+        image: downscalecmip6.azurecr.io/dodola:0.3.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -415,7 +414,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.3.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -490,7 +489,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.3.0
         env:
           - name: IN1_ZARR
             value: "{{ inputs.parameters.in1-zarr }}"

--- a/workflows/dc6-workflow.yaml
+++ b/workflows/dc6-workflow.yaml
@@ -287,7 +287,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:dev  # Later than 0.2.0...
+        image: downscalecmip6.azurecr.io/dodola:0.3.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -449,8 +449,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
-        imagePullPolicy: Always
+        image: downscalecmip6.azurecr.io/dodola:0.3.0
         env:
           - name: VARIABLE
             value: "{{  inputs.parameters.variable }}"
@@ -543,8 +542,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:dev
-        imagePullPolicy: Always
+        image: downscalecmip6.azurecr.io/dodola:0.3.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -605,8 +603,7 @@ spec:
             s3:
               key: "{{ workflow.name }}/qdm-years/{{ inputs.parameters.year }}.nc"
       container:
-        image: downscalecmip6.azurecr.io/dodola:dev
-        imagePullPolicy: Always
+        image: downscalecmip6.azurecr.io/dodola:0.3.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -840,8 +837,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
-        imagePullPolicy: Always
+        image: downscalecmip6.azurecr.io/dodola:0.3.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -969,8 +965,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
-        imagePullPolicy: Always
+        image: downscalecmip6.azurecr.io/dodola:0.3.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"


### PR DESCRIPTION
We have several references in the workflows to "floating" `dodola:dev`. This PR updates these references, pinning them to the latest `dodola:0.3.0` release. This will help anchor workflow steps to releases with which we know they will work.

This change has a pretty wide reach because 1) we only recently committed the workflow prototypes to the repo and 2) it has been some time since we've done a `dodola` release and much has changed.