### PR TITLE
Bump argo-workflows to minor release v3.1.0

### DIFF
--- a/infrastructure/kubernetes/argo/kustomization.yaml
+++ b/infrastructure/kubernetes/argo/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - github.com/argoproj/argo-workflows/manifests/cluster-install?ref=v3.0.7
+  - https://github.com/argoproj/argo-workflows/releases/download/v3.1.0/install.yaml
 patchesStrategicMerge:
   - ./patches/add-default-artifact-repository.yaml
   - ./patches/change-aks-containerruntimeexecutor.yaml


### PR DESCRIPTION
This upgrade has a backward-compatibility-breaking change concerning how manifests are installed with versioned containers. Thus, the change in resource URL in addition to the version bump.
