### PR TITLE
Simplify workflows, add events and automated triggers, workflowtemplates

### DIFF
--- a/infrastructure/kubernetes/workflows-default/events/clean-cmip6-dtr-sensor.yaml
+++ b/infrastructure/kubernetes/workflows-default/events/clean-cmip6-dtr-sensor.yaml
@@ -1,0 +1,73 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: clean-cmip6-dtr-sensor
+spec:
+  template:
+    serviceAccountName: argoworkflow-trigger-sa
+  dependencies:
+    - name: cleaned-variable
+      eventSourceName: workflowsuccess-eventsource
+      eventName: cleancmip6-success
+      filters:
+        data:
+          # TODO: Check other variables that are input to workflows below.
+          - path: body.spec.arguments.parameters.0.name
+            type: string
+            value:
+              - "variable-id"
+          - path: body.spec.arguments.parameters.0.value
+            type: string
+            value:
+              - "dtr"
+  triggers:
+    - template:
+        name: biascorrect-dtr-trigger
+        conditions: cleaned-variable
+        k8s:
+          group: argoproj.io
+          version: v1alpha1
+          resource: workflows
+          operation: create
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: biascorrect-
+                labels:
+                  climatevariable: unknown
+                  sourceid: unknown
+              spec:
+                workflowTemplateRef:
+                  name: dc6
+                arguments:
+                  parameters:
+                    - name: variable-id
+                    - name: source-id
+                    - name: ssps
+                    - name: qdm-kind
+                      value: "multiplicative"
+          # TODO: Add label pointing to workflow this is triggered from.
+          # TODO: Has to be a better way to do this.
+          parameters:
+            - src:
+                dependencyName: cleaned-variable
+                dataKey: body.spec.arguments.parameters.0.value
+              dest: metadata.labels.climatevariable
+            - src:
+                dependencyName: cleaned-variable
+                dataKey: body.spec.arguments.parameters.1.value
+              dest: metadata.labels.sourceid
+            - src:
+                dependencyName: cleaned-variable
+                dataKey: body.spec.arguments.parameters.0.value
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: cleaned-variable
+                dataKey: body.spec.arguments.parameters.1.value
+              dest: spec.arguments.parameters.1.value
+            - src:
+                dependencyName: cleaned-variable
+                dataKey: body.spec.arguments.parameters.3.value
+              dest: spec.arguments.parameters.2.value

--- a/infrastructure/kubernetes/workflows-default/events/clean-cmip6-pr-sensor.yaml
+++ b/infrastructure/kubernetes/workflows-default/events/clean-cmip6-pr-sensor.yaml
@@ -1,0 +1,77 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: clean-cmip6-pr-sensor
+spec:
+  template:
+    serviceAccountName: argoworkflow-trigger-sa
+  dependencies:
+    - name: cleaned-variable
+      eventSourceName: workflowsuccess-eventsource
+      eventName: cleancmip6-success
+      filters:
+        data:
+          # TODO: Check other variables that are input to workflows below.
+          - path: body.spec.arguments.parameters.0.name
+            type: string
+            value:
+              - "variable-id"
+          - path: body.spec.arguments.parameters.0.value
+            type: string
+            value:
+              - "pr"
+  triggers:
+    - template:
+        name: biascorrect-pr-trigger
+        conditions: cleaned-variable
+        k8s:
+          group: argoproj.io
+          version: v1alpha1
+          resource: workflows
+          operation: create
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: biascorrect-
+                labels:
+                  climatevariable: unknown
+                  sourceid: unknown
+              spec:
+                workflowTemplateRef:
+                  name: dc6
+                arguments:
+                  parameters:
+                    - name: variable-id
+                    - name: source-id
+                    - name: ssps
+                    - name: qdm-kind
+                      value: "multiplicative"
+                    - name: correct-wetday-frequency
+                      value: "true"
+                    - name: regrid-method
+                      value: "conservative"
+          # TODO: Add label pointing to workflow this is triggered from.
+          # TODO: Has to be a better way to do this.
+          parameters:
+            - src:
+                dependencyName: cleaned-variable
+                dataKey: body.spec.arguments.parameters.0.value
+              dest: metadata.labels.climatevariable
+            - src:
+                dependencyName: cleaned-variable
+                dataKey: body.spec.arguments.parameters.1.value
+              dest: metadata.labels.sourceid
+            - src:
+                dependencyName: cleaned-variable
+                dataKey: body.spec.arguments.parameters.0.value
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: cleaned-variable
+                dataKey: body.spec.arguments.parameters.1.value
+              dest: spec.arguments.parameters.1.value
+            - src:
+                dependencyName: cleaned-variable
+                dataKey: body.spec.arguments.parameters.3.value
+              dest: spec.arguments.parameters.2.value

--- a/infrastructure/kubernetes/workflows-default/events/clean-cmip6-tas-sensor.yaml
+++ b/infrastructure/kubernetes/workflows-default/events/clean-cmip6-tas-sensor.yaml
@@ -1,0 +1,72 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: clean-cmip6-tas-sensor
+spec:
+  template:
+    serviceAccountName: argoworkflow-trigger-sa
+  dependencies:
+    - name: cleaned-variable
+      eventSourceName: workflowsuccess-eventsource
+      eventName: cleancmip6-success
+      filters:
+        data:
+          # TODO: Check other variables that are input to workflows below.
+          - path: body.spec.arguments.parameters.0.name
+            type: string
+            value:
+              - "variable-id"
+          - path: body.spec.arguments.parameters.0.value
+            type: string
+            value:
+              - "tasmax"
+              - "tasmin"
+  triggers:
+    - template:
+        name: biascorrect-tas-trigger
+        conditions: cleaned-variable
+        k8s:
+          group: argoproj.io
+          version: v1alpha1
+          resource: workflows
+          operation: create
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: biascorrect-
+                labels:
+                  climatevariable: unknown
+                  sourceid: unknown
+              spec:
+                workflowTemplateRef:
+                  name: dc6
+                arguments:
+                  parameters:
+                    - name: variable-id
+                    - name: source-id
+                    - name: ssps
+          # TODO: Add label pointing to workflow this is triggered from.
+          # TODO: Has to be a better way to do this.
+          parameters:
+            - src:
+                dependencyName: cleaned-variable
+                dataKey: body.spec.arguments.parameters.0.value
+              dest: metadata.labels.climatevariable
+            - src:
+                dependencyName: cleaned-variable
+                dataKey: body.spec.arguments.parameters.1.value
+              dest: metadata.labels.sourceid
+            - src:
+                dependencyName: cleaned-variable
+                dataKey: body.spec.arguments.parameters.0.value
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: cleaned-variable
+                dataKey: body.spec.arguments.parameters.1.value
+              dest: spec.arguments.parameters.1.value
+            - src:
+                dependencyName: cleaned-variable
+                dataKey: body.spec.arguments.parameters.3.value
+              dest: spec.arguments.parameters.2.value

