### PR TITLE
Patch cert-manager to v1.4.1

### DIFF
--- a/infrastructure/kubernetes/cert-manager/kustomization.yaml
+++ b/infrastructure/kubernetes/cert-manager/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml
+  - https://github.com/jetstack/cert-manager/releases/download/v1.4.1/cert-manager.yaml
   - letsencrypt-prod-clusterissuer.yaml
   - letsencrypt-staging-clusterissuer.yaml


### PR DESCRIPTION
This isn't a required or critical update for our system. It's bug fixes on their end. This PR is keeping cert-manager rolling with the latest releases.