### PR TITLE
Fix regrid dtype to float32, QDMs extra endpoints, quiet logging

### DIFF
--- a/workflows/dc6-workflow.yaml
+++ b/workflows/dc6-workflow.yaml
@@ -350,7 +350,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.3.0
+        image: downscalecmip6.azurecr.io/dodola:0.4.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -366,6 +366,7 @@ spec:
         args:
           - "regrid"
           - "{{ inputs.parameters.in-zarr }}"
+          - "--astype=float32"
           - "--out"
           - "{{ inputs.parameters.out-zarr }}"
           - "--method"

--- a/workflows/dc6-workflow.yaml
+++ b/workflows/dc6-workflow.yaml
@@ -513,7 +513,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.3.0
+        image: downscalecmip6.azurecr.io/dodola:0.4.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -574,7 +574,7 @@ spec:
             s3:
               key: "{{ workflow.name }}/qdm-years/{{ inputs.parameters.year }}.nc"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.3.0
+        image: downscalecmip6.azurecr.io/dodola:0.4.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:

--- a/workflows/dc6-workflow.yaml
+++ b/workflows/dc6-workflow.yaml
@@ -350,7 +350,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.4.0
+        image: downscalecmip6.azurecr.io/dodola:0.4.1
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -513,7 +513,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.4.0
+        image: downscalecmip6.azurecr.io/dodola:0.4.1
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -574,7 +574,7 @@ spec:
             s3:
               key: "{{ workflow.name }}/qdm-years/{{ inputs.parameters.year }}.nc"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.4.0
+        image: downscalecmip6.azurecr.io/dodola:0.4.1
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -629,7 +629,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:0.1.0
+        image: downscalecmip6.azurecr.io/dodola:0.4.1
         env:
           - name: IN
             value: "{{ inputs.parameters.in-dir }}"
@@ -808,7 +808,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:0.3.0
+        image: downscalecmip6.azurecr.io/dodola:0.4.1
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -936,7 +936,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:0.3.0
+        image: downscalecmip6.azurecr.io/dodola:0.4.1
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -1099,7 +1099,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.3.0
+        image: downscalecmip6.azurecr.io/dodola:0.4.1
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:


### PR DESCRIPTION
This PR has several workflow fixes: 
- forces all dc6 workflow regridding steps to recast output to float32. Previously, it _always_ output float64. We don't need float64. Using float32 should cut our storage budget in half (see https://github.com/ClimateImpactLab/dodola/issues/91).
- updates the dc6 workflow QDM containers so they correctly account for endpoints in bias correction. See https://github.com/ClimateImpactLab/dodola/issues/87 for more details.
- fixes an issue with several workflow steps not logging work correctly (from https://github.com/ClimateImpactLab/dodola/issues/103).