### PR TITLE
Fix argo server "share" button badge 

### DIFF
--- a/infrastructure/kubernetes/argo/patches/argo-server-deployment.yaml
+++ b/infrastructure/kubernetes/argo/patches/argo-server-deployment.yaml
@@ -2,3 +2,8 @@
   path: /spec/template/spec/containers/0/args/-
   value:
     --auth-mode=sso
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --x-frame-options=SAMEORIGIN


### PR DESCRIPTION
Our argo server has a little "share" button that allows us to embed badges and little graphics giving live updates of workflows. These don't display on the current deployment. This PR is an attempt to fix that. It's not an essential feature. I just wanted to see if I could get it to work.