### PR TITLE
Use consolidated zarr stores in all workflows

### DIFF
--- a/workflows/clean-cmip6-workflow.yaml
+++ b/workflows/clean-cmip6-workflow.yaml
@@ -358,7 +358,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -400,7 +400,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -475,7 +475,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: IN1_ZARR
             value: "{{ inputs.parameters.in1-zarr }}"
@@ -552,7 +552,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: TASMAX_ZARR
             value: "{{ inputs.parameters.tasmax-zarr }}"

--- a/workflows/clean-cmip6-workflow.yaml
+++ b/workflows/clean-cmip6-workflow.yaml
@@ -358,7 +358,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.4.0
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -400,7 +400,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:0.3.0
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -475,7 +475,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:0.3.0
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: IN1_ZARR
             value: "{{ inputs.parameters.in1-zarr }}"
@@ -552,7 +552,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:0.4.0
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: TASMAX_ZARR
             value: "{{ inputs.parameters.tasmax-zarr }}"

--- a/workflows/clean-era5-workflow.yaml
+++ b/workflows/clean-era5-workflow.yaml
@@ -37,7 +37,7 @@ spec:
       - name: out-zarr
         value: "{{ inputs.parameters.out-zarr }}"
     container:
-      image: downscalecmip6.azurecr.io/dodola:dev
+      image: downscalecmip6.azurecr.io/dodola:0.5.0
       env:
       - name: IN_ZARR
         value: "{{  inputs.parameters.in-zarr }}"
@@ -83,7 +83,7 @@ spec:
       - name: out-zarr
         value: "{{ inputs.parameters.out-zarr }}"
     script:
-      image: downscalecmip6.azurecr.io/dodola:dev
+      image: downscalecmip6.azurecr.io/dodola:0.5.0
       env:
       - name: IN_ZARR
         value: "{{  inputs.parameters.in-zarr }}"
@@ -161,7 +161,7 @@ spec:
         - name: out-zarr
           value: "{{ inputs.parameters.out-zarr }}"
     container:
-      image: downscalecmip6.azurecr.io/dodola:dev
+      image: downscalecmip6.azurecr.io/dodola:0.5.0
       env:
         - name: AZURE_STORAGE_ACCOUNT_NAME
           valueFrom:

--- a/workflows/clean-era5-workflow.yaml
+++ b/workflows/clean-era5-workflow.yaml
@@ -10,9 +10,9 @@ spec:
   arguments:
     parameters:
     - name: in-zarr
-      value: "clean-dev/ERA-5/F320/tasmax.1995-2015.F320.v2.zarr"
+      value: "az://clean-dev/ERA-5/F320/tasmax.1995-2015.F320.v2.zarr"
     - name: out-zarr
-      value: "scratch/clean-dev/ERA-5/tasmax.1995-2015.F320.zarr"
+      value: "az://scratch/clean-dev/ERA-5/tasmax.1995-2015.F320.zarr"
   templates:
 
   - name: main
@@ -37,7 +37,7 @@ spec:
       - name: out-zarr
         value: "{{ inputs.parameters.out-zarr }}"
     container:
-      image: downscalecmip6.azurecr.io/dodola:0.1.0
+      image: downscalecmip6.azurecr.io/dodola:dev
       env:
       - name: IN_ZARR
         value: "{{  inputs.parameters.in-zarr }}"
@@ -83,7 +83,7 @@ spec:
       - name: out-zarr
         value: "{{ inputs.parameters.out-zarr }}"
     script:
-      image: downscalecmip6.azurecr.io/dodola:0.1.0
+      image: downscalecmip6.azurecr.io/dodola:dev
       env:
       - name: IN_ZARR
         value: "{{  inputs.parameters.in-zarr }}"
@@ -116,15 +116,7 @@ spec:
 
         fs = AzureBlobFileSystem()
 
-        ds = xr.open_zarr(
-            fs.get_mapper(in_store_path),
-            # chunks="auto",
-            # chunks={
-            #     "latitude": 10,
-            #     "longitude": 10,
-            #     "time": 365,
-            # }
-        )
+        ds = xr.open_zarr(in_store_path)
         print(f"opening {in_store_path}")
 
         if "tmax" in ds.variables:
