### PR TITLE
Tweaks to main workflow based on recent prototype run

### DIFF
--- a/workflows/dc6-workflow.yaml
+++ b/workflows/dc6-workflow.yaml
@@ -372,7 +372,10 @@ spec:
           limits:
             memory: 32Gi
             cpu: "2000m"
-      activeDeadlineSeconds: 10800
+      activeDeadlineSeconds: 1800
+      retryStrategy:
+        limit: 1
+        retryPolicy: "Always"
 
 
     - name: biascorrect-qdm

--- a/workflows/dc6-workflow.yaml
+++ b/workflows/dc6-workflow.yaml
@@ -1,4 +1,3 @@
-# Rolling QDM test case
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -548,9 +547,9 @@ spec:
       volumes:
         - name: out
           emptyDir: { }
-      activeDeadlineSeconds: 86400
+      activeDeadlineSeconds: 3600
       retryStrategy:
-        limit: 2
+        limit: 4
         retryPolicy: "Always"
 
 


### PR DESCRIPTION
This PR has a few adjustments to the `qdm-adjust-year` template in the main Argo workflow prototype. These are based on recent full prototype runs for tasmax and dtr using the newly cleaned ERA-5 reanalysis data.

The jobs on the cluster were a bit noisy on amaterasu - more so than usual - and we saw several jobs sporadically error due to preemption and OOM even after on 2-3 retries. However, these jobs ran to completion on a single additional retry. So we're bumping the number of allowed retries. Similar story for the `rechunk`  template change. Its deadline has been shorted but it has been allowed more retries.

When running the dtr variable, a `qdm-adjust-year` step for a single year ran for several hours without progress. Jobs for other years have completed in 10-20 minutes. The long-running job ran to completion after I manually deleted the pod — restarting the job for that year. This problem could be costly and blocking if many years decided to run on. To avoid this step running for too long in the future we're giving them an hour deadline. I feel like this _might_ still be too long, but it's fine for an early prototype.