--- a/infrastructure/kubernetes/workflows-default/events/downloadraw-sensor.yaml
+++ b/infrastructure/kubernetes/workflows-default/events/downloadraw-sensor.yaml
@@ -1,0 +1,79 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: downloadraw-sensor
+spec:
+  template:
+    serviceAccountName: argoworkflow-trigger-sa
+  dependencies:
+    - name: downloaded-generic-variable
+      eventSourceName: workflowsuccess-eventsource
+      eventName: downloadraw-success
+      filters:
+        data:
+          # TODO: Check other variables that are input to workflows below.
+          - path: body.spec.arguments.parameters.0.name
+            type: string
+            value:
+              - "variableID"
+          - path: body.spec.arguments.parameters.0.value
+            type: string
+            value:
+              - "tasmax"
+              - "tasmin"
+              - "pr"
+  triggers:
+    - template:
+        name: generic-clean-cmip6-trigger
+        conditions: downloaded-generic-variable
+        k8s:
+          group: argoproj.io
+          version: v1alpha1
+          resource: workflows
+          operation: create
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: clean-cmip6-
+                labels:
+                  climatevariable: unknown
+                  sourceid: unknown
+              spec:
+                arguments:
+                  parameters:
+                    - name: variable-id
+                    - name: source-id
+                    - name: historical
+                    - name: ssps
+                workflowTemplateRef:
+                  name: clean-cmip6
+          # TODO: Add label pointing to workflow this is triggered from.
+          # TODO: Has to be a better way to do this.
+          parameters:
+            - src:
+                dependencyName: downloaded-generic-variable
+                dataKey: body.spec.arguments.parameters.0.value
+              dest: metadata.labels.climatevariable
+            - src:
+                dependencyName: downloaded-generic-variable
+                dataKey: body.spec.arguments.parameters.1.value
+              dest: metadata.labels.sourceid
+            - src:
+                dependencyName: downloaded-generic-variable
+                dataKey: body.spec.arguments.parameters.0.value
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: downloaded-generic-variable
+                dataKey: body.spec.arguments.parameters.1.value
+              dest: spec.arguments.parameters.1.value
+            - src:
+                dependencyName: downloaded-generic-variable
+                dataKey: body.spec.arguments.parameters.2.value
+              dest: spec.arguments.parameters.2.value
+            - src:
+                dependencyName: downloaded-generic-variable
+                dataKey: body.spec.arguments.parameters.3.value
+              dest: spec.arguments.parameters.3.value
+

--- a/infrastructure/kubernetes/workflows-default/events/kustomization.yaml
+++ b/infrastructure/kubernetes/workflows-default/events/kustomization.yaml
@@ -4,3 +4,7 @@ resources:
   - rbac
   - default-eventbus.yaml
   - workflowsuccess-eventsource.yaml
+  - downloadraw-sensor.yaml
+  - clean-cmip6-tas-sensor.yaml
+  - clean-cmip6-pr-sensor.yaml
+  - clean-cmip6-dtr-sensor.yaml

--- a/infrastructure/kubernetes/workflows-default/events/workflowsuccess-eventsource.yaml
+++ b/infrastructure/kubernetes/workflows-default/events/workflowsuccess-eventsource.yaml
@@ -34,7 +34,7 @@ spec:
         labels:
           - key: component
             operation: ==
-            value: "cleancmip6"
+            value: "clean-cmip6"
           - key: workflows.argoproj.io/completed
             operation: ==
             value: "true"

--- a/workflows/parameters/GFDL-ESM4-tasmin.yaml
+++ b/workflows/parameters/GFDL-ESM4-tasmin.yaml
@@ -1,0 +1,12 @@
+climateVariable: "tasmin"
+sourceID: "GFDL-ESM4"
+historical: |
+  [
+    { "activityID": "CMIP", "experimentID": "historical", "tableID": "day", "variableID": "tasmin", "sourceID": "GFDL-ESM4", "institutionID": "NOAA-GFDL", "memberID": "r1i1p1f1", "gridLabel": "gr1", "version": "20190726" }
+  ]
+ssps: |
+  [
+    { "activityID": "ScenarioMIP", "experimentID": "ssp370", "tableID": "day", "variableID": "tasmin", "sourceID": "GFDL-ESM4", "institutionID": "NOAA-GFDL", "memberID": "r1i1p1f1", "gridLabel": "gr1", "version": "20180701" },
+    { "activityID": "ScenarioMIP", "experimentID": "ssp245", "tableID": "day", "variableID": "tasmin", "sourceID": "GFDL-ESM4", "institutionID": "NOAA-GFDL", "memberID": "r1i1p1f1", "gridLabel": "gr1", "version": "20180701" },
+    { "activityID": "ScenarioMIP", "experimentID": "ssp126", "tableID": "day", "variableID": "tasmin", "sourceID": "GFDL-ESM4", "institutionID": "NOAA-GFDL", "memberID": "r1i1p1f1", "gridLabel": "gr1", "version": "20180701" }
+  ]

