### PR TITLE
Update era5 cleaning workflow

### DIFF
--- a/workflows/clean-era5-workflow.yaml
+++ b/workflows/clean-era5-workflow.yaml
@@ -11,9 +11,9 @@ spec:
   arguments:
     parameters:
     - name: in-zarr
-      value: "clean-dev/ERA-5/tmax.1995-2014.0p25.zarr"
+      value: "clean-dev/ERA-5/F320/tasmax.1995-2015.F320.v2.zarr"
     - name: out-zarr
-      value: "scratch/clean-dev/ERA-5/tasmax.1995-2014.0p25.zarr"
+      value: "scratch/clean-dev/ERA-5/tasmax.1995-2015.F320.zarr"
   serviceAccountName: workflows-default
   nodeSelector:
     dedicated: worker
@@ -167,7 +167,8 @@ spec:
         )
         print(f"opening {in_store_path}")
 
-        ds = ds.rename({"tmax": "tasmax"})
+	if 'tmax' in ds.variables:
+            ds = ds.rename({"tmax": "tasmax"})
         ds = ds.rename({"latitude": "lat", "longitude": "lon"})
 
         # ds = ds.rename({"latitude": "lat", "longitude": "lon", "tmax": "tasmax"})

--- a/workflows/clean-era5-workflow.yaml
+++ b/workflows/clean-era5-workflow.yaml
@@ -167,7 +167,7 @@ spec:
         )
         print(f"opening {in_store_path}")
 
-	if "tmax" in ds.variables:
+        if "tmax" in ds.variables:
             ds = ds.rename({"tmax": "tasmax"})
         ds = ds.rename({"latitude": "lat", "longitude": "lon"})
 

--- a/workflows/clean-era5-workflow.yaml
+++ b/workflows/clean-era5-workflow.yaml
@@ -167,7 +167,7 @@ spec:
         )
         print(f"opening {in_store_path}")
 
-	if 'tmax' in ds.variables:
+	if "tmax" in ds.variables:
             ds = ds.rename({"tmax": "tasmax"})
         ds = ds.rename({"latitude": "lat", "longitude": "lon"})
 

--- a/workflows/clean-era5-workflow.yaml
+++ b/workflows/clean-era5-workflow.yaml
@@ -11,9 +11,9 @@ spec:
   arguments:
     parameters:
     - name: in-zarr
-      value: "clean-dev/ERA-5/F320/tasmax.1995-2015.F320.v2.zarr"
+      value: "clean-dev/ERA-5/F320/dtr.1995-2015.F320.v2.zarr"
     - name: out-zarr
-      value: "scratch/clean-dev/ERA-5/tasmax.1995-2015.F320.zarr"
+      value: "scratch/clean-dev/ERA-5/dtr.1995-2015.F320.zarr"
   serviceAccountName: workflows-default
   nodeSelector:
     dedicated: worker

--- a/workflows/clean-era5-workflow.yaml
+++ b/workflows/clean-era5-workflow.yaml
@@ -11,9 +11,9 @@ spec:
   arguments:
     parameters:
     - name: in-zarr
-      value: "clean-dev/ERA-5/F320/dtr.1995-2015.F320.v2.zarr"
+      value: "clean-dev/ERA-5/F320/tasmax.1995-2015.F320.v2.zarr"
     - name: out-zarr
-      value: "scratch/clean-dev/ERA-5/dtr.1995-2015.F320.zarr"
+      value: "scratch/clean-dev/ERA-5/tasmax.1995-2015.F320.zarr"
   serviceAccountName: workflows-default
   nodeSelector:
     dedicated: worker

--- a/workflows/clean-era5-workflow.yaml
+++ b/workflows/clean-era5-workflow.yaml
@@ -169,6 +169,10 @@ spec:
 
         if "tmax" in ds.variables:
             ds = ds.rename({"tmax": "tasmax"})
+        if "tmin" in ds.variables:
+            ds = ds.rename({"tmin": "tasmin"})
+        if "precip" in ds.variables:
+            ds = ds.rename({"precip": "pr"})
         ds = ds.rename({"latitude": "lat", "longitude": "lon"})
 
         # ds = ds.rename({"latitude": "lat", "longitude": "lon", "tmax": "tasmax"})

--- a/workflows/clean-era5-workflow.yaml
+++ b/workflows/clean-era5-workflow.yaml
@@ -175,7 +175,6 @@ spec:
             ds = ds.rename({"precip": "pr"})
         ds = ds.rename({"latitude": "lat", "longitude": "lon"})
 
-        # ds = ds.rename({"latitude": "lat", "longitude": "lon", "tmax": "tasmax"})
         print(f"standardized tmax/latitude/longitude name to tasmax/lat/lon")
 
         # # Hack to get around issue with writing chunks to zarr in xarray v0.17.0

--- a/workflows/dc6-workflow.yaml
+++ b/workflows/dc6-workflow.yaml
@@ -10,7 +10,7 @@ spec:
   arguments:
     parameters:
       - name: reference-zarr
-        value: "az://scratch/clean-dev/ERA-5/tasmax.1995-2014.0p25.zarr"
+        value: "az://scratch/clean-dev/ERA-5/tasmax.1995-2015.F320.zarr"
       - name: gcm-historical-zarr
         value: "az://clean/ACCESS-ESM1-5/training/r1i1p1f1/tasmax.zarr"
       - name: gcm-training-zarr


### PR DESCRIPTION
 This PR updates the ERA-5 cleaning workflow and main dc6 workflow to use the updated ERA-5 zarrs. It also updates the cleaning ERA-5 workflow so that it will work for tasmin, dtr and precip and doesn't presume that tasmax is named tmax. 

closes #97 