### PR TITLE
Add secret manager, ingress, loadbalancer components to infra

### DIFF
--- a/infrastructure/kubernetes/kubernetes-external-secrets/.helmignore
+++ b/infrastructure/kubernetes/kubernetes-external-secrets/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/infrastructure/kubernetes/kubernetes-external-secrets/Chart.yaml
+++ b/infrastructure/kubernetes/kubernetes-external-secrets/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: kubernetes-external-secrets
+description: DC6 kubernetes-external-secrets deployment
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.0.1"
+
+dependencies:
+  - name: kubernetes-external-secrets
+    version: "8.1.3"
+    repository: 'https://external-secrets.github.io/kubernetes-external-secrets'

--- a/infrastructure/kubernetes/kubernetes-external-secrets/README.md
+++ b/infrastructure/kubernetes/kubernetes-external-secrets/README.md
@@ -1,0 +1,56 @@
+# kubernetes-external-secrets
+This component allows us to securely reference, access, and update sensitive data while keeping our Kubernetes setup public.
+
+## Pre-deployment
+This requires manual setup to create Azure Key Vault, create a Service Principal for Kubernetes to access the vault, and finally, create the namespace and placing the Service Principal Credentials into a Secret for access to the vault.
+
+We generally use Terraform for this setup. However, we need to do this manually because of Terraform has limited permissions to create and edit Service Principals.
+```bash
+# BE SURE KUBECTL CONFIG CONTEXT IS POINTING TO THE CORRECT CLUSTER BEFORE YOU BEGIN!
+
+AZURE_RESOURCE_GROUP="dc6-resources"
+KEYVAULT_NAME="dc6-general-20210701"
+EXTERNALSECRETS_NAMESPACE="kubernetes-external-secrets"
+
+## Create Azure Key Vault. This may take several moments.
+az keyvault create -n "${KEYVAULT_NAME}" \
+  -g "${AZURE_RESOURCE_GROUP}"
+
+## Get service principal for k8s external secrets. Put credentials on cluster secret
+SP=$(az ad sp create-for-rbac --skip-assignment)
+APPID=$(echo $SP | jq .appId)
+APPID=$(echo "${APPID//\"/}")
+SECRETID=$(echo $SP | jq .password)
+SECRETID=$(echo "${SECRETID//\"/}")
+TENANT=$(echo $SP | jq .tenant)
+TENANT=$(echo "${TENANT//\"/}")
+
+# Set service principal->keyvault permissions required by k8s external secrets.
+az keyvault set-policy -n "${KEYVAULT_NAME}" \
+  --spn "${APPID}" \
+  --secret-permissions get list
+
+# Place the secret in the cluster.
+kubectl create namespace "${EXTERNALSECRETS_NAMESPACE}"  # If it doesn't already exist.
+kubectl create secret generic azure-credentials \
+  -n "${EXTERNALSECRETS_NAMESPACE}" \
+  --from-literal clientid="${APPID}" \
+  --from-literal clientsecret="${SECRETID}" \
+  --from-literal tenantid="${TENANT}"
+```
+
+## Deploy (`argocd`)
+
+You can deploy this in a dev environment with `argocd` from the CLI with
+
+```bash
+argocd app create kubernetes-external-secrets \
+    --repo https://github.com/ClimateImpactLab/downscaleCMIP6 \
+    --path infrastructure/kubernetes/kubernetes-external-secrets \
+    --values values.yaml \
+    --dest-server https://kubernetes.default.svc \
+    --dest-namespace kubernetes-external-secrets \
+    --sync-policy automated \
+    --auto-prune \
+    --port-forward-namespace argocd
+```

--- a/infrastructure/kubernetes/kubernetes-external-secrets/values.yaml
+++ b/infrastructure/kubernetes/kubernetes-external-secrets/values.yaml
@@ -1,5 +1,5 @@
 kubernetes-external-secrets:
-  env:
+  envVarsFromSecret:
     AZURE_TENANT_ID:
       secretKeyRef: azure-credentials
       key: tenantid

--- a/infrastructure/kubernetes/kubernetes-external-secrets/values.yaml
+++ b/infrastructure/kubernetes/kubernetes-external-secrets/values.yaml
@@ -1,0 +1,11 @@
+kubernetes-external-secrets:
+  env:
+    AZURE_TENANT_ID:
+      secretKeyRef: azure-credentials
+      key: tenantid
+    AZURE_CLIENT_ID:
+      secretKeyRef: azure-credentials
+      key: clientid
+    AZURE_CLIENT_SECRET:
+      secretKeyRef: azure-credentials
+      key: clientsecret

--- a/infrastructure/kubernetes/traefik/.helmignore
+++ b/infrastructure/kubernetes/traefik/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/infrastructure/kubernetes/traefik/Chart.yaml
+++ b/infrastructure/kubernetes/traefik/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: traefik
+description: DC6 traefik deployment for various ingresses
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.0.1"
+
+dependencies:
+  - name: traefik
+    version: "9.19.2"
+    repository: 'https://helm.traefik.io/traefik'

--- a/infrastructure/kubernetes/traefik/README.md
+++ b/infrastructure/kubernetes/traefik/README.md
@@ -1,0 +1,25 @@
+# traefik
+This component is the cluster ingress. We use this one because it can terminate TLS and both TCP and HTTP connections on the same port. Hooray for less work.
+
+## Pre-deployment
+Be sure the `traefik` Namespace exists on the cluster.
+Create the Namespace with
+```bash
+kubectl create namespace "traefik"
+```
+
+## Deploy (`argocd`)
+
+You can deploy this in a dev environment with `argocd` from the CLI with
+
+```bash
+argocd app create traefik \
+    --repo https://github.com/ClimateImpactLab/downscaleCMIP6 \
+    --path infrastructure/kubernetes/traefik \
+    --values values.yaml \
+    --dest-server https://kubernetes.default.svc \
+    --dest-namespace traefik \
+    --sync-policy automated \
+    --auto-prune \
+    --port-forward-namespace argocd
+```

--- a/infrastructure/kubernetes/traefik/values.yaml
+++ b/infrastructure/kubernetes/traefik/values.yaml
@@ -1,0 +1,8 @@
+traefik:
+  resources:
+     requests:
+       cpu: "100m"
+       memory: "50Mi"
+     limits:
+       cpu: "300m"
+       memory: "150Mi"

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -31,6 +31,31 @@ resource "azurerm_resource_group" "rg" {
   }
 }
 
+
+# Loadbalancer and IP address for services from the cluster.
+resource "azurerm_public_ip" "primary" {
+  name                = "PublicIPForLB"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Static"
+  tags = {
+    managed-by = "terraform"
+  }
+}
+resource "azurerm_lb" "primary" {
+  name                = "ProdLoadBalancer"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+  tags = {
+    managed-by = "terraform"
+  }
+  frontend_ip_configuration {
+    name                 = "PublicIPAddress"
+    public_ip_address_id = azurerm_public_ip.primary.id
+  }
+}
+
+
 module "aks_cluster" {
   source              = "./modules/aks_cluster"
   prefix              = var.prefix

--- a/infrastructure/terraform/outputs.tf
+++ b/infrastructure/terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "public_ip_address" {
+  value = azurerm_public_ip.primary.ip_address
+}


### PR DESCRIPTION
This PR adds a few new components to Amaterasu.

- `kubernetes_external_secrets` - Allows us to securely reference, access, and update sensitive data while keeping our Kubernetes setup public.
- `traefik` - Custom ingress for routing internet traffic, terminates TLS.
- 
These are all managed by argocd.

This PR also adds a loadbalancer and static public IP to Azure via Terraform.

Each of these components will be used for a super secret surprise.