--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -1,0 +1,381 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: clean-cmip6
+  labels:
+    component: clean-cmip6
+spec:
+  workflowMetadata:
+    labels:
+      component: clean-cmip6
+  entrypoint: clean-generic-variable
+  arguments:
+    parameters:
+      - name: variable-id
+        value: "{{workflows.parameters.variable-id}}"
+      - name: source-id
+        value: "{{workflows.parameters.source-id}}"
+      - name: ssps
+        value: "{{workflows.parameters.ssps}}"
+      - name: histslice-from-time
+        value: "1950"
+      - name: histslice-to-time
+        value: "2014"
+      - name: referenceslicehist-from-time
+        value: "1994-12-17"
+      - name: referenceslicehist-to-time
+        value: "2015-01-15"
+      - name: scratch
+        value: "az://scratch/{{ workflow.name }}/{{ inputs.parameters.variable-id }}/"
+  templates:
+
+    - name: clean-generic-variable
+      inputs:
+        parameters:
+          - name: variable-id
+          - name: source-id
+          - name: ssps
+          - name: histslice-from-time
+          - name: histslice-to-time
+          - name: referenceslicehist-from-time
+          - name: referenceslicehist-to-time
+          - name: scratch
+      dag:
+        tasks:
+          - name: standardize-historical-run
+            template: standardize-cmip6
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "az://raw/{{inputs.parameters.source-id}}/historical/{{inputs.parameters.variable-id}}.zarr"
+          - name: slice-training
+            template: timeslicezarr
+            dependencies: [ standardize-historical-run ]
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ tasks.standardize-historical-run.outputs.parameters.out-zarr }}"
+                - name: out-zarr
+                  value: "az://clean/{{inputs.parameters.source-id}}/training/{{inputs.parameters.variable-id}}.zarr"
+                - name: from-time
+                  value: "{{ inputs.parameters.referenceslicehist-from-time }}"
+                - name: to-time
+                  value: "{{ inputs.parameters.referenceslicehist-to-time }}"
+          - name: slice-historical
+            template: timeslicezarr
+            dependencies: [ standardize-historical-run ]
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ tasks.standardize-historical-run.outputs.parameters.out-zarr }}"
+                - name: out-zarr
+                  value: "az://clean/{{inputs.parameters.source-id}}/historical/{{inputs.parameters.variable-id}}.zarr"
+                - name: from-time
+                  value: "{{ inputs.parameters.histslice-from-time }}"
+                - name: to-time
+                  value: "{{ inputs.parameters.histslice-to-time }}"
+          - name: ssp-loop
+            dependencies: [ slice-historical ]
+            template: concatenate-ssp
+            arguments:
+              parameters:
+                - name: variable-id
+                  value: "{{ inputs.parameters.variable-id }}"
+                - name: source-id
+                  value: "{{ inputs.parameters.source-id }}"
+                - name: historical-zarr
+                  value: "{{ tasks.slice-historical.outputs.parameters.out-zarr }}"
+                - name: scratch
+                  value: "{{ inputs.parameters.scratch }}{{ item.experimentID }}/"
+                - name: ssp
+                  value: "{{ item.experimentID }}"
+            withParam: "{{ inputs.parameters.ssps }}"
+
+
+    - name: concatenate-ssp
+      inputs:
+        parameters:
+          - name: variable-id
+          - name: source-id
+          - name: historical-zarr
+          - name: ssp
+          - name: scratch
+      dag:
+        tasks:
+          - name: standardize-future-run
+            template: standardize-cmip6
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "az://raw/{{ inputs.parameters.source-id }}/{{ inputs.parameters.ssp }}/{{ inputs.parameters.variable-id }}.zarr"
+          - name: concat-histfuture
+            dependencies: [ standardize-future-run ]
+            template: timeconcatzarrs
+            arguments:
+              parameters:
+                - name: in1-zarr
+                  value: "{{ inputs.parameters.historical-zarr }}"
+                - name: in2-zarr
+                  value: "{{ tasks.standardize-future-run.outputs.parameters.out-zarr }}"
+                - name: out-zarr
+                  value: "az://clean/{{ inputs.parameters.source-id }}/{{ inputs.parameters.ssp }}/{{ inputs.parameters.variable-id }}.zarr"
+
+
+    - name: standardize-cmip6
+      inputs:
+        parameters:
+          - name: in-zarr
+          - name: out-zarr
+            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/out.zarr"
+      outputs:
+        parameters:
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-zarr }}"
+      container:
+        image: downscalecmip6.azurecr.io/dodola:0.4.0
+        env:
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [ "dodola" ]
+        args:
+          - "cleancmip6"
+          - "{{ inputs.parameters.in-zarr }}"
+          - "{{ inputs.parameters.out-zarr }}"
+        resources:
+          requests:
+            memory: 16Gi
+            cpu: "2000m"
+          limits:
+            memory: 16Gi
+            cpu: "2000m"
+      activeDeadlineSeconds: 3600
+      retryStrategy:
+        limit: 2
+        retryPolicy: "Always"
+
+
+    - name: timeslicezarr
+      inputs:
+        parameters:
+          - name: in-zarr
+          - name: from-time
+          - name: to-time
+          - name: out-zarr
+            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/out.zarr"
+      outputs:
+        parameters:
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-zarr }}"
+      script:
+        image: downscalecmip6.azurecr.io/dodola:0.3.0
+        env:
+          - name: IN_ZARR
+            value: "{{ inputs.parameters.in-zarr }}"
+          - name: FROM_TIME
+            value: "{{ inputs.parameters.from-time }}"
+          - name: TO_TIME
+            value: "{{ inputs.parameters.to-time }}"
+          - name: OUT_ZARR
+            value: "{{ inputs.parameters.out-zarr }}"
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [ python ]
+        source: |
+          import os
+          import xarray as xr
+
+          in_zarr = os.environ.get("IN_ZARR")
+          from_time = os.environ.get("FROM_TIME")
+          to_time = os.environ.get("TO_TIME")
+          out_zarr = os.environ.get("OUT_ZARR")
+
+          ds = xr.open_dataset(
+              in_zarr,
+              chunks={},
+              engine="zarr"
+          )
+          print(f"Read {in_zarr}")  # DEBUG
+
+          print(f"slicing {from_time} : {to_time}")
+          ds = ds.sel(time=slice(from_time, to_time))
+
+          ds = ds.chunk({"time": 365})
+
+          # Hack to get around issue with writing chunks to zarr in xarray v0.17.0
+          for v in ds.data_vars.keys():
+              del ds[v].encoding["chunks"]
+
+          ds.to_zarr(
+              out_zarr,
+              mode="w"
+          )
+          print(f"Written to {out_zarr}")  # DEBUG
+        resources:
+          requests:
+            memory: 8Gi
+            cpu: "1000m"
+          limits:
+            memory: 8Gi
+            cpu: "2000m"
+      activeDeadlineSeconds: 3600
+      retryStrategy:
+        limit: 2
+        retryPolicy: "Always"
+
+
+    - name: timeconcatzarrs
+      inputs:
+        parameters:
+          - name: in1-zarr
+          - name: in2-zarr
+          - name: out-zarr
+            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/out.zarr"
+      outputs:
+        parameters:
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-zarr }}"
+      script:
+        image: downscalecmip6.azurecr.io/dodola:0.3.0
+        env:
+          - name: IN1_ZARR
+            value: "{{ inputs.parameters.in1-zarr }}"
+          - name: IN2_ZARR
+            value: "{{ inputs.parameters.in2-zarr }}"
+          - name: OUT_ZARR
+            value: "{{ inputs.parameters.out-zarr }}"
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [ python ]
+        source: |
+          import os
+          import xarray as xr
+
+          print(os.environ.get("IN1_ZARR"))  # DEBUG
+          print(os.environ.get("IN2_ZARR"))  # DEBUG
+
+          ds1 = xr.open_zarr(os.environ.get("IN1_ZARR"))
+          ds2 = xr.open_zarr(os.environ.get("IN2_ZARR"))
+          # # Seems a bit more reliable this week if we pre-load:
+          # ds1.load()
+          # ds2.load()
+
+          print("ds1:")  # DEBUG
+          print(ds1)  # DEBUG
+          print("ds2:")  # DEBUG
+          print(ds2)  # DEBUG
+
+          ds = xr.concat([ds1, ds2], dim="time")
+          ds = ds.chunk({"time": 365, "lat": -1, "lon": -1, "bnds": 2})
+
+          # Hack to get around issue with writing chunks to zarr in xarray v0.17.0
+          for v in ds.data_vars.keys():
+              del ds[v].encoding["chunks"]
+          # TODO: For whatever reason these where not removed in the above loop, even if iter over ds.keys()...
+          del ds["lat_bnds"].encoding["chunks"]
+          del ds["lon_bnds"].encoding["chunks"]
+
+          print(os.environ.get("OUT_ZARR"))  # DEBUG
+          ds.to_zarr(
+              os.environ.get("OUT_ZARR"),
+              mode="w",
+          )
+          print("Output written")  # DEBUG
+        resources:
+          requests:
+            memory: 48Gi
+            cpu: "1000m"
+          limits:
+            memory: 48Gi
+            cpu: "2000m"
+      activeDeadlineSeconds: 3600
+      retryStrategy:
+        limit: 2
+        retryPolicy: "Always"
+
+
+    - name: compute-dtr
+      inputs:
+        parameters:
+          - name: tasmax-zarr
+          - name: tasmin-zarr
+          - name: out-zarr
+            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/out.zarr"
+      outputs:
+        parameters:
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-zarr }}"
+      script:
+        image: downscalecmip6.azurecr.io/dodola:0.4.0
+        env:
+          - name: TASMAX_ZARR
+            value: "{{ inputs.parameters.tasmax-zarr }}"
+          - name: TASMIN_ZARR
+            value: "{{ inputs.parameters.tasmin-zarr }}"
+          - name: OUT_ZARR
+            value: "{{ inputs.parameters.out-zarr }}"
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [ python ]
+        source: |
+          import os
+          import xarray as xr
+
+          tasmin_zarr = os.environ.get("TASMIN_ZARR")
+          tasmax_zarr = os.environ.get("TASMAX_ZARR")
+          out_zarr = os.environ.get("OUT_ZARR")
+
+          tasmin = xr.open_zarr(tasmin_zarr)["tasmin"]
+          print(f"Read {tasmin_zarr}")  # DEBUG
+          tasmax = xr.open_zarr(tasmax_zarr)["tasmax"]
+          print(f"Read {tasmax_zarr}")  # DEBUG
+
+          dtr = tasmax - tasmin
+
+          dtr.to_dataset(name="dtr").to_zarr(
+              out_zarr,
+              mode="w"
+          )
+          print(f"Written to {out_zarr}")  # DEBUG
+        resources:
+          requests:
+            memory: 16Gi
+            cpu: "1000m"
+          limits:
+            memory: 16Gi
+            cpu: "2000m"
+      activeDeadlineSeconds: 3600
+      retryStrategy:
+        limit: 2
+        retryPolicy: "Always"

