### PR TITLE
Give argo workers heavy dask-k8s permissions

### DIFF
--- a/infrastructure/kubernetes/workflows-default/daskkubernetes-role.yaml
+++ b/infrastructure/kubernetes/workflows-default/daskkubernetes-role.yaml
@@ -1,3 +1,5 @@
+# Needed to spawn Dask cluster
+# from https://kubernetes.dask.org/en/latest/kubecluster.html?highlight=rbac#role-based-access-control-rbac
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -20,10 +22,20 @@ rules:
     verbs:
       - "get"
       - "list"
-  - apiGroups: # Newer dask kubernetes functionality begins here:
+  - apiGroups:
       - "" # indicates the core API group
     resources:
       - "services"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "delete"
+  - apiGroups:
+      - "policy"  # indicates the policy API group
+    resources:
+      - "poddisruptionbudgets"
     verbs:
       - "get"
       - "list"

--- a/infrastructure/kubernetes/workflows-default/daskkubernetes-role.yaml
+++ b/infrastructure/kubernetes/workflows-default/daskkubernetes-role.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: daskkubernetes
+rules:
+  - apiGroups:
+      - ""  # indicates the core API group
+    resources:
+      - "pods"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "delete"
+  - apiGroups:
+      - ""  # indicates the core API group
+    resources:
+      - "pods/log"
+    verbs:
+      - "get"
+      - "list"
+  - apiGroups: # Newer dask kubernetes functionality begins here:
+      - "" # indicates the core API group
+    resources:
+      - "services"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "delete"

--- a/infrastructure/kubernetes/workflows-default/kustomization.yaml
+++ b/infrastructure/kubernetes/workflows-default/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./workflow-role.yaml
   - ./workflows-default-serviceaccount.yaml
+  - ./workflow-role.yaml
+  - ./daskkubernetes-role.yaml
+  - ./workflows-default-dask-rolebinding.yaml
   - ./workflows-default-rolebinding.yaml

--- a/infrastructure/kubernetes/workflows-default/workflows-default-dask-rolebinding.yaml
+++ b/infrastructure/kubernetes/workflows-default/workflows-default-dask-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: workflows-default-dask-rolebinding
+subjects:
+  - kind: ServiceAccount
+    name: workflows-default
+roleRef:
+  kind: Role
+  name: daskkubernetes
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This gives Argo Workflow workers permissions to create and manage dask cluster on k8s.