### PR TITLE
Upgrade Argo Workflows to v3.1.3

### DIFF
--- a/infrastructure/kubernetes/argo/kustomization.yaml
+++ b/infrastructure/kubernetes/argo/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/argoproj/argo-workflows/releases/download/v3.1.2/install.yaml
+  - https://github.com/argoproj/argo-workflows/releases/download/v3.1.3/install.yaml
   - sso-secrets
   - argo-server-ingress.yaml
 


### PR DESCRIPTION
Patch Argo Workflows to v3.1.3. Just rolling updates, we don't require any of the fixes.