--- a/workflows/templates/clean-era5.yaml
+++ b/workflows/templates/clean-era5.yaml
@@ -1,0 +1,215 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: clean-era5
+  labels:
+    component: clean-era5
+spec:
+  workflowMetadata:
+    labels:
+      component: clean-era5
+  entrypoint: main
+  arguments:
+    parameters:
+    - name: in-zarr
+      value: "clean-dev/ERA-5/F320/tasmax.1995-2015.F320.v2.zarr"
+    - name: out-zarr
+      value: "scratch/clean-dev/ERA-5/tasmax.1995-2015.F320.zarr"
+  templates:
+
+  - name: main
+    inputs:
+      parameters:
+        - name: in-zarr
+        - name: out-zarr
+    dag:
+      tasks:
+      - name: standardize
+        template: standardize
+        arguments:
+          parameters:
+          - name: in-zarr
+            value: "{{ inputs.parameters.in-zarr }}"
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-zarr }}"
+
+  - name: noleap
+    inputs:
+      parameters:
+      - name: in-zarr
+      - name: out-zarr
+    outputs:
+      parameters:
+      - name: out-zarr
+        value: "{{ inputs.parameters.out-zarr }}"
+    container:
+      image: downscalecmip6.azurecr.io/dodola:0.1.0
+      env:
+      - name: IN_ZARR
+        value: "{{  inputs.parameters.in-zarr }}"
+      - name: OUT_ZARR
+        value: "{{  inputs.parameters.out-zarr }}"
+      - name: PYTHONUNBUFFERED
+        value: "1"
+      - name: AZURE_STORAGE_ACCOUNT
+        valueFrom:
+          secretKeyRef:
+            name: workerstoragecreds-secret
+            key: azurestorageaccount
+      - name: AZURE_STORAGE_KEY
+        valueFrom:
+          secretKeyRef:
+            name: workerstoragecreds-secret
+            key: azurestoragekey
+      command: ["dodola"]
+      args:
+      - "removeleapdays"
+      - "{{ inputs.parameters.in-zarr }}"
+      - "{{ inputs.parameters.out-zarr }}"
+      resources:
+        requests:
+          memory: "42Gi"
+          cpu: "2000m"
+        limits:
+          memory: "42Gi"
+          cpu: "2000m"
+    activeDeadlineSeconds: 2700
+    retryStrategy:
+      limit: 3
+      retryPolicy: "Always"
+
+
+  - name: standardize
+    inputs:
+      parameters:
+      - name: in-zarr
+      - name: out-zarr
+    outputs:
+      parameters:
+      - name: out-zarr
+        value: "{{ inputs.parameters.out-zarr }}"
+    script:
+      image: downscalecmip6.azurecr.io/dodola:0.1.0
+      env:
+      - name: IN_ZARR
+        value: "{{  inputs.parameters.in-zarr }}"
+      - name: OUT_ZARR
+        value: "{{  inputs.parameters.out-zarr }}"
+      - name: PYTHONUNBUFFERED
+        value: "1"
+      - name: AZURE_STORAGE_ACCOUNT_NAME
+        valueFrom:
+          secretKeyRef:
+            name: workerstoragecreds-secret
+            key: azurestorageaccount
+      - name: AZURE_STORAGE_ACCOUNT_KEY
+        valueFrom:
+          secretKeyRef:
+            name: workerstoragecreds-secret
+            key: azurestoragekey
+      - name: PYTHONUNBUFFERED
+        value: "1"
+      command: [python]
+      source: |
+        import os
+        import xarray as xr
+        from adlfs import AzureBlobFileSystem
+
+        print("starting ERA-5 cleaning")
+
+        in_store_path = os.environ.get("IN_ZARR")
+        out_store_path = os.environ.get("OUT_ZARR")
+
+        fs = AzureBlobFileSystem()
+
+        ds = xr.open_zarr(
+            fs.get_mapper(in_store_path),
+            # chunks="auto",
+            # chunks={
+            #     "latitude": 10,
+            #     "longitude": 10,
+            #     "time": 365,
+            # }
+        )
+        print(f"opening {in_store_path}")
+
+        if "tmax" in ds.variables:
+            ds = ds.rename({"tmax": "tasmax"})
+        if "tmin" in ds.variables:
+            ds = ds.rename({"tmin": "tasmin"})
+        if "precip" in ds.variables:
+            ds = ds.rename({"precip": "pr"})
+        ds = ds.rename({"latitude": "lat", "longitude": "lon"})
+
+        print(f"standardized tmax/latitude/longitude name to tasmax/lat/lon")
+
+        ds.to_zarr(
+            store=fs.get_mapper(out_store_path),
+            mode="w",
+        )
+        print(f"written to {out_store_path}")
+
+        print("ERA-5 cleaning done")
+      resources:
+        requests:
+          memory: 42Gi
+          cpu: "2000m"
+        limits:
+          memory: 42Gi
+          cpu: "2000m"
+    activeDeadlineSeconds: 21600
+    retryStrategy:
+      limit: 3
+      retryPolicy: "Always"
+
+
+  - name: rechunk
+    inputs:
+      parameters:
+        - name: in-zarr
+        - name: out-zarr
+        - name: time-chunk
+        - name: lat-chunk
+        - name: lon-chunk
+    outputs:
+      parameters:
+        - name: out-zarr
+          value: "{{ inputs.parameters.out-zarr }}"
+    container:
+      image: downscalecmip6.azurecr.io/dodola:0.4.0
+      env:
+        - name: AZURE_STORAGE_ACCOUNT_NAME
+          valueFrom:
+            secretKeyRef:
+              name: workerstoragecreds-secret
+              key: azurestorageaccount
+        - name: AZURE_STORAGE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: workerstoragecreds-secret
+              key: azurestoragekey
+        - name: PYTHONUNBUFFERED
+          value: "1"
+      command: [dodola]
+      args:
+        - "rechunk"
+        - "az://{{ inputs.parameters.in-zarr }}"
+        - "--out"
+        - "az://{{ inputs.parameters.out-zarr }}"
+        - "--chunk"
+        - "time={{ inputs.parameters.time-chunk }}"
+        - "--chunk"
+        - "lat={{ inputs.parameters.lat-chunk }}"
+        - "--chunk"
+        - "lon={{ inputs.parameters.lon-chunk }}"
+      resources:
+        requests:
+          memory: 48Gi
+          cpu: "2000m"
+        limits:
+          memory: 48Gi
+          cpu: "2000m"
+    activeDeadlineSeconds: 10800
+    retryStrategy:
+      limit: 3
+      retryPolicy: "Always"

