### PR TITLE
Add "biascorrect-kind" workflow parameter for QDM training

### DIFF
--- a/workflows/dc6-workflow.yaml
+++ b/workflows/dc6-workflow.yaml
@@ -25,6 +25,8 @@ spec:
         value: 1980
       - name: biascorrect-lastfutureyear
         value: 2099
+      - name: biascorrect-kind
+        value: additive  # multiplicative
       - name: domainfile1x1
         value: "az://support/domain.1x1.zarr"
       - name: domainfile0p25x0p25
@@ -174,7 +176,7 @@ spec:
                 - name: out-zarr
                   value: "az://scratch/{{ workflow.name }}/biascorrected.zarr"
                 - name: kind
-                  value: additive
+                  value: "{{ workflow.parameters.biascorrect-kind }}"
                 - name: firstyear
                   value: "{{ workflow.parameters.biascorrect-firstfutureyear }}"
                 - name: lastyear

--- a/workflows/dc6-workflow.yaml
+++ b/workflows/dc6-workflow.yaml
@@ -387,7 +387,6 @@ spec:
           - name: firstyear
           - name: lastyear
           - name: kind
-            value: additive
       outputs:
         parameters:
           - name: out-zarr


### PR DESCRIPTION
This adds a "biascorrect-kind" workflow parameter for QDM training in the main argo workflow. This parameter needs to be "additive" or "multiplicative".

We need this parameter to easily run DTR through the pipeline.