### PR TITLE
Add argo-events to infrastructure

### DIFF
--- a/infrastructure/kubernetes/argo-events/README.md
+++ b/infrastructure/kubernetes/argo-events/README.md
@@ -1,0 +1,28 @@
+# argo-events
+
+This component adds an event-based framework to the cluster for general automation.
+
+## Pre-deployment
+
+Be sure the `argo-events` Namespace exists on the cluster.
+Create the Namespace with
+
+```bash
+kubectl create namespace "argo-events"
+```
+
+## Deploy (`argocd`)
+
+You can deploy this in a dev environment with `argocd` from the CLI with
+
+```bash
+argocd app create argo-events \
+    --repo https://github.com/ClimateImpactLab/downscaleCMIP6 \
+    --revision master \
+    --path infrastructure/kubernetes/argo-events \
+    --dest-server https://kubernetes.default.svc \
+    --dest-namespace argo-events \
+    --sync-policy automated \
+    --auto-prune \
+    --port-forward-namespace argocd
+```

--- a/infrastructure/kubernetes/argo-events/kustomize.yaml
+++ b/infrastructure/kubernetes/argo-events/kustomize.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Basic cluster-wide argo-events install based on https://argoproj.github.io/argo-events/installation/#cluster-wide-installation
+  # Installs validating admission controller.
+  - github.com/argoproj/argo-events/manifests/cluster-install?ref=v1.4.0
+  - github.com/argoproj/argo-events/manifests/extensions/validating-webhook?ref=v1.4.0


### PR DESCRIPTION
This adds [`argo-events`](https://argoproj.github.io/argo-events/) manifests.

Adding it to the cluster gives us an event-based framework we can use for automating tasks.

The hope is that this gives us a mechanism to simplify workflows and remove tedious work.