### PR TITLE
Bump to argo 3.1.1

### DIFF
--- a/infrastructure/kubernetes/argo/kustomization.yaml
+++ b/infrastructure/kubernetes/argo/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/argoproj/argo-workflows/releases/download/v3.1.0/install.yaml
+  - https://github.com/argoproj/argo-workflows/releases/download/v3.1.1/install.yaml
 patchesStrategicMerge:
   - ./patches/add-default-artifact-repository.yaml
   - ./patches/change-aks-containerruntimeexecutor.yaml


### PR DESCRIPTION
Patches argo workflows v3.1.0 -> v3.1.1.

This isn't needed for any particular reason. Just rolling on while we have a free moment.