@@ -139,10 +131,7 @@ spec:
 
         print(f"standardized tmax/latitude/longitude name to tasmax/lat/lon")
 
-        ds.to_zarr(
-            store=fs.get_mapper(out_store_path),
-            mode="w",
-        )
+        ds.to_zarr(out_store_path, mode="w")
         print(f"written to {out_store_path}")
 
         print("ERA-5 cleaning done")
@@ -172,7 +161,7 @@ spec:
         - name: out-zarr
           value: "{{ inputs.parameters.out-zarr }}"
     container:
-      image: downscalecmip6.azurecr.io/dodola:0.4.0
+      image: downscalecmip6.azurecr.io/dodola:dev
       env:
         - name: AZURE_STORAGE_ACCOUNT_NAME
           valueFrom:
@@ -189,9 +178,9 @@ spec:
       command: [dodola]
       args:
         - "rechunk"
-        - "az://{{ inputs.parameters.in-zarr }}"
+        - "{{ inputs.parameters.in-zarr }}"
         - "--out"
-        - "az://{{ inputs.parameters.out-zarr }}"
+        - "{{ inputs.parameters.out-zarr }}"
         - "--chunk"
         - "time={{ inputs.parameters.time-chunk }}"
         - "--chunk"

--- a/workflows/dc6-workflow.yaml
+++ b/workflows/dc6-workflow.yaml
@@ -8,17 +8,17 @@ spec:
   arguments:
     parameters:
       - name: reference-zarr
-        value: "az://scratch/clean-dev/ERA-5/tasmax.1995-2015.F320.zarr"
+        value: "az://scratch/clean-dev/ERA-5/tasmin.1995-2015.F320.zarr"
       - name: gcm-historical-zarr
-        value: "az://clean/ACCESS-ESM1-5/training/r1i1p1f1/tasmax.zarr"
+        value: "az://clean/ACCESS-ESM1-5/training/r1i1p1f1/tasmin.zarr"
       - name: gcm-training-zarr
-        value: "az://clean/ACCESS-ESM1-5/training/r1i1p1f1/tasmax.zarr"
+        value: "az://clean/ACCESS-ESM1-5/training/r1i1p1f1/tasmin.zarr"
       - name: gcm-future-zarr
-        value: "az://clean/ACCESS-ESM1-5/ssp370/r1i1p1f1/tasmax.zarr"
+        value: "az://clean/ACCESS-ESM1-5/ssp370/r1i1p1f1/tasmin.zarr"
       - name: out-zarr
         value: "az://scratch/{{ workflow.name }}/out.zarr"
       - name: target-variable
-        value: tasmax
+        value: tasmin
       - name: biascorrect-firstfutureyear
         value: 1980
       - name: biascorrect-lastfutureyear
@@ -30,7 +30,7 @@ spec:
       - name: domainfile0p25x0p25
         value: "az://support/domain.0p25x0p25.zarr"
       - name: climatology-zarr
-        value: "az://clean-dev/tasmax_1995_2015_climo_cleaned.zarr"
+        value: "az://clean-dev/tasmin_1995_2015_climo_cleaned.zarr"
       - name: correct-wetday-frequency
         value: false  # true or false
   entrypoint: main
@@ -391,7 +391,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -446,7 +446,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -554,7 +554,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -615,7 +615,7 @@ spec:
             s3:
               key: "{{ workflow.name }}/qdm-years/{{ inputs.parameters.year }}.nc"
       container:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -671,7 +671,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: IN
             value: "{{ inputs.parameters.in-dir }}"
@@ -841,7 +841,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -921,7 +921,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -971,7 +971,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -1039,7 +1039,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: IN_ZARR
             value: "{{  inputs.parameters.in-zarr }}"
@@ -1136,7 +1136,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -1180,7 +1180,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: IN
             value: "{{ inputs.parameters.in-zarr }}"
@@ -1224,7 +1224,7 @@ spec:
         parameters:
           - name: in-zarr
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"

