### PR TITLE
Add precip unit conversion to clean-cmip6, pin dev steps to v0.4.0 release

### DIFF
--- a/workflows/clean-cmip6-workflow.yaml
+++ b/workflows/clean-cmip6-workflow.yaml
@@ -372,7 +372,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.3.0
+        image: downscalecmip6.azurecr.io/dodola:0.4.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:

--- a/workflows/clean-cmip6-workflow.yaml
+++ b/workflows/clean-cmip6-workflow.yaml
@@ -566,7 +566,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.4.0
         env:
           - name: TASMAX_ZARR
             value: "{{ inputs.parameters.tasmax-zarr }}"

--- a/workflows/clean-cmip6-workflow.yaml
+++ b/workflows/clean-cmip6-workflow.yaml
@@ -391,10 +391,10 @@ spec:
           - "{{ inputs.parameters.out-zarr }}"
         resources:
           requests:
-            memory: 8Gi
+            memory: 16Gi
             cpu: "2000m"
           limits:
-            memory: 8Gi
+            memory: 16Gi
             cpu: "2000m"
       activeDeadlineSeconds: 3600
       retryStrategy:
@@ -467,10 +467,10 @@ spec:
           print(f"Written to {out_zarr}")  # DEBUG
         resources:
           requests:
-            memory: 4Gi
+            memory: 8Gi
             cpu: "1000m"
           limits:
-            memory: 4Gi
+            memory: 8Gi
             cpu: "2000m"
       activeDeadlineSeconds: 3600
       retryStrategy:

--- a/workflows/clean-era5-workflow.yaml
+++ b/workflows/clean-era5-workflow.yaml
@@ -305,8 +305,7 @@ spec:
         - name: out-zarr
           value: "{{ inputs.parameters.out-zarr }}"
     container:
-      image: downscalecmip6.azurecr.io/dodola:dev
-      imagePullPolicy: Always
+      image: downscalecmip6.azurecr.io/dodola:0.4.0
       env:
         - name: AZURE_STORAGE_ACCOUNT_NAME
           valueFrom:


### PR DESCRIPTION
This PR changes the CMIP6 cleaning workflow so that it checks precipitation units and performs a basic unit conversion if needed. 

This PR also takes Argo workflow stages using `dodola`'s floating `dev` tag and pins them to use the recent v0.4.0 release. This should keep the stages from unintentionally breaking from package updates, etc. in the container.