### PR TITLE
Upgrade argo workflows to patch v3.1.5

### DIFF
--- a/infrastructure/kubernetes/argo/kustomization.yaml
+++ b/infrastructure/kubernetes/argo/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/argoproj/argo-workflows/releases/download/v3.1.3/install.yaml
+  - https://github.com/argoproj/argo-workflows/releases/download/v3.1.5/install.yaml
   - sso-secrets
   - argo-server-ingress.yaml
 


### PR DESCRIPTION
Fixes bugs. This upgrade is not needed for anything critical.