### PR TITLE
add zarr validation and write to azure

### DIFF
--- a/notebooks/era5_workflow/validate_zarrs_and_write_to_azure.ipynb
+++ b/notebooks/era5_workflow/validate_zarrs_and_write_to_azure.ipynb
@@ -1,0 +1,537 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b244315-e8a6-40ca-a2bb-588dfb56dabf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ! pip install adlfs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "70044855-d247-4b96-9b0f-b52b2b37b955",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline \n",
+    "import xarray as xr\n",
+    "import numpy as np\n",
+    "import os \n",
+    "\n",
+    "from adlfs import AzureBlobFileSystem\n",
+    "\n",
+    "import dask.distributed as dd\n",
+    "import dask\n",
+    "import rhg_compute_tools.kubernetes as rhgk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0c2e0288-5d3a-4d2f-b9ad-e9268421566d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gcsfs\n",
+    "fs = gcsfs.GCSFileSystem(token='/opt/gcsfuse_tokens/impactlab-data.json')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "41ec27cd-da7a-4e77-951d-8c62d6b7ffcd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c3ba1f3d5145404e98edb774ae806958",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HTML(value='<h2>GatewayCluster</h2>'), HBox(children=(HTML(value='\\n<div>\\n<style scoped>\\n    …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "client, cluster = rhgk.get_standard_cluster(extra_pip_packages=\"adlfs\")\n",
+    "cluster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f119db26-d7af-4a19-88f2-c413c5fb1689",
+   "metadata": {},
+   "source": [
+    "Validation code for zarr stores "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b4728d82-6017-4ab7-9e98-45e570e0f8cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_for_nans(ds, var):\n",
+    "    \"\"\"\n",
+    "    test for presence of NaNs\n",
+    "    \"\"\"\n",
+    "    assert ds[var].isnull().sum() == 0, \"there are nans!\"\n",
+    "    \n",
+    "def test_date_range(ds, var): \n",
+    "    \"\"\"\n",
+    "    test that first date and last date in zarrs are correct\n",
+    "    \"\"\"\n",
+    "    start_date = datetime.strptime('01 01 1994', '%d %m %Y')\n",
+    "    end_date = datetime.strptime('31 12 2015', '%d %m %Y')\n",
+    "    ds_dates = ds.indexes['time'].to_datetimeindex()\n",
+    "    assert ds_dates[0] == start_date, \"1994 is not the start date\"\n",
+    "    assert ds_dates[-1] == end_date, \"zarr store does not contain the full time series\"\n",
+    "    \n",
+    "def test_lat_lon_length(ds, var):\n",
+    "    \"\"\"\n",
+    "    tests that full lat/lon arrays were written to zarr store\n",
+    "    \"\"\"\n",
+    "    assert len(ds.latitude) == 640, \"the full latitude array did not get written\"\n",
+    "    assert len(ds.longitude) == 1280, \"the full longitude array did not get written\"\n",
+    "    \n",
+    "def validate_zarr_store(ds, var):\n",
+    "    \"\"\"\n",
+    "    validate zarr store by checking for NaNs and that full time series is present \n",
+    "    \"\"\"\n",
+    "    test_for_nans(ds, var)\n",
+    "    test_date_range(ds, var)\n",
+    "    test_lat_lon_length(ds, var)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "111f41bf-b08a-4e69-8dda-1af21073411c",
+   "metadata": {},
+   "source": [
+    "Validate zarr stores by checking a) NaNs, b) valid date range (1994 - 2015 so we can slice the additional +/- 15 days), c) valid lat/lon lengths. Other validation was covered in previous validation steps. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8c580faf-2c44-4f88-974c-257b70514b1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "variables = [\"tasmax\", \"tasmin\", \"dtr\", \"pr\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89ef5a86-7bb9-4826-bc06-3b96fb0a8188",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for var in variables:\n",
+    "    print(\"validating {}\".format(var))\n",
+    "    zarr_storepath = 'gs://impactlab-data/climate/source_data/ERA-5/downscaling/{}.1995-2014.F320.v2.zarr'\n",
+    "    store = fs.get_mapper(zarr_storepath.format(var), check=False)\n",
+    "    with xr.open_zarr(store, consolidated=False) as ds:\n",
+    "        validate_zarr_store(ds, var)\n",
+    "        print(\"finished validating zarr store for {}\".format(var))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35c58959-f395-4ebd-b285-bd00b14f4029",
+   "metadata": {},
+   "source": [
+    "write zarr stores to Azure (account key excluded for privacy purposes) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "80b59d5b-6809-4012-83c6-1dd838d20caf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs_az = AzureBlobFileSystem(\n",
+    "        account_name='dc6',\n",
+    "        account_key='', \n",
+    "        client_id=os.environ.get(\"AZURE_CLIENT_ID\", None),\n",
+    "        client_secret=os.environ.get(\"AZURE_CLIENT_SECRET\", None),\n",
+    "        tenant_id=os.environ.get(\"AZURE_TENANT_ID\", None))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "464668d5-3b6a-4fe0-81af-4b6641081a8a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "wrote zarr store to Azure for tasmax\n",
+      "wrote zarr store to Azure for tasmin\n",
+      "wrote zarr store to Azure for dtr\n"
+     ]
+    }
+   ],
+   "source": [
+    "for var in variables:\n",
+    "    \n",
+    "    zarr_storepath = 'gs://impactlab-data/climate/source_data/ERA-5/downscaling/{}.1995-2014.F320.v2.zarr'\n",
+    "    store = fs.get_mapper(zarr_storepath.format(var), check=False)\n",
+    "    \n",
+    "    with xr.open_zarr(store, consolidated=False) as ds:\n",
+    "    \n",
+    "        zarr_path = \"clean-dev/ERA-5/F320/{}.1995-2015.F320.v2.zarr\"\n",
+    "        az_zarr_direct_path = \"az://clean-dev/ERA-5/{}.1995-2015.F320.v2.zarr\"\n",
+    "        az_zarr_store = fs_az.get_mapper(zarr_path.format(var), check=False)\n",
+    "\n",
+    "        ds.to_zarr(az_zarr_store, consolidated=True, mode=\"w\")\n",
+    "        print(\"wrote zarr store to Azure for {}\".format(var))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f30b69d7-6f62-498f-9ee3-ba98ba50c370",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "0561b2f46df64248a5739fa0d30619fc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "AccordionModel",
+      "state": {
+       "_titles": {
+        "0": "Manual Scaling",
+        "1": "Adaptive Scaling"
+       },
+       "children": [
+        "IPY_MODEL_f9aaee4e868d4db4b07e4022bd9a5948",
+        "IPY_MODEL_63bb8cd930f44ec9bd80e9ed7c928e03"
+       ],
+       "layout": "IPY_MODEL_dd6c2199f9b8482e8c9c492ce70784ac"
+      }
+     },
+     "182739b7c2d3402c9aa4728aeac7c76d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a985f5f5e01744389ae8054998d3c435",
+       "style": "IPY_MODEL_7e5f76cc04c4463983297c4380731aad",
+       "value": "\n<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table style=\"text-align: right;\">\n    <tr><th>Workers</th> <td>0</td></tr>\n    <tr><th>Cores</th> <td>0</td></tr>\n    <tr><th>Memory</th> <td>0 B</td></tr>\n</table>\n</div>\n"
+      }
+     },
+     "258920018f774054acd90e111e8bfdd8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5efbbad98a8348969878e2450a2152b9",
+       "style": "IPY_MODEL_4cf51b6934674ca4aab2f6f9a575c38b",
+       "value": "<p><b>Dashboard: </b><a href=\"/services/dask-gateway/clusters/impactlab-hub.8b65a90fd53c46c4994200605ab32d9f/status\" target=\"_blank\">/services/dask-gateway/clusters/impactlab-hub.8b65a90fd53c46c4994200605ab32d9f/status</a></p>\n"
+      }
+     },
+     "36acd1c2fb354608834cb6950086ff0c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3c4f56b2fe0545afafc19ccce1c4a746": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4cf51b6934674ca4aab2f6f9a575c38b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "54b8c8701d55447e9b1134e8d7e09144": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5efbbad98a8348969878e2450a2152b9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "63bb8cd930f44ec9bd80e9ed7c928e03": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_f2e323ffc1f04d468a64cb70c7aa5c18",
+        "IPY_MODEL_6c4f91afbbae4f84bd234bd36cc81087",
+        "IPY_MODEL_a3512f9ebd954278b0a58f09a775e7fa"
+       ],
+       "layout": "IPY_MODEL_a99f353ac2584556912698916a15359b"
+      }
+     },
+     "66e0aea654e84a1f833d980b687af341": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "68d3e7101d7b416aa3c6f63b79bf0ca4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8dae7b9e7da947ee9e300352e527b24b",
+       "style": "IPY_MODEL_9f0ed5a07a114b33b6e95e003514074c",
+       "value": "<p><b>Name: </b>impactlab-hub.8b65a90fd53c46c4994200605ab32d9f</p>"
+      }
+     },
+     "6c4f91afbbae4f84bd234bd36cc81087": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Maximum",
+       "layout": "IPY_MODEL_6e6ff02c1bd54756b8e9e47be37383c2",
+       "step": 1,
+       "style": "IPY_MODEL_b1bd4b5402a54c23a4c8434f990d2c17"
+      }
+     },
+     "6e6ff02c1bd54756b8e9e47be37383c2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "150px"
+      }
+     },
+     "7e5f76cc04c4463983297c4380731aad": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8dae7b9e7da947ee9e300352e527b24b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "91940ecf19b2497ea34a50bda5fdd5b0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_182739b7c2d3402c9aa4728aeac7c76d",
+        "IPY_MODEL_0561b2f46df64248a5739fa0d30619fc"
+       ],
+       "layout": "IPY_MODEL_93692b1cb10d4ff085cb18f156d66350"
+      }
+     },
+     "93692b1cb10d4ff085cb18f156d66350": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9f0ed5a07a114b33b6e95e003514074c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a0374759b8fc4e46804f7b9554ef3860": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a3512f9ebd954278b0a58f09a775e7fa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Adapt",
+       "layout": "IPY_MODEL_6e6ff02c1bd54756b8e9e47be37383c2",
+       "style": "IPY_MODEL_b1180e88981d44699848e37567e9fd5e"
+      }
+     },
+     "a985f5f5e01744389ae8054998d3c435": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "150px"
+      }
+     },
+     "a99f353ac2584556912698916a15359b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b1180e88981d44699848e37567e9fd5e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "b1bd4b5402a54c23a4c8434f990d2c17": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b8a198f84a2b44e0a18c438ad9f807ea": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "c3ba1f3d5145404e98edb774ae806958": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c7207255ca2d41a4ac0a1067aa9c1b7a",
+        "IPY_MODEL_91940ecf19b2497ea34a50bda5fdd5b0",
+        "IPY_MODEL_68d3e7101d7b416aa3c6f63b79bf0ca4",
+        "IPY_MODEL_258920018f774054acd90e111e8bfdd8"
+       ],
+       "layout": "IPY_MODEL_a0374759b8fc4e46804f7b9554ef3860"
+      }
+     },
+     "c7207255ca2d41a4ac0a1067aa9c1b7a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_66e0aea654e84a1f833d980b687af341",
+       "style": "IPY_MODEL_54b8c8701d55447e9b1134e8d7e09144",
+       "value": "<h2>GatewayCluster</h2>"
+      }
+     },
+     "cb7aa96d3f5e4e3fad325002c437fcb2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Workers",
+       "layout": "IPY_MODEL_6e6ff02c1bd54756b8e9e47be37383c2",
+       "step": 1,
+       "style": "IPY_MODEL_3c4f56b2fe0545afafc19ccce1c4a746"
+      }
+     },
+     "dd6c2199f9b8482e8c9c492ce70784ac": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "500px"
+      }
+     },
+     "e201a1231c544e1487a1446d941ad620": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ecbfc2621bfb41c9a4645997751d30f3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Scale",
+       "layout": "IPY_MODEL_6e6ff02c1bd54756b8e9e47be37383c2",
+       "style": "IPY_MODEL_b8a198f84a2b44e0a18c438ad9f807ea"
+      }
+     },
+     "f2e323ffc1f04d468a64cb70c7aa5c18": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Minimum",
+       "layout": "IPY_MODEL_6e6ff02c1bd54756b8e9e47be37383c2",
+       "step": 1,
+       "style": "IPY_MODEL_36acd1c2fb354608834cb6950086ff0c"
+      }
+     },
+     "f9aaee4e868d4db4b07e4022bd9a5948": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_cb7aa96d3f5e4e3fad325002c437fcb2",
+        "IPY_MODEL_ecbfc2621bfb41c9a4645997751d30f3"
+       ],
+       "layout": "IPY_MODEL_e201a1231c544e1487a1446d941ad620"
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/era5_workflow/validate_zarrs_and_write_to_azure.ipynb
+++ b/notebooks/era5_workflow/validate_zarrs_and_write_to_azure.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1b244315-e8a6-40ca-a2bb-588dfb56dabf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,8 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "70044855-d247-4b96-9b0f-b52b2b37b955",
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,6 +21,7 @@
     "import os \n",
     "\n",
     "from adlfs import AzureBlobFileSystem\n",