--- a/workflows/dc6-workflow.yaml
+++ b/workflows/dc6-workflow.yaml
@@ -391,7 +391,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -446,7 +446,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -554,7 +554,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -615,7 +615,7 @@ spec:
             s3:
               key: "{{ workflow.name }}/qdm-years/{{ inputs.parameters.year }}.nc"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -671,7 +671,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: IN
             value: "{{ inputs.parameters.in-dir }}"
@@ -841,7 +841,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -921,7 +921,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.2.0
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -971,7 +971,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -1039,7 +1039,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:0.2.0
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: IN_ZARR
             value: "{{  inputs.parameters.in-zarr }}"
@@ -1136,7 +1136,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -1224,7 +1224,7 @@ spec:
         parameters:
           - name: in-zarr
       script:
-        image: downscalecmip6.azurecr.io/dodola:0.2.0
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"

--- a/workflows/downloadraw-workflow.yaml
+++ b/workflows/downloadraw-workflow.yaml
@@ -168,7 +168,7 @@ spec:
         print("Authenticated with storage")
 
         store = fs.get_mapper(os.environ.get("OUTPATH"))
-        d[k[0]].to_zarr(store, mode="w", compute=True)
+        d[k[0]].to_zarr(store, mode="w", compute=True, consolidated=True)
         print(f"Output written to {os.environ.get('OUTPATH')}")
       resources:
         requests:

--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -127,7 +127,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.4.0
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -170,7 +170,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:0.3.0
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -246,7 +246,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:0.3.0
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: IN1_ZARR
             value: "{{ inputs.parameters.in1-zarr }}"
@@ -324,7 +324,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:0.4.0
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: TASMAX_ZARR
             value: "{{ inputs.parameters.tasmax-zarr }}"

--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -127,7 +127,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -170,7 +170,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -246,7 +246,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: IN1_ZARR
             value: "{{ inputs.parameters.in1-zarr }}"
@@ -324,7 +324,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: TASMAX_ZARR
             value: "{{ inputs.parameters.tasmax-zarr }}"

--- a/workflows/templates/clean-era5.yaml
+++ b/workflows/templates/clean-era5.yaml
@@ -43,7 +43,7 @@ spec:
       - name: out-zarr
         value: "{{ inputs.parameters.out-zarr }}"
     container:
-      image: downscalecmip6.azurecr.io/dodola:dev
+      image: downscalecmip6.azurecr.io/dodola:0.5.0
       env:
       - name: IN_ZARR
         value: "{{  inputs.parameters.in-zarr }}"
@@ -89,7 +89,7 @@ spec:
       - name: out-zarr
         value: "{{ inputs.parameters.out-zarr }}"
     script:
-      image: downscalecmip6.azurecr.io/dodola:dev
+      image: downscalecmip6.azurecr.io/dodola:0.5.0
       env:
       - name: IN_ZARR
         value: "{{  inputs.parameters.in-zarr }}"
@@ -163,7 +163,7 @@ spec:
         - name: out-zarr
           value: "{{ inputs.parameters.out-zarr }}"
     container:
-      image: downscalecmip6.azurecr.io/dodola:dev
+      image: downscalecmip6.azurecr.io/dodola:0.5.0
       env:
         - name: AZURE_STORAGE_ACCOUNT_NAME
           valueFrom:

--- a/workflows/templates/clean-era5.yaml
+++ b/workflows/templates/clean-era5.yaml
@@ -12,9 +12,9 @@ spec:
   arguments:
     parameters:
     - name: in-zarr
-      value: "clean-dev/ERA-5/F320/tasmax.1995-2015.F320.v2.zarr"
+      value: "az://clean-dev/ERA-5/F320/tasmax.1995-2015.F320.v2.zarr"
     - name: out-zarr
-      value: "scratch/clean-dev/ERA-5/tasmax.1995-2015.F320.zarr"
+      value: "az://scratch/clean-dev/ERA-5/tasmax.1995-2015.F320.zarr"
   templates:
 
   - name: main
@@ -43,7 +43,7 @@ spec:
       - name: out-zarr
         value: "{{ inputs.parameters.out-zarr }}"
     container:
-      image: downscalecmip6.azurecr.io/dodola:0.1.0
+      image: downscalecmip6.azurecr.io/dodola:dev
       env:
       - name: IN_ZARR
         value: "{{  inputs.parameters.in-zarr }}"