--- a/workflows/templates/dc6.yaml
+++ b/workflows/templates/dc6.yaml
@@ -1,0 +1,687 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: dc6
+  labels:
+    component: dc6
+spec:
+  workflowMetadata:
+    labels:
+      component: dc6
+  entrypoint: biascorrect-variable
+  arguments:
+    parameters:
+      - name: variable-id
+        value: "tasmin"
+      - name: source-id
+        value: "GFDL-ESM4"
+      - name: ssps
+        value: |
+          [
+            { "activityID": "ScenarioMIP", "experimentID": "ssp370", "tableID": "day", "variableID": "tasmin", "sourceID": "GFDL-ESM4", "institutionID": "NOAA-GFDL", "memberID": "r1i1p1f1", "gridLabel": "gr1", "version": "20180701" },
+            { "activityID": "ScenarioMIP", "experimentID": "ssp245", "tableID": "day", "variableID": "tasmin", "sourceID": "GFDL-ESM4", "institutionID": "NOAA-GFDL", "memberID": "r1i1p1f1", "gridLabel": "gr1", "version": "20180701" },
+            { "activityID": "ScenarioMIP", "experimentID": "ssp126", "tableID": "day", "variableID": "tasmin", "sourceID": "GFDL-ESM4", "institutionID": "NOAA-GFDL", "memberID": "r1i1p1f1", "gridLabel": "gr1", "version": "20180701" }
+          ]
+      - name: regrid-method
+        value: "bilinear"
+      - name: correct-wetday-frequency  # "true" or "false" STRING!
+        value: "false"
+      - name: domainfile1x1
+        value: "az://support/domain.1x1.zarr"
+      - name: qdm-kind #additive or multiplicative
+        value: "additive"
+  templates:
+
+    - name: biascorrect-variable
+      inputs:
+        parameters:
+          - name: variable-id
+          - name: source-id
+          - name: ssps
+          - name: regrid-method
+          - name: correct-wetday-frequency
+          - name: domainfile1x1
+          - name: qdm-kind
+      outputs:
+        parameters:
+          - name: out-zarr-qdm-model
+            valueFrom:
+              parameter: "{{ tasks.move-chunks-to-space.outputs.parameters.out-zarr }}"
+          - name: out-zarr-historical
+            valueFrom:
+              parameter: "{{ tasks.move-chunks-to-space.outputs.parameters.out-zarr }}"
+          - name: out-zarr-ssps
+            valueFrom:
+              parameter: "{{ tasks.move-chunks-to-space.outputs.parameters.out-zarr }}"
+      dag:
+        tasks:
+          - name: preprocess-historical
+            template: preprocess
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "az://clean/{{ inputs.parameters.source-id }}/historical/{{ inputs.parameters.variable-id }}.zarr"
+                - name: regrid-method
+                  value: "{{ inputs.parameters.regrid-method }}"
+                - name: domain-file
+                  value: "{{ inputs.parameters.domainfile1x1 }}"
+                - name: correct-wetday-frequency
+                  value: "{{ inputs.parameters.correct-wetday-frequency }}"
+          - name: preprocess-reference
+            template: preprocess
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "az://scratch/clean-dev/ERA-5/{{ inputs.parameters.variable-id }}.1995-2015.F320.zarr"
+                - name: regrid-method
+                  value: "{{ inputs.parameters.regrid-method }}"
+                - name: domain-file
+                  value: "{{ inputs.parameters.domainfile1x1 }}"
+                # Reference is never WDF corrected, as this in preprocessing with ERA-5
+                - name: correct-wetday-frequency
+                  value: "false"
+          - name: preprocess-training
+            template: preprocess
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "az://clean/{{ inputs.parameters.source-id }}/training/{{ inputs.parameters.variable-id }}.zarr"
+                - name: regrid-method
+                  value: "{{ inputs.parameters.regrid-method }}"
+                - name: domain-file
+                  value: "{{ inputs.parameters.domainfile1x1 }}"
+                - name: correct-wetday-frequency
+                  value: "{{ inputs.parameters.correct-wetday-frequency }}"
+          - name: preprocess-ssps
+            template: preprocess
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "az://clean/{{ inputs.parameters.source-id }}/{{ item.experimentID }}/{{ inputs.parameters.variable-id }}.zarr"
+                - name: regrid-method
+                  value: "{{ inputs.parameters.regrid-method }}"
+                - name: domain-file
+                  value: "{{ inputs.parameters.domainfile1x1 }}"
+                - name: correct-wetday-frequency
+                  value: "{{ inputs.parameters.correct-wetday-frequency }}"
+            withParam: "{{ inputs.parameters.ssps }}"
+          - name: train-qdm
+            dependencies: [ preprocess-reference, preprocess-training ]
+            template: train-qdm
+            arguments:
+              parameters:
+                - name: variable
+                  value: "{{ inputs.parameters.variable-id }}"
+                - name: ref-zarr
+                  value: "{{ tasks.preprocess-reference.outputs.parameters.out-zarr }}"
+                - name: hist-zarr
+                  value: "{{ tasks.preprocess-training.outputs.parameters.out-zarr }}"
+                - name: kind
+                  value: "{{ inputs.parameters.qdm-kind }}"
+          - name: biascorrect-historical
+            dependencies: [ train-qdm, preprocess-historical ]
+            template: apply-qdm
+            arguments:
+              parameters:
+                - name: variable
+                  value: "{{ inputs.parameters.variable-id }}"
+                - name: future-zarr
+                  value: "{{ tasks.preprocess-historical.outputs.parameters.out-zarr }}"
+                - name: qdm-model
+                  value: "{{ tasks.train-qdm.outputs.parameters.out-zarr }}"
+                - name: firstyear
+                  value: 1950
+                - name: lastyear
+                  value: 2014
+                - name: out-key
+                  value: "historical-{{ inputs.parameters.variable-id }}-qdm-years"
+          - name: biascorrect-ssps
+            dependencies: [ train-qdm, preprocess-ssps]
+            template: apply-qdm
+            arguments:
+              parameters:
+                - name: variable
+                  value: "{{ inputs.parameters.variable-id }}"
+                - name: future-zarr
+                  value: "{{ item.out-zarr }}"
+                - name: qdm-model
+                  value: "{{ tasks.train-qdm.outputs.parameters.out-zarr }}"
+                - name: firstyear
+                  value: 2015
+                - name: lastyear
+                  value: 2100
+                - name: out-key
+                  value: "{{=sprig.randAlphaNum(7)}}-{{ inputs.parameters.variable-id }}-qdm-years"
+            withParam: "{{ tasks.preprocess-ssps.outputs.parameters }}"
+
+
+    - name: preprocess
+      inputs:
+        parameters:
+          - name: in-zarr
+          - name: regrid-method
+          - name: domain-file
+          - name: correct-wetday-frequency  # "true" or "false" STRING!
+      outputs:
+        parameters:
+          - name: out-zarr
+            valueFrom:
+              parameter: "{{ tasks.move-chunks-to-space.outputs.parameters.out-zarr }}"
+      dag:
+        tasks:
+          - name: check-wetday-frequency
+            template: wdf-check
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ inputs.parameters.in-zarr }}"
+                - name: uncorrected-out-zarr
+                  value: "{{ inputs.parameters.in-zarr }}"
+                - name: process
+                  value: "pre"
+                - name: correct-bool
+                  value: "{{ inputs.parameters.correct-wetday-frequency }}"
+          - name: add-cyclic
+            dependencies: [ check-wetday-frequency ]
+            template: add-cyclic
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ tasks.check-wetday-frequency.outputs.parameters.out-zarr }}"
+          - name: move-chunks-to-time
+            dependencies: [ add-cyclic ]
+            template: rechunk
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ tasks.add-cyclic.outputs.parameters.out-zarr }}"
+                - name: time-chunk
+                  value: "365"
+                - name: lat-chunk
+                  value: -1
+                - name: lon-chunk
+                  value: -1
+          - name: regrid
+            dependencies: [ move-chunks-to-time ]
+            template: regrid
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ tasks.move-chunks-to-time.outputs.parameters.out-zarr }}"
+                - name: regrid-method
+                  value: "{{ inputs.parameters.regrid-method }}"
+                - name: domain-file
+                  value: "{{ inputs.parameters.domain-file }}"
+          - name: move-chunks-to-space
+            dependencies: [ regrid ]
+            template: rechunk
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ tasks.regrid.outputs.parameters.out-zarr }}"
+                - name: time-chunk
+                  value: "-1"
+                - name: lat-chunk
+                  value: 10
+                - name: lon-chunk
+                  value: 10
+
+
+    - name: regrid
+      inputs:
+        parameters:
+          - name: in-zarr
+          - name: out-zarr
+            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/out.zarr"
+          - name: regrid-method
+          - name: domain-file
+      outputs:
+        parameters:
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-zarr }}"
+      container:
+        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        env:
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [ "dodola" ]
+        args:
+          - "regrid"
+          - "{{ inputs.parameters.in-zarr }}"
+          - "--astype=float32"
+          - "--out"
+          - "{{ inputs.parameters.out-zarr }}"
+          - "--method"
+          - "{{ inputs.parameters.regrid-method }}"
+          - "--domain-file"
+          - "{{ inputs.parameters.domain-file }}"
+        resources:
+          requests:
+            memory: 48Gi
+            cpu: "1000m"
+          limits:
+            memory: 48Gi
+            cpu: "2000m"
+      activeDeadlineSeconds: 3600
+      retryStrategy:
+        limit: 2
+        retryPolicy: "Always"
+
+
+    - name: rechunk
+      inputs:
+        parameters:
+          - name: in-zarr
+          - name: out-zarr
+            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/out.zarr"
+          - name: time-chunk
+            value: 365
+          - name: lat-chunk
+            value: 10
+          - name: lon-chunk
+            value: 10
+          - name: time-dim-name
+            value: time
+      outputs:
+        parameters:
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-zarr }}"
+      container:
+        image: downscalecmip6.azurecr.io/dodola:dev
+        env:
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [ dodola ]
+        args:
+          - "rechunk"
+          - "{{ inputs.parameters.in-zarr }}"
+          - "--out"
+          - "{{ inputs.parameters.out-zarr }}"
+          - "--chunk"
+          - "{{ inputs.parameters.time-dim-name }}={{ inputs.parameters.time-chunk }}"
+          - "--chunk"
+          - "lat={{ inputs.parameters.lat-chunk }}"
+          - "--chunk"
+          - "lon={{ inputs.parameters.lon-chunk }}"
+        resources:
+          requests:
+            memory: 32Gi
+            cpu: "1000m"
+          limits:
+            memory: 32Gi
+            cpu: "2000m"
+      activeDeadlineSeconds: 1800
+      retryStrategy:
+        limit: 1
+        retryPolicy: "Always"
+
+
+    - name: apply-qdm
+      inputs:
+        parameters:
+          - name: variable
+          - name: future-zarr
+          - name: qdm-model
+          - name: firstyear
+          - name: lastyear
+          - name: out-key
+            value: "qdm-years"
+      outputs:
+        parameters:
+          - name: out-zarr
+            valueFrom:
+              parameter: "{{ tasks.netcdfs2zarr.outputs.parameters.out-zarr }}"
+      dag:
+        tasks:
+          - name: qdm-adjust-year
+            template: qdm-adjust-year
+            arguments:
+              parameters:
+                - name: future-zarr
+                  value: "{{ inputs.parameters.future-zarr }}"
+                - name: variable
+                  value: "{{ inputs.parameters.variable }}"
+                - name: year
+                  value: "{{item}}"
+                - name: qdm-model-zarr
+                  value: "{{ inputs.parameters.qdm-model }}"
+                - name: out-key
+                  value: "{{ workflow.name }}/{{ inputs.parameters.out-key }}/{{ inputs.parameters.year }}.nc"
+            withSequence:
+              start: "{{ inputs.parameters.firstyear }}"
+              end: "{{ inputs.parameters.lastyear }}"
+          - name: netcdfs2zarr
+            dependencies: [ qdm-adjust-year ]
+            template: netcdfs2zarr
+            arguments:
+              parameters:
+                - name: in-dir
+                  value: "scratch/{{workflow.name}}/qdm-years/"
+                - name: out-zarr
+                  value: "{{ inputs.parameters.out-zarr }}"
+
+
+    - name: train-qdm
+      inputs:
+        parameters:
+          - name: variable
+          - name: ref-zarr
+          - name: hist-zarr
+          - name: out-zarr
+            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/out.zarr"
+          - name: kind
+      outputs:
+        parameters:
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-zarr }}"
+      container:
+        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        env:
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [ "dodola" ]
+        args:
+          - "train-qdm"
+          - "--historical"
+          - "{{ inputs.parameters.hist-zarr }}"
+          - "--reference"
+          - "{{ inputs.parameters.ref-zarr }}"
+          - "--out"
+          - "{{ inputs.parameters.out-zarr }}"
+          - "--variable"
+          - "{{ inputs.parameters.variable }}"
+          - "--kind"
+          - "{{ inputs.parameters.kind }}"
+        resources:
+          requests:
+            memory: 48Gi
+            cpu: "2000m"
+          limits:
+            memory: 48Gi
+            cpu: "2500m"
+        volumeMounts:
+          - name: out
+            mountPath: /mnt/out
+      volumes:
+        - name: out
+          emptyDir: { }
+      activeDeadlineSeconds: 172800
+      retryStrategy:
+        limit: 4
+        retryPolicy: "Always"
+
+
+    - name: qdm-adjust-year
+      inputs:
+        parameters:
+          - name: future-zarr
+          - name: year
+          - name: qdm-model-zarr
+          - name: variable
+          - name: out-key
+            value: "{{ workflow.name }}/qdm-years/{{ inputs.parameters.year }}.nc"
+      outputs:
+        artifacts:
+          - name: adjusted
+            path: "/mnt/out/{{ inputs.parameters.year }}.nc"
+            archive:
+              none: { }
+            s3:
+              key: "{{ inputs.parameters.out-key }}"
+      container:
+        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        env:
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [ dodola ]
+        args:
+          - "apply-qdm"
+          - "--simulation"
+          - "{{ inputs.parameters.future-zarr }}"
+          - "--out"
+          - "/mnt/out/{{ inputs.parameters.year }}.nc"
+          - "--year"
+          - "{{ inputs.parameters.year }}"
+          - "--variable"
+          - "{{ inputs.parameters.variable }}"
+          - "--qdm"
+          - "{{ inputs.parameters.qdm-model-zarr }}"
+        resources:
+          requests:
+            memory: 42Gi
+            cpu: "2000m"
+          limits:
+            memory: 42Gi
+            cpu: "2000m"
+        # emptyDir volume as k8sapi can't output to base image layer:
+        volumeMounts:
+          - name: out
+            mountPath: /mnt/out
+      volumes:
+        - name: out
+          emptyDir: { }
+      activeDeadlineSeconds: 3600
+      retryStrategy:
+        limit: 4
+        retryPolicy: "Always"
+
+
+    - name: netcdfs2zarr
+      inputs:
+        parameters:
+          - name: in-dir  # DIR with container containing all the nc files. No az://!
+          - name: out-zarr
+            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/out.zarr"
+      outputs:
+        parameters:
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-zarr }}"
+      script:
+        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        env:
+          - name: IN
+            value: "{{ inputs.parameters.in-dir }}"
+          - name: OUT
+            value: "{{ inputs.parameters.out-zarr }}"
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [ python ]
+        source: |
+          # Real workflow begins here:
+          import os
+          import numpy as np
+          import xarray as xr
+          from adlfs import AzureBlobFileSystem
+
+
+          fs = AzureBlobFileSystem()
+          # Grab dir of yearly NetCDFs, read into single remote Zarr.
+          local_stash = "/mnt/in/"
+          fs.get(rpath=os.environ.get("IN"), lpath=local_stash, recursive=True)
+
+          d = xr.open_mfdataset(
+              f"{local_stash}*.nc",
+              concat_dim="time"
+          )
+          d.to_zarr(
+              os.environ.get("OUT"),
+              mode="w",
+              compute=True
+          )
+        resources:
+          requests:
+            memory: 42Gi
+            cpu: "1000m"
+          limits:
+            memory: 42Gi
+            cpu: "8000m"
+        volumeMounts:
+          - name: in
+            mountPath: /mnt/in
+      volumes:
+        - name: in
+          emptyDir: { }
+      activeDeadlineSeconds: 480
+      retryStrategy:
+        limit: 4
+        retryPolicy: "Always"
+
+
+    # Easier way to do conditional wet day frequency in Argo 3.1. This evaluates whether we do wet day frequency
+    # correction or not and outputs the location of the corrected or uncorrected file if appropriate.
+    # It's pretty clunky. Sorry. There has to be a better way to do this.
+    - name: wdf-check
+      inputs:
+        parameters:
+          - name: in-zarr
+          - name: process  # "pre" or "post"
+          - name: correct-bool  # Do the correction? true or false
+      steps:
+        - - name: correct-wetday-frequency
+            template: correct-wetday-frequency
+            when: "{{ inputs.parameters.correct-bool }} == true"
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ inputs.parameters.in-zarr }}"
+                - name: process  # pre or post
+                  value: "{{ inputs.parameters.process }}"
+      outputs:
+        parameters:
+          - name: out-zarr
+            valueFrom:
+              expression: "inputs.parameters['correct-bool'] == true ? steps.correct-wetday-frequency.outputs.parameters['out-zarr'] : inputs.parameters['in-zarr']"
+
+
+    - name: correct-wetday-frequency
+      inputs:
+        parameters:
+          - name: in-zarr
+          - name: out-zarr
+            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/out.zarr"
+          - name: process  # pre or post
+      outputs:
+        parameters:
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-zarr }}"
+      container:
+        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        env:
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [ dodola ]
+        args:
+          - "correct-wetday-frequency"
+          - "{{ inputs.parameters.in-zarr }}"
+          - "--out"
+          - "{{ inputs.parameters.out-zarr }}"
+          - "--process"
+          - "{{ inputs.parameters.process }}"
+        resources:
+          requests:
+            memory: 8Gi
+            cpu: "1000m"
+          limits:
+            memory: 8Gi
+            cpu: "2000m"
+      activeDeadlineSeconds: 600
+      retryStrategy:
+        limit: 3
+        retryPolicy: "Always"
+
+
+    - name: add-cyclic
+      inputs:
+        parameters:
+          - name: in-zarr
+          - name: out-zarr
+            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/out.zarr"
+      outputs:
+        parameters:
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-zarr }}"
+      script:
+        image: downscalecmip6.azurecr.io/dodola:dev
+        env:
+          - name: IN
+            value: "{{ inputs.parameters.in-zarr }}"
+          - name: OUT
+            value: "{{ inputs.parameters.out-zarr }}"
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [ python ]
+        source: |
+          import os
+          import dodola.repository as storage
+          from dodola.core import _add_cyclic
+
+          ds = storage.read(os.environ.get("IN"))
+          ds = _add_cyclic(ds, dim="lon")
+          storage.write(os.environ.get("OUT"), ds)
+        resources:
+          requests:
+            memory: 32Gi
+            cpu: "1000m"
+          limits:
+            memory: 32Gi
+            cpu: "4000m"
+      activeDeadlineSeconds: 480
+      retryStrategy:
+        limit: 4
+        retryPolicy: "Always"

