### PR TITLE
Fix so workflowtemplate drops dayofyear like legacy workflow

### DIFF
--- a/workflows/templates/clean-era5.yaml
+++ b/workflows/templates/clean-era5.yaml
@@ -131,6 +131,8 @@ spec:
             ds = ds.rename({"precip": "pr"})
         ds = ds.rename({"latitude": "lat", "longitude": "lon"})
 
+        ds = ds.drop_vars("dayofyear", errors="ignore")
+
         print(f"standardized tmax/latitude/longitude name to tasmax/lat/lon")
 
         ds.to_zarr(out_store_path, mode="w")


### PR DESCRIPTION
The legacy workflow dropped dayofyear variable but the workflowtemplate did not. This fixes it so both drop dayofyear, if present.