@@ -89,7 +89,7 @@ spec:
       - name: out-zarr
         value: "{{ inputs.parameters.out-zarr }}"
     script:
-      image: downscalecmip6.azurecr.io/dodola:0.1.0
+      image: downscalecmip6.azurecr.io/dodola:dev
       env:
       - name: IN_ZARR
         value: "{{  inputs.parameters.in-zarr }}"
@@ -113,24 +113,14 @@ spec:
       source: |
         import os
         import xarray as xr
-        from adlfs import AzureBlobFileSystem
 
         print("starting ERA-5 cleaning")
 
         in_store_path = os.environ.get("IN_ZARR")
         out_store_path = os.environ.get("OUT_ZARR")
 
-        fs = AzureBlobFileSystem()
 
-        ds = xr.open_zarr(
-            fs.get_mapper(in_store_path),
-            # chunks="auto",
-            # chunks={
-            #     "latitude": 10,
-            #     "longitude": 10,
-            #     "time": 365,
-            # }
-        )
+        ds = xr.open_zarr(in_store_path)
         print(f"opening {in_store_path}")
 
         if "tmax" in ds.variables:
@@ -143,10 +133,7 @@ spec:
 
         print(f"standardized tmax/latitude/longitude name to tasmax/lat/lon")
 
-        ds.to_zarr(
-            store=fs.get_mapper(out_store_path),
-            mode="w",
-        )
+        ds.to_zarr(out_store_path, mode="w")
         print(f"written to {out_store_path}")
 
         print("ERA-5 cleaning done")
@@ -176,7 +163,7 @@ spec:
         - name: out-zarr
           value: "{{ inputs.parameters.out-zarr }}"
     container:
-      image: downscalecmip6.azurecr.io/dodola:0.4.0
+      image: downscalecmip6.azurecr.io/dodola:dev
       env:
         - name: AZURE_STORAGE_ACCOUNT_NAME
           valueFrom:
@@ -193,9 +180,9 @@ spec:
       command: [dodola]
       args:
         - "rechunk"
-        - "az://{{ inputs.parameters.in-zarr }}"
+        - "{{ inputs.parameters.in-zarr }}"
         - "--out"
-        - "az://{{ inputs.parameters.out-zarr }}"
+        - "{{ inputs.parameters.out-zarr }}"
         - "--chunk"
         - "time={{ inputs.parameters.time-chunk }}"
         - "--chunk"

--- a/workflows/templates/dc6.yaml
+++ b/workflows/templates/dc6.yaml
@@ -244,7 +244,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -396,7 +396,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -458,7 +458,7 @@ spec:
             s3:
               key: "{{ inputs.parameters.out-key }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -514,7 +514,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: IN
             value: "{{ inputs.parameters.in-dir }}"
@@ -610,7 +610,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:0.4.1
+        image: downscalecmip6.azurecr.io/dodola:dev
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:

--- a/workflows/templates/dc6.yaml
+++ b/workflows/templates/dc6.yaml
@@ -244,7 +244,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -299,7 +299,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -396,7 +396,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -458,7 +458,7 @@ spec:
             s3:
               key: "{{ inputs.parameters.out-key }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -514,7 +514,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: IN
             value: "{{ inputs.parameters.in-dir }}"
@@ -610,7 +610,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
@@ -654,7 +654,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: IN
             value: "{{ inputs.parameters.in-zarr }}"

--- a/workflows/templates/distributed-regrid.yaml
+++ b/workflows/templates/distributed-regrid.yaml
@@ -97,7 +97,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -193,7 +193,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"

--- a/workflows/templates/downloadraw.yaml
+++ b/workflows/templates/downloadraw.yaml
@@ -109,7 +109,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-url }}"
       script:
-        image: downscalecmip6.azurecr.io/dodola:dev
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
           - name: ACTIVITY_ID
             value: "{{inputs.parameters.activity-id}}"


### PR DESCRIPTION
Upgrade all workflows to dodola:0.5.0. This includes an upgrade to `xarray` v0.19.0 which has breaking changes in how it saves and reads Zarr stores. Esp. note that all metadata is now consolidated by default.