--- a/workflows/templates/downloadraw.yaml
+++ b/workflows/templates/downloadraw.yaml
@@ -1,0 +1,180 @@
+# Downloads select, raw CMIP6 from GCP to co-located Azure storage for test case.
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: downloadraw
+  labels:
+    component: downloadraw
+spec:
+  workflowMetadata:
+    labels:
+      component: downloadraw
+  entrypoint: main
+  arguments:
+    parameters:
+      - name: variableID
+        value: "tasmin"
+      - name: sourceID
+        value: "GFDL-ESM4"
+      - name: historical
+        value: |
+          [
+            { "activityID": "CMIP", "experimentID": "historical", "tableID": "day", "variableID": "tasmin", "sourceID": "GFDL-ESM4", "institutionID": "NOAA-GFDL", "memberID": "r1i1p1f1", "gridLabel": "gr1", "version": "20190726" }
+          ]
+      - name: ssps
+        value: |
+          [
+            { "activityID": "ScenarioMIP", "experimentID": "ssp370", "tableID": "day", "variableID": "tasmin", "sourceID": "GFDL-ESM4", "institutionID": "NOAA-GFDL", "memberID": "r1i1p1f1", "gridLabel": "gr1", "version": "20180701" },
+            { "activityID": "ScenarioMIP", "experimentID": "ssp245", "tableID": "day", "variableID": "tasmin", "sourceID": "GFDL-ESM4", "institutionID": "NOAA-GFDL", "memberID": "r1i1p1f1", "gridLabel": "gr1", "version": "20180701" },
+            { "activityID": "ScenarioMIP", "experimentID": "ssp126", "tableID": "day", "variableID": "tasmin", "sourceID": "GFDL-ESM4", "institutionID": "NOAA-GFDL", "memberID": "r1i1p1f1", "gridLabel": "gr1", "version": "20180701" }
+          ]
+  templates:
+
+    - name: main
+      inputs:
+        parameters:
+          - name: variableID
+          - name: sourceID
+          - name: historical
+          - name: ssps
+      dag:
+        tasks:
+          - name: download-historical
+            template: download-gcm
+            arguments:
+              parameters:
+                - name: experiment-id
+                  value: "{{item.experimentID}}"
+                - name: activity-id
+                  value: "{{item.activityID}}"
+                - name: table-id
+                  value: "{{item.tableID}}"
+                - name: variable-id
+                  value: "{{item.variableID}}"
+                - name: source-id
+                  value: "{{item.sourceID}}"
+                - name: institution-id
+                  value: "{{item.institutionID}}"
+                - name: member-id
+                  value: "{{item.memberID}}"
+                - name: grid-label
+                  value: "{{item.gridLabel}}"
+                - name: version
+                  value: "{{item.version}}"
+                - name: out-url
+                  value: "az://raw/{{inputs.parameters.sourceID}}/historical/{{inputs.parameters.variableID}}.zarr"
+            withParam: "{{ inputs.parameters.historical }}"
+          - name: download-ssps
+            template: download-gcm
+            arguments:
+              parameters:
+                - name: experiment-id
+                  value: "{{item.experimentID}}"
+                - name: activity-id
+                  value: "{{item.activityID}}"
+                - name: table-id
+                  value: "{{item.tableID}}"
+                - name: variable-id
+                  value: "{{item.variableID}}"
+                - name: source-id
+                  value: "{{item.sourceID}}"
+                - name: institution-id
+                  value: "{{item.institutionID}}"
+                - name: member-id
+                  value: "{{item.memberID}}"
+                - name: grid-label
+                  value: "{{item.gridLabel}}"
+                - name: version
+                  value: "{{item.version}}"
+                - name: out-url
+                  value: "az://raw/{{inputs.parameters.sourceID}}/{{item.experimentID}}/{{inputs.parameters.variableID}}.zarr"
+            withParam: "{{ inputs.parameters.ssps }}"
+
+
+    - name: download-gcm
+      inputs:
+        parameters:
+          - name: experiment-id
+          - name: activity-id
+          - name: table-id
+          - name: variable-id
+          - name: source-id
+          - name: institution-id
+          - name: member-id
+          - name: grid-label
+          - name: version
+          - name: out-url
+      outputs:
+        parameters:
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-url }}"
+      script:
+        image: downscalecmip6.azurecr.io/dodola:dev
+        env:
+          - name: ACTIVITY_ID
+            value: "{{inputs.parameters.activity-id}}"
+          - name: EXPERIMENT_ID
+            value: "{{inputs.parameters.experiment-id}}"
+          - name: TABLE_ID
+            value: "{{inputs.parameters.table-id}}"
+          - name: VARIABLE_ID
+            value: "{{inputs.parameters.variable-id}}"
+          - name: SOURCE_ID
+            value: "{{inputs.parameters.source-id}}"
+          - name: INSTITUTION_ID
+            value: "{{inputs.parameters.institution-id}}"
+          - name: MEMBER_ID
+            value: "{{inputs.parameters.member-id}}"
+          - name: GRID_LABEL
+            value: "{{inputs.parameters.grid-label}}"
+          - name: INTAKE_VERSION
+            value: "{{inputs.parameters.version}}"
+          - name: OUTPATH
+            value: "{{inputs.parameters.out-url}}"
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [python]
+        source: |
+          import os
+          import intake
+          import dodola.repository
+
+          print("Searching catalog")
+          col = intake.open_esm_datastore("https://storage.googleapis.com/cmip6/pangeo-cmip6.json")
+          cat = col.search(
+              activity_id=os.environ.get("ACTIVITY_ID"),
+              experiment_id=os.environ.get("EXPERIMENT_ID"),
+              table_id=os.environ.get("TABLE_ID"),
+              variable_id=os.environ.get("VARIABLE_ID"),
+              source_id=os.environ.get("SOURCE_ID"),
+              member_id=os.environ.get("MEMBER_ID"),
+              grid_label=os.environ.get("GRID_LABEL"),
+              version=int(os.environ.get("INTAKE_VERSION")),
+          )
+          d = cat.to_dataset_dict(progressbar=False)
+          k = list(d.keys())
+          if len(k) != 1:
+              raise ValueError("catalog does not have one entry, reconsider input IDs so only one entry")
+          print(f"Found one catalog entry {k}")
+          print(d)  # DEBUG
+
+          dodola.repository.write(os.environ.get("OUTPATH"), d[k[0]])
+        resources:
+          requests:
+            memory: 14Gi
+            cpu: "200m"
+          limits:
+            memory: 14Gi
+            cpu: "1000m"
+      activeDeadlineSeconds: 1500
+      retryStrategy:
+        limit: 4
+        retryPolicy: "Always"

--- a/workflows/templates/kustomization.yaml
+++ b/workflows/templates/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - rbac
-  - events
-  - ../../../workflows/templates
+  - clean-cmip6.yaml
+  - clean-era5.yaml
+  - dc6.yaml
+  - downloadraw.yaml


### PR DESCRIPTION
This PR simplifies workflows by moving logic into reuseable `WorkflowTemplates`. 

Workflows can now trigger subsequent work automatically. Generally, this is `downloadraw -> clean-cmip6 -> dc6`. This is another attempt to simplify work.

The parameters for workflows are now in `workflows/parameters` for each `<GCM>-<variable>.yaml` these can be passed to any of the above workflow templates to launch a "unit of work". This will hopefully save us from really long, tedious JSON/YAML files.

If this system works well, we will gradually transition away from the old workflows YAMLs, JSON, and the intake catalog.

This PR also does bias correction on each SSP and the historical as spec'd in #99.

Close #99