### PR TITLE
argo to use emissary containerRuntimeExecutor over k8sapi

### DIFF
--- a/infrastructure/kubernetes/argo/patches/workflow-controller-configmap.yaml
+++ b/infrastructure/kubernetes/argo/patches/workflow-controller-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: workflow-controller-configmap
 data:
 
-  containerRuntimeExecutor: k8sapi
+  containerRuntimeExecutor: emissary
 
   artifactRepository: |
     archiveLogs: true


### PR DESCRIPTION
Use [`emissary`](https://argoproj.github.io/argo-workflows/workflow-executors/#emissary-emissary) as argo's container runtime executor.

This might be able to run workflow steps much much faster without taxing the k8sapi. The drawback is that its relatively untested and new.