+    "from datetime import datetime\n",
     "\n",
     "import dask.distributed as dd\n",
     "import dask\n",
@@ -32,7 +31,6 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "0c2e0288-5d3a-4d2f-b9ad-e9268421566d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,13 +41,12 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "41ec27cd-da7a-4e77-951d-8c62d6b7ffcd",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c3ba1f3d5145404e98edb774ae806958",
+       "model_id": "6bef76e64dae407d857e7acc934b215b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -68,7 +65,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f119db26-d7af-4a19-88f2-c413c5fb1689",
    "metadata": {},
    "source": [
     "Validation code for zarr stores "
@@ -77,7 +73,6 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "b4728d82-6017-4ab7-9e98-45e570e0f8cd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +110,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "111f41bf-b08a-4e69-8dda-1af21073411c",
    "metadata": {},
    "source": [
     "Validate zarr stores by checking a) NaNs, b) valid date range (1994 - 2015 so we can slice the additional +/- 15 days), c) valid lat/lon lengths. Other validation was covered in previous validation steps. "
@@ -124,7 +118,6 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "8c580faf-2c44-4f88-974c-257b70514b1a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,15 +126,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "89ef5a86-7bb9-4826-bc06-3b96fb0a8188",
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "validating pr\n",
+      "finished validating zarr store for pr\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-4-ba36f5af85d3>:13: RuntimeWarning: Converting a CFTimeIndex with dates from a non-standard calendar, 'noleap', to a pandas.DatetimeIndex, which uses dates from the standard calendar.  This may lead to subtle errors in operations that depend on the length of time between dates.\n",
+      "  ds_dates = ds.indexes['time'].to_datetimeindex()\n"
+     ]
+    }
+   ],
    "source": [
     "for var in variables:\n",
     "    print(\"validating {}\".format(var))\n",
-    "    zarr_storepath = 'gs://impactlab-data/climate/source_data/ERA-5/downscaling/{}.1995-2014.F320.v2.zarr'\n",
-    "    store = fs.get_mapper(zarr_storepath.format(var), check=False)\n",
+    "    if var == 'pr':\n",
+    "        version = 'v3'\n",
+    "    else: \n",
+    "        version = 'v2'\n",
+    "    zarr_storepath = 'gs://impactlab-data/climate/source_data/ERA-5/downscaling/{}.1995-2014.F320.{}.zarr'\n",
+    "    store = fs.get_mapper(zarr_storepath.format(var, version), check=False)\n",
     "    with xr.open_zarr(store, consolidated=False) as ds:\n",
     "        validate_zarr_store(ds, var)\n",
     "        print(\"finished validating zarr store for {}\".format(var))"
@@ -149,7 +162,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35c58959-f395-4ebd-b285-bd00b14f4029",
    "metadata": {},
    "source": [
     "write zarr stores to Azure (account key excluded for privacy purposes) "
@@ -157,8 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "80b59d5b-6809-4012-83c6-1dd838d20caf",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,25 +183,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "464668d5-3b6a-4fe0-81af-4b6641081a8a",
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "wrote zarr store to Azure for tasmax\n",
-      "wrote zarr store to Azure for tasmin\n",
-      "wrote zarr store to Azure for dtr\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for var in variables:\n",
     "    \n",
-    "    zarr_storepath = 'gs://impactlab-data/climate/source_data/ERA-5/downscaling/{}.1995-2014.F320.v2.zarr'\n",
-    "    store = fs.get_mapper(zarr_storepath.format(var), check=False)\n",
+    "    if var == 'pr':\n",
+    "        version = 'v3'\n",
+    "    else: \n",
+    "        version = 'v2'\n",
+    "    zarr_storepath = 'gs://impactlab-data/climate/source_data/ERA-5/downscaling/{}.1995-2014.F320.{}.zarr'\n",
+    "    store = fs.get_mapper(zarr_storepath.format(var, version), check=False)\n",
     "    \n",
     "    with xr.open_zarr(store, consolidated=False) as ds:\n",
     "    \n",
@@ -205,7 +209,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f30b69d7-6f62-498f-9ee3-ba98ba50c370",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if 'dtr' in ds.variables: \n",
+    "    print(\"yes\")\n",
+    "    \n",
+    "if 'tmax' in ds.variables: \n",
+    "    print(\"why is tmax here\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -227,12 +243,251 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.6"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {
-     "0561b2f46df64248a5739fa0d30619fc": {
+     "0fb635da4df249f7a998d535ad1fbf29": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "1e6791208be74fc49abee1b489a685fa": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "150px"
+      }
+     },
+     "256d6d40d5fb497da02f7c76b0062a5b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_cc7c114c1c444f3c8a2e27abc2d01829",
+       "style": "IPY_MODEL_2e3f91c8ef184b5a940d2d5b46271edd",
+       "value": "<h2>GatewayCluster</h2>"
+      }
+     },
+     "2acd0974b4f64e53a6d1f077d6588c7c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2ba4c9f8065641ecad6536f83acbf5b3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_33bd11b903aa4152946f201f5327cbd4",
+        "IPY_MODEL_c33df53537a04458879d3dad0e2749a0"
+       ],
+       "layout": "IPY_MODEL_bb84c830848e4fd2bd2613a1f6885d01"
+      }
+     },
+     "2e3f91c8ef184b5a940d2d5b46271edd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "33bd11b903aa4152946f201f5327cbd4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_1e6791208be74fc49abee1b489a685fa",
+       "style": "IPY_MODEL_7b68d436e35e4710900eec9df48fac9d",
+       "value": "\n<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table style=\"text-align: right;\">\n    <tr><th>Workers</th> <td>0</td></tr>\n    <tr><th>Cores</th> <td>0</td></tr>\n    <tr><th>Memory</th> <td>0 B</td></tr>\n</table>\n</div>\n"
+      }
+     },
+     "42805ab2e4e144d8b0883de55de42c92": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "52cd76d8bc374bf0b879ed8bf472f0a8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "61017ef1dc13421299e46e2f727b6ec0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_a7b039ea69274688ab965ca17eaa0f00",
+        "IPY_MODEL_da256621987b4d5aa7406ec47516a3dd",
+        "IPY_MODEL_921fbd4774e7494b844a29433baad964"
+       ],
+       "layout": "IPY_MODEL_a8fb8a19b87e40cea30a867207eda5a8"
+      }
+     },
+     "6382a82d966b47a39221a29b04e033de": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_2acd0974b4f64e53a6d1f077d6588c7c",
+       "style": "IPY_MODEL_d07029db3d3a44df872011a1409d9a92",
+       "value": "<p><b>Dashboard: </b><a href=\"/services/dask-gateway/clusters/impactlab-hub.65cf3a7e070a46ae80aafa1d1b086db8/status\" target=\"_blank\">/services/dask-gateway/clusters/impactlab-hub.65cf3a7e070a46ae80aafa1d1b086db8/status</a></p>\n"
+      }
+     },
+     "6d47051582b34a26bd05dbe2fe9d144c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "500px"
+      }
+     },
+     "7b449d720b994859b79e4584b6589f64": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "150px"
+      }
+     },
+     "7b646daeaa084a99bc5c88aa8bb96fe0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7b68d436e35e4710900eec9df48fac9d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7d93e7080cd14acaa90c91cf995d067a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Workers",
+       "layout": "IPY_MODEL_7b449d720b994859b79e4584b6589f64",
+       "step": 1,
+       "style": "IPY_MODEL_d9fc4c0d18474c6998394d80df62817d"
+      }
+     },
+     "862719049e7a45baa8e61e365b0ec85d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7b646daeaa084a99bc5c88aa8bb96fe0",
+       "style": "IPY_MODEL_42805ab2e4e144d8b0883de55de42c92",
+       "value": "<p><b>Name: </b>impactlab-hub.65cf3a7e070a46ae80aafa1d1b086db8</p>"
+      }
+     },
+     "8bbe207fd7d4499baabc3ca2d74852a6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Scale",
+       "layout": "IPY_MODEL_7b449d720b994859b79e4584b6589f64",
+       "style": "IPY_MODEL_e678d1aeafb5407e824fd233ac919c97"
+      }
+     },
+     "921fbd4774e7494b844a29433baad964": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Adapt",
+       "layout": "IPY_MODEL_7b449d720b994859b79e4584b6589f64",
+       "style": "IPY_MODEL_0fb635da4df249f7a998d535ad1fbf29"
+      }
+     },
+     "9bc2b671eafd4f82ab8ff031ace60ddb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a12a6ddbbce14ffb8cb2605e0d764abd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_256d6d40d5fb497da02f7c76b0062a5b",
+        "IPY_MODEL_2ba4c9f8065641ecad6536f83acbf5b3",
+        "IPY_MODEL_862719049e7a45baa8e61e365b0ec85d",
+        "IPY_MODEL_6382a82d966b47a39221a29b04e033de"
+       ],
+       "layout": "IPY_MODEL_a4a8840e7c364ed99ceb21545a784bd8"
+      }
+     },
+     "a4a8840e7c364ed99ceb21545a784bd8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a7b039ea69274688ab965ca17eaa0f00": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Minimum",
+       "layout": "IPY_MODEL_7b449d720b994859b79e4584b6589f64",
+       "step": 1,
+       "style": "IPY_MODEL_9bc2b671eafd4f82ab8ff031ace60ddb"
+      }
+     },
+     "a8fb8a19b87e40cea30a867207eda5a8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a93f380c4e7a4f7f8564616d3090ee18": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_7d93e7080cd14acaa90c91cf995d067a",
+        "IPY_MODEL_8bbe207fd7d4499baabc3ca2d74852a6"
+       ],
+       "layout": "IPY_MODEL_52cd76d8bc374bf0b879ed8bf472f0a8"
+      }
+     },
+     "b51a8fe7cf2d4705965b3593da9d2603": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "bb84c830848e4fd2bd2613a1f6885d01": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c33df53537a04458879d3dad0e2749a0": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "AccordionModel",
@@ -242,289 +497,51 @@
         "1": "Adaptive Scaling"
        },
        "children": [
-        "IPY_MODEL_f9aaee4e868d4db4b07e4022bd9a5948",
-        "IPY_MODEL_63bb8cd930f44ec9bd80e9ed7c928e03"
+        "IPY_MODEL_a93f380c4e7a4f7f8564616d3090ee18",
+        "IPY_MODEL_61017ef1dc13421299e46e2f727b6ec0"
        ],
-       "layout": "IPY_MODEL_dd6c2199f9b8482e8c9c492ce70784ac"
+       "layout": "IPY_MODEL_6d47051582b34a26bd05dbe2fe9d144c",
+       "selected_index": null
       }
      },
-     "182739b7c2d3402c9aa4728aeac7c76d": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_a985f5f5e01744389ae8054998d3c435",
-       "style": "IPY_MODEL_7e5f76cc04c4463983297c4380731aad",
-       "value": "\n<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table style=\"text-align: right;\">\n    <tr><th>Workers</th> <td>0</td></tr>\n    <tr><th>Cores</th> <td>0</td></tr>\n    <tr><th>Memory</th> <td>0 B</td></tr>\n</table>\n</div>\n"
-      }
-     },
-     "258920018f774054acd90e111e8bfdd8": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_5efbbad98a8348969878e2450a2152b9",
-       "style": "IPY_MODEL_4cf51b6934674ca4aab2f6f9a575c38b",
-       "value": "<p><b>Dashboard: </b><a href=\"/services/dask-gateway/clusters/impactlab-hub.8b65a90fd53c46c4994200605ab32d9f/status\" target=\"_blank\">/services/dask-gateway/clusters/impactlab-hub.8b65a90fd53c46c4994200605ab32d9f/status</a></p>\n"
-      }
-     },
-     "36acd1c2fb354608834cb6950086ff0c": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "3c4f56b2fe0545afafc19ccce1c4a746": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "4cf51b6934674ca4aab2f6f9a575c38b": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "54b8c8701d55447e9b1134e8d7e09144": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "5efbbad98a8348969878e2450a2152b9": {
+     "cc7c114c1c444f3c8a2e27abc2d01829": {
       "model_module": "@jupyter-widgets/base",
       "model_module_version": "1.2.0",
       "model_name": "LayoutModel",
       "state": {}
      },
-     "63bb8cd930f44ec9bd80e9ed7c928e03": {
+     "d07029db3d3a44df872011a1409d9a92": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
-      "model_name": "HBoxModel",
+      "model_name": "DescriptionStyleModel",
       "state": {
-       "children": [
-        "IPY_MODEL_f2e323ffc1f04d468a64cb70c7aa5c18",
-        "IPY_MODEL_6c4f91afbbae4f84bd234bd36cc81087",
-        "IPY_MODEL_a3512f9ebd954278b0a58f09a775e7fa"
-       ],
-       "layout": "IPY_MODEL_a99f353ac2584556912698916a15359b"
+       "description_width": ""
       }
      },
-     "66e0aea654e84a1f833d980b687af341": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "68d3e7101d7b416aa3c6f63b79bf0ca4": {
+     "d9fc4c0d18474c6998394d80df62817d": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
+      "model_name": "DescriptionStyleModel",
       "state": {
-       "layout": "IPY_MODEL_8dae7b9e7da947ee9e300352e527b24b",
-       "style": "IPY_MODEL_9f0ed5a07a114b33b6e95e003514074c",
-       "value": "<p><b>Name: </b>impactlab-hub.8b65a90fd53c46c4994200605ab32d9f</p>"
+       "description_width": ""
       }
      },
-     "6c4f91afbbae4f84bd234bd36cc81087": {
+     "da256621987b4d5aa7406ec47516a3dd": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "IntTextModel",
       "state": {
        "description": "Maximum",
-       "layout": "IPY_MODEL_6e6ff02c1bd54756b8e9e47be37383c2",
+       "layout": "IPY_MODEL_7b449d720b994859b79e4584b6589f64",
        "step": 1,
-       "style": "IPY_MODEL_b1bd4b5402a54c23a4c8434f990d2c17"
+       "style": "IPY_MODEL_b51a8fe7cf2d4705965b3593da9d2603"
       }
      },
-     "6e6ff02c1bd54756b8e9e47be37383c2": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "width": "150px"
-      }
-     },
-     "7e5f76cc04c4463983297c4380731aad": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "8dae7b9e7da947ee9e300352e527b24b": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "91940ecf19b2497ea34a50bda5fdd5b0": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "children": [
-        "IPY_MODEL_182739b7c2d3402c9aa4728aeac7c76d",
-        "IPY_MODEL_0561b2f46df64248a5739fa0d30619fc"
-       ],
-       "layout": "IPY_MODEL_93692b1cb10d4ff085cb18f156d66350"
-      }
-     },
-     "93692b1cb10d4ff085cb18f156d66350": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "9f0ed5a07a114b33b6e95e003514074c": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "a0374759b8fc4e46804f7b9554ef3860": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "a3512f9ebd954278b0a58f09a775e7fa": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "ButtonModel",
-      "state": {
-       "description": "Adapt",
-       "layout": "IPY_MODEL_6e6ff02c1bd54756b8e9e47be37383c2",
-       "style": "IPY_MODEL_b1180e88981d44699848e37567e9fd5e"
-      }
-     },
-     "a985f5f5e01744389ae8054998d3c435": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "min_width": "150px"
-      }
-     },
-     "a99f353ac2584556912698916a15359b": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "b1180e88981d44699848e37567e9fd5e": {
+     "e678d1aeafb5407e824fd233ac919c97": {
       "model_module": "@jupyter-widgets/controls",
       "model_module_version": "1.5.0",
       "model_name": "ButtonStyleModel",
       "state": {}
-     },
-     "b1bd4b5402a54c23a4c8434f990d2c17": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "DescriptionStyleModel",
-      "state": {
-       "description_width": ""
-      }
-     },
-     "b8a198f84a2b44e0a18c438ad9f807ea": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "ButtonStyleModel",
-      "state": {}
-     },
-     "c3ba1f3d5145404e98edb774ae806958": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "VBoxModel",
-      "state": {
-       "children": [
-        "IPY_MODEL_c7207255ca2d41a4ac0a1067aa9c1b7a",
-        "IPY_MODEL_91940ecf19b2497ea34a50bda5fdd5b0",
-        "IPY_MODEL_68d3e7101d7b416aa3c6f63b79bf0ca4",
-        "IPY_MODEL_258920018f774054acd90e111e8bfdd8"
-       ],
-       "layout": "IPY_MODEL_a0374759b8fc4e46804f7b9554ef3860"
-      }
-     },
-     "c7207255ca2d41a4ac0a1067aa9c1b7a": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HTMLModel",
-      "state": {
-       "layout": "IPY_MODEL_66e0aea654e84a1f833d980b687af341",
-       "style": "IPY_MODEL_54b8c8701d55447e9b1134e8d7e09144",
-       "value": "<h2>GatewayCluster</h2>"
-      }
-     },
-     "cb7aa96d3f5e4e3fad325002c437fcb2": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "IntTextModel",
-      "state": {
-       "description": "Workers",
-       "layout": "IPY_MODEL_6e6ff02c1bd54756b8e9e47be37383c2",
-       "step": 1,
-       "style": "IPY_MODEL_3c4f56b2fe0545afafc19ccce1c4a746"
-      }
-     },
-     "dd6c2199f9b8482e8c9c492ce70784ac": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "min_width": "500px"
-      }
-     },
-     "e201a1231c544e1487a1446d941ad620": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "1.2.0",
-      "model_name": "LayoutModel",
-      "state": {}
-     },
-     "ecbfc2621bfb41c9a4645997751d30f3": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "ButtonModel",
-      "state": {
-       "description": "Scale",
-       "layout": "IPY_MODEL_6e6ff02c1bd54756b8e9e47be37383c2",
-       "style": "IPY_MODEL_b8a198f84a2b44e0a18c438ad9f807ea"
-      }
-     },
-     "f2e323ffc1f04d468a64cb70c7aa5c18": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "IntTextModel",
-      "state": {
-       "description": "Minimum",
-       "layout": "IPY_MODEL_6e6ff02c1bd54756b8e9e47be37383c2",
-       "step": 1,
-       "style": "IPY_MODEL_36acd1c2fb354608834cb6950086ff0c"
-      }
-     },
-     "f9aaee4e868d4db4b07e4022bd9a5948": {
-      "model_module": "@jupyter-widgets/controls",
-      "model_module_version": "1.5.0",
-      "model_name": "HBoxModel",
-      "state": {
-       "children": [
-        "IPY_MODEL_cb7aa96d3f5e4e3fad325002c437fcb2",
-        "IPY_MODEL_ecbfc2621bfb41c9a4645997751d30f3"
-       ],
-       "layout": "IPY_MODEL_e201a1231c544e1487a1446d941ad620"
-      }
      }
     },
     "version_major": 2,


### PR DESCRIPTION
This PR adds validation for ERA5 zarr stores as well as code for writing them to Azure from GCS (with authentication info taken removed). Validation tests for a) NaNs, b) valid lat/lon lengths, and c) valid time ranges (1994-2015). Other validation is done in previous steps before the zarrs are created. 