### PR TITLE
Nouveau QDM scheme - apply QDM in parallel along latitudinal bands

### DIFF
--- a/workflows/dc6-workflow.yaml
+++ b/workflows/dc6-workflow.yaml
@@ -20,9 +20,9 @@ spec:
       - name: target-variable
         value: tasmax
       - name: biascorrect-firstfutureyear
-        value: 1980
+        value: 2015
       - name: biascorrect-lastfutureyear
-        value: 2099
+        value: 2100
       - name: biascorrect-kind
         value: additive  # multiplicative
       - name: domainfile1x1

--- a/workflows/dc6-workflow.yaml
+++ b/workflows/dc6-workflow.yaml
@@ -53,7 +53,7 @@ spec:
                 - name: in-zarr
                   value: "{{ tasks.reference-add-cyclic.outputs.parameters.out-zarr }}"
                 - name: time-chunk
-                  value: "365"
+                  value: 365
                 - name: lat-chunk
                   value: -1
                 - name: lon-chunk
@@ -77,11 +77,11 @@ spec:
                 - name: in-zarr
                   value: "{{ tasks.reference-regrid.outputs.parameters.out-zarr }}"
                 - name: time-chunk
-                  value: "-1"
+                  value: -1
                 - name: lat-chunk
                   value: 10
                 - name: lon-chunk
-                  value: 10
+                  value: -1
           - name: gcm-historical-wetdaycorrect
             template: wdf-check
             arguments:
@@ -111,7 +111,7 @@ spec:
                 - name: in-zarr
                   value: "{{ tasks.gcm-historical-add-cyclic.outputs.parameters.out-zarr }}"
                 - name: time-chunk
-                  value: "365"
+                  value: 365
                 - name: lat-chunk
                   value: -1
                 - name: lon-chunk
@@ -135,11 +135,11 @@ spec:
                 - name: in-zarr
                   value: "{{ tasks.gcm-historical-regrid.outputs.parameters.out-zarr }}"
                 - name: time-chunk
-                  value: "-1"
+                  value: -1
                 - name: lat-chunk
                   value: 10
                 - name: lon-chunk
-                  value: 10
+                  value: -1
           - name: gcm-training-wetdaycorrect
             template: wdf-check
             arguments:
@@ -169,7 +169,7 @@ spec:
                 - name: in-zarr
                   value: "{{ tasks.gcm-training-add-cyclic.outputs.parameters.out-zarr }}"
                 - name: time-chunk
-                  value: "365"
+                  value: 365
                 - name: lat-chunk
                   value: -1
                 - name: lon-chunk
@@ -193,11 +193,11 @@ spec:
                 - name: in-zarr
                   value: "{{ tasks.gcm-training-regrid.outputs.parameters.out-zarr }}"
                 - name: time-chunk
-                  value: "-1"
+                  value: -1
                 - name: lat-chunk
                   value: 10
                 - name: lon-chunk
-                  value: 10
+                  value: -1
           - name: gcm-future-wetdaycorrect
             template: wdf-check
             arguments:
@@ -227,7 +227,7 @@ spec:
                 - name: in-zarr
                   value: "{{ tasks.gcm-future-add-cyclic.outputs.parameters.out-zarr }}"
                 - name: time-chunk
-                  value: "365"
+                  value: 365
                 - name: lat-chunk
                   value: -1
                 - name: lon-chunk
@@ -251,11 +251,11 @@ spec:
                 - name: in-zarr
                   value: "{{ tasks.gcm-future-regrid.outputs.parameters.out-zarr }}"
                 - name: time-chunk
-                  value: "-1"
+                  value: -1
                 - name: lat-chunk
                   value: 10
                 - name: lon-chunk
-                  value: 10
+                  value: -1
           - name: biascorrect
             dependencies: [ gcm-training-rechunk, gcm-future-rechunk, reference-rechunk ]
             template: biascorrect-qdm
@@ -265,17 +265,17 @@ spec:
                   value: "{{ workflow.parameters.target-variable }}"
                 - name: ref-zarr
                   value: "{{ tasks.reference-rechunk.outputs.parameters.out-zarr }}"
-                - name: hist-zarr
+                - name: train-zarr
                   value: "{{ tasks.gcm-training-rechunk.outputs.parameters.out-zarr }}"
-                - name: future-zarr
+                - name: simulation-zarr
                   value: "{{ tasks.gcm-future-rechunk.outputs.parameters.out-zarr }}"
                 - name: out-zarr
                   value: "az://scratch/{{ workflow.name }}/biascorrected.zarr"
                 - name: kind
                   value: "{{ workflow.parameters.biascorrect-kind }}"
-                - name: firstyear
+                - name: first-year
                   value: "{{ workflow.parameters.biascorrect-firstfutureyear }}"
-                - name: lastyear
+                - name: last-year
                   value: "{{ workflow.parameters.biascorrect-lastfutureyear }}"
           - name: rechunk-biascorrected
             template: rechunk
@@ -488,184 +488,72 @@ spec:
         parameters:
           - name: variable
           - name: ref-zarr
-          - name: hist-zarr
-          - name: future-zarr
-          - name: out-zarr  # Needs to be az://... format
-          - name: firstyear
-          - name: lastyear
+          - name: train-zarr
+          - name: simulation-zarr
+          - name: out-zarr
           - name: kind
+          - name: first-year
+          - name: last-year
       outputs:
         parameters:
           - name: out-zarr
             valueFrom:
-              parameter: "{{ tasks.netcdfs2zarr.outputs.parameters.out-zarr }}"
+              parameter: "{{ tasks.prime-output-zarrstore.outputs.parameters.out-zarr }}"
       dag:
         tasks:
-          - name: train-qdm
-            template: train-qdm
+          - name: prime-output-zarrstore
+            template: prime-output-zarrstore
+            arguments:
+              parameters:
+                - name: variable
+                  value: "{{ inputs.parameters.variable }}"
+                - name: simulation-zarr
+                  value: "{{ inputs.parameters.simulation-zarr }}"
+                - name: first-year
+                  value: "{{ inputs.parameters.first-year }}"
+                - name: last-year
+                  value: "{{ inputs.parameters.last-year }}"
+                - name: out-zarr
+                  value: "{{ inputs.parameters.out-zarr }}"
+          - name: with-lat-chunk
+            depends: "prime-output-zarrstore"
+            template: with-lat-chunk
             arguments:
               parameters:
                 - name: variable
                   value: "{{ inputs.parameters.variable }}"
                 - name: ref-zarr
                   value: "{{ inputs.parameters.ref-zarr }}"
-                - name: hist-zarr
-                  value: "{{ inputs.parameters.hist-zarr }}"
+                - name: train-zarr
+                  value: "{{ inputs.parameters.train-zarr }}"
+                - name: simulation-zarr
+                  value: "{{ inputs.parameters.simulation-zarr }}"
+                - name: first-year
+                  value: "{{ inputs.parameters.first-year }}"
+                - name: last-year
+                  value: "{{ inputs.parameters.last-year }}"
                 - name: kind
                   value: "{{ inputs.parameters.kind }}"
-          - name: qdm-adjust-year
-            dependencies: [ train-qdm ]
-            template: qdm-adjust-year
-            arguments:
-              parameters:
-                - name: future-zarr
-                  value: "{{ inputs.parameters.future-zarr }}"
-                - name: variable
-                  value: "{{ inputs.parameters.variable }}"
-                - name: year
-                  value: "{{item}}"
-                - name: qdm-model-zarr
-                  value: "{{ tasks.train-qdm.outputs.parameters.out-zarr }}"
-            withSequence:
-              start: "{{ inputs.parameters.firstyear }}"
-              end: "{{ inputs.parameters.lastyear }}"
-          - name: netcdfs2zarr
-            dependencies: [ qdm-adjust-year ]
-            template: netcdfs2zarr
-            arguments:
-              parameters:
-                - name: in-dir
-                  value: "scratch/{{workflow.name}}/qdm-years/"
+                - name: lat-slice-min
+                  value: "{{=asInt(item) * 10 }}"
+                - name: lat-slice-max
+                  value: "{{=asInt(item) * 10 + 10 }}"
                 - name: out-zarr
-                  value: "{{ inputs.parameters.out-zarr }}"
+                  value: "{{ tasks.prime-output-zarrstore.outputs.parameters.out-zarr }}"
+            withSequence:
+              start: "0"
+              end: "17"
 
 
-    - name: train-qdm
+    - name: prime-output-zarrstore
       inputs:
         parameters:
           - name: variable
-          - name: ref-zarr  # Needs to be az://... format
-          - name: hist-zarr  # Needs to be az://... format
+          - name: simulation-zarr
+          - name: first-year
+          - name: last-year
           - name: out-zarr
-            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/out.zarr"
-          - name: kind
-      outputs:
-        parameters:
-          - name: out-zarr
-            value: "{{ inputs.parameters.out-zarr }}"
-      container:
-        image: downscalecmip6.azurecr.io/dodola:0.5.0
-        env:
-          - name: AZURE_STORAGE_ACCOUNT_NAME
-            valueFrom:
-              secretKeyRef:
-                name: workerstoragecreds-secret
-                key: azurestorageaccount
-          - name: AZURE_STORAGE_ACCOUNT_KEY
-            valueFrom:
-              secretKeyRef:
-                name: workerstoragecreds-secret
-                key: azurestoragekey
-        command: [ "dodola" ]
-        args:
-          - "train-qdm"
-          - "--historical"
-          - "{{ inputs.parameters.hist-zarr }}"
-          - "--reference"
-          - "{{ inputs.parameters.ref-zarr }}"
-          - "--out"
-          - "{{ inputs.parameters.out-zarr }}"
-          - "--variable"
-          - "{{ inputs.parameters.variable }}"
-          - "--kind"
-          - "{{ inputs.parameters.kind }}"
-        resources:
-          requests:
-            memory: 48Gi
-            cpu: "2000m"
-          limits:
-            memory: 48Gi
-            cpu: "2500m"
-        # emptyDir volume as k8sapi can't output to base image layer:
-        volumeMounts:
-          - name: out
-            mountPath: /mnt/out
-      volumes:
-        - name: out
-          emptyDir: { }
-      activeDeadlineSeconds: 172800
-      retryStrategy:
-        limit: 4
-        retryPolicy: "Always"
-
-
-    - name: qdm-adjust-year
-      inputs:
-        parameters:
-          - name: future-zarr  # Needs to be az://... format
-          - name: year
-          - name: qdm-model-zarr
-          - name: variable
-      outputs:
-        artifacts:
-          - name: adjusted
-            path: "/mnt/out/{{ inputs.parameters.year }}.nc"
-            archive:
-              none: { }
-            s3:
-              key: "{{ workflow.name }}/qdm-years/{{ inputs.parameters.year }}.nc"
-      container:
-        image: downscalecmip6.azurecr.io/dodola:0.5.0
-        env:
-          - name: AZURE_STORAGE_ACCOUNT_NAME
-            valueFrom:
-              secretKeyRef:
-                name: workerstoragecreds-secret
-                key: azurestorageaccount
-          - name: AZURE_STORAGE_ACCOUNT_KEY
-            valueFrom:
-              secretKeyRef:
-                name: workerstoragecreds-secret
-                key: azurestoragekey
-        command: [ dodola ]
-        args:
-          - "apply-qdm"
-          - "--simulation"
-          - "{{ inputs.parameters.future-zarr }}"
-          - "--out"
-          - "/mnt/out/{{ inputs.parameters.year }}.nc"
-          - "--year"
-          - "{{ inputs.parameters.year }}"
-          - "--variable"
-          - "{{ inputs.parameters.variable }}"
-          - "--qdm"
-          - "{{ inputs.parameters.qdm-model-zarr }}"
-        resources:
-          requests:
-            memory: 42Gi
-            cpu: "2000m"
-          limits:
-            memory: 42Gi
-            cpu: "2000m"
-        # emptyDir volume as k8sapi can't output to base image layer:
-        volumeMounts:
-          - name: out
-            mountPath: /mnt/out
-      volumes:
-        - name: out
-          emptyDir: { }
-      activeDeadlineSeconds: 3600
-      retryStrategy:
-        limit: 4
-        retryPolicy: "Always"
-
-
-    - name: netcdfs2zarr
-      inputs:
-        parameters:
-          - name: in-dir  # DIR with container containing all the nc files. No az://!
-          - name: out-zarr
-            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/out.zarr"
+            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/qdm_adjusted.zarr"
       outputs:
         parameters:
           - name: out-zarr
@@ -673,10 +561,6 @@ spec:
       script:
         image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
-          - name: IN
-            value: "{{ inputs.parameters.in-dir }}"
-          - name: OUT
-            value: "{{ inputs.parameters.out-zarr }}"
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
               secretKeyRef:
@@ -689,44 +573,273 @@ spec:
                 key: azurestoragekey
         command: [ python ]
         source: |
-          # Real workflow begins here:
-          import os
-          import numpy as np
+          import dodola.repository
           import xarray as xr
-          from adlfs import AzureBlobFileSystem
 
+          nonlat_variables = ["lon", "time"]
 
-          fs = AzureBlobFileSystem()
-          # Grab dir of yearly NetCDFs, read into single remote Zarr.
-          local_stash = "/mnt/in/"
-          fs.get(rpath=os.environ.get("IN"), lpath=local_stash, recursive=True)
+          simulation_zarr = "{{ inputs.parameters.simulation-zarr }}"
+          out_zarr = "{{ inputs.parameters.out-zarr }}"
+          first_year = int({{ inputs.parameters.first-year }})
+          last_year = int({{ inputs.parameters.last-year }})
+          variable = "{{ inputs.parameters.variable }}"
 
-          d = xr.open_mfdataset(
-              f"{local_stash}*.nc",
-              concat_dim="time"
+          timeslice = slice(str(first_year), str(last_year + 1))
+
+          primed_out = dodola.repository.read(simulation_zarr).sel(time=timeslice).chunk({"time": -1, "lat": 10, "lon":-1})
+
+          print(primed_out)  # DEBUG
+
+          primed_out.to_zarr(
+            out_zarr,
+            mode="w",
+            compute=False,
+            consolidated=True,
           )
-          d.to_zarr(
-              os.environ.get("OUT"),
-              mode="w",
-              compute=True
-          )
+          print(f"Output written to {out_zarr}")  # DEBUG
+
+          # Append variables that do not depend on "lat"
+          if nonlat_variables:
+              primed_out[nonlat_variables].to_zarr(
+                  out_zarr,
+                  mode="a",
+                  compute=True,
+                  consolidated=True
+              )
         resources:
           requests:
-            memory: 42Gi
+            memory: 4Gi
             cpu: "1000m"
           limits:
-            memory: 42Gi
-            cpu: "8000m"
-        # emptyDir volume as k8sapi can't output to base image layer:
-        volumeMounts:
-          - name: in
-            mountPath: /mnt/in
-      volumes:
-        - name: in
-          emptyDir: { }
-      activeDeadlineSeconds: 480
+            memory: 4Gi
+            cpu: "1000m"
+      activeDeadlineSeconds: 900
       retryStrategy:
-        limit: 4
+        limit: 1
+        retryPolicy: "Always"
+
+
+    - name: with-lat-chunk
+      inputs:
+        parameters:
+          - name: variable
+          - name: ref-zarr
+          - name: train-zarr
+          - name: simulation-zarr
+          - name: out-zarr
+          - name: kind
+          - name: lat-slice-min
+          - name: lat-slice-max
+          - name: first-year
+          - name: last-year
+      outputs:
+        parameters:
+          - name: out-zarr
+            valueFrom:
+              parameter: "{{ tasks.apply-qdm.outputs.parameters.out-zarr }}"
+      dag:
+        tasks:
+          - name: train-qdm
+            template: train-qdm
+            arguments:
+              parameters:
+                - name: variable
+                  value: "{{ inputs.parameters.variable }}"
+                - name: ref-zarr
+                  value: "{{ inputs.parameters.ref-zarr }}"
+                - name: train-zarr
+                  value: "{{ inputs.parameters.train-zarr }}"
+                - name: kind
+                  value: "{{ inputs.parameters.kind }}"
+                - name: lat-slice-min
+                  value: "{{ inputs.parameters.lat-slice-min }}"
+                - name: lat-slice-max
+                  value: "{{ inputs.parameters.lat-slice-max }}"
+          - name: apply-qdm
+            depends: "train-qdm"
+            template: apply-qdm
+            arguments:
+              parameters:
+                - name: variable
+                  value: "{{ inputs.parameters.variable }}"
+                - name: qdm-zarr
+                  value: "{{ tasks.train-qdm.outputs.parameters.out-zarr }}"
+                - name: simulation-zarr
+                  value: "{{ inputs.parameters.simulation-zarr }}"
+                - name: first-year
+                  value: "{{ inputs.parameters.first-year }}"
+                - name: last-year
+                  value: "{{ inputs.parameters.last-year }}"
+                - name: lat-slice-min
+                  value: "{{ inputs.parameters.lat-slice-min }}"
+                - name: lat-slice-max
+                  value: "{{ inputs.parameters.lat-slice-max }}"
+                - name: out-zarr
+                  value: "{{ inputs.parameters.out-zarr }}"
+
+    - name: train-qdm
+      inputs:
+        parameters:
+          - name: variable
+          - name: ref-zarr
+          - name: train-zarr
+          - name: kind
+          - name: lat-slice-min
+          - name: lat-slice-max
+          - name: out-zarr
+            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/qdm_model.zarr"
+      outputs:
+        parameters:
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-zarr }}"
+      script:
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
+        env:
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [ python ]
+        source: |
+          import os
+          import dodola.repository
+          from dodola.core import train_quantiledeltamapping
+
+          kind_map = {"multiplicative": "*", "additive": "+"}
+
+          ref_zarr = "{{ inputs.parameters.ref-zarr }}"
+          train_zarr = "{{ inputs.parameters.train-zarr }}"
+          out_zarr = "{{ inputs.parameters.out-zarr }}"
+          min_slice = int({{ inputs.parameters.lat-slice-min }})
+          max_slice = int({{ inputs.parameters.lat-slice-max }})
+          variable = "{{ inputs.parameters.variable }}"
+          kind = kind_map["{{ inputs.parameters.kind }}"]
+
+          latslice = slice(min_slice, max_slice)
+
+          print(f"reading {ref_zarr}")
+          reference = dodola.repository.read(ref_zarr).isel(lat=latslice)
+          print(f"reading {train_zarr}")
+          training = dodola.repository.read(train_zarr).isel(lat=latslice)
+
+          reference.load()
+          training.load()
+
+          qdm = train_quantiledeltamapping(
+              reference=reference,
+              historical=training,
+              variable=variable,
+              kind=kind,
+          )
+
+          dodola.repository.write(out_zarr, qdm.ds)
+          print(f"Output written to {out_zarr}")  # DEBUG
+        resources:
+          requests:
+            memory: 8Gi
+            cpu: "1000m"
+          limits:
+            memory: 8Gi
+            cpu: "2000m"
+      activeDeadlineSeconds: 900
+      retryStrategy:
+        limit: 1
+        retryPolicy: "Always"
+
+
+    - name: apply-qdm
+      inputs:
+        parameters:
+          - name: variable
+          - name: qdm-zarr
+          - name: simulation-zarr
+          - name: first-year
+          - name: last-year
+          - name: lat-slice-min
+          - name: lat-slice-max
+          - name: out-zarr
+            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/qdm_adjusted.zarr"
+      outputs:
+        parameters:
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-zarr }}"
+      script:
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
+        env:
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [ python ]
+        source: |
+          import dask.delayed
+          import dodola.repository
+          from dodola.core import adjust_quantiledeltamapping_year
+          import xarray as xr
+
+          nonlat_variables = ["lon", "time"]
+
+          qdm_zarr = "{{ inputs.parameters.qdm-zarr }}"
+          simulation_zarr = "{{ inputs.parameters.simulation-zarr }}"
+          out_zarr = "{{ inputs.parameters.out-zarr }}"
+          min_slice = int({{ inputs.parameters.lat-slice-min }})
+          max_slice = int({{ inputs.parameters.lat-slice-max }})
+          first_year = int({{ inputs.parameters.first-year }})
+          last_year = int({{ inputs.parameters.last-year }})
+          variable = "{{ inputs.parameters.variable }}"
+
+          latslice = slice(min_slice, max_slice)
+
+          print(f"slicing({min_slice}, {max_slice})")  # DEBUG
+
+          qdm = dodola.repository.read(qdm_zarr)
+          simulation = dodola.repository.read(simulation_zarr).isel(lat=latslice)
+
+          qdm.load()
+          simulation.load()
+          simulation_delayed = dask.delayed(simulation)
+          qdm_delayed = dask.delayed(qdm)
+
+          qdm_list = []
+          for year in range(first_year, last_year + 1):
+              adj = dask.delayed(adjust_quantiledeltamapping_year)(simulation_delayed, qdm_delayed, year, variable)
+              qdm_list.append(adj)
+
+          out_all_years = dask.delayed(xr.concat)(qdm_list, dim="time")
+          out_all_years = out_all_years.compute()
+
+          print(out_all_years)  # DEBUG
+
+          if nonlat_variables:
+              out_all_years = out_all_years.drop_vars(nonlat_variables)
+
+          out_all_years = out_all_years.transpose("time", "lat", "lon")
+
+          # Output to region of existing zarr store.
+          out_all_years.to_zarr(out_zarr, region={"lat": latslice}, mode="a")
+          print(f"Output written to {out_zarr}")  # DEBUG
+        resources:
+          requests:
+            memory: 32Gi
+            cpu: "1000m"
+          limits:
+            memory: 32Gi
+            cpu: "8000m"
+      activeDeadlineSeconds: 900
+      retryStrategy:
+        limit: 3
         retryPolicy: "Always"
 
 

--- a/workflows/templates/dc6.yaml
+++ b/workflows/templates/dc6.yaml
@@ -42,14 +42,6 @@ spec:
           - name: correct-wetday-frequency
           - name: domainfile1x1
           - name: qdm-kind
-      outputs:
-        parameters:
-          - name: out-zarr-historical
-            valueFrom:
-              parameter: "{{ tasks.biascorrect-historical.outputs.parameters.out-zarr }}"
-          - name: out-zarr-ssps
-            valueFrom:
-              parameter: "{{ tasks.biascorrect-ssps.outputs.parameters }}"
       dag:
         tasks:
           - name: preprocess-historical

--- a/workflows/templates/dc6.yaml
+++ b/workflows/templates/dc6.yaml
@@ -44,15 +44,12 @@ spec:
           - name: qdm-kind
       outputs:
         parameters:
-          - name: out-zarr-qdm-model
-            valueFrom:
-              parameter: "{{ tasks.move-chunks-to-space.outputs.parameters.out-zarr }}"
           - name: out-zarr-historical
             valueFrom:
-              parameter: "{{ tasks.move-chunks-to-space.outputs.parameters.out-zarr }}"
+              parameter: "{{ tasks.biascorrect-historical.outputs.parameters.out-zarr }}"
           - name: out-zarr-ssps
             valueFrom:
-              parameter: "{{ tasks.move-chunks-to-space.outputs.parameters.out-zarr }}"
+              parameter: "{{ tasks.biascorrect-ssps.outputs.parameters }}"
       dag:
         tasks:
           - name: preprocess-historical
@@ -105,57 +102,44 @@ spec:
                 - name: correct-wetday-frequency
                   value: "{{ inputs.parameters.correct-wetday-frequency }}"
             withParam: "{{ inputs.parameters.ssps }}"
-          - name: train-qdm
-            dependencies: [ preprocess-reference, preprocess-training ]
-            template: train-qdm
+          - name: biascorrect-historical
+            dependencies: [ preprocess-reference, preprocess-training, preprocess-historical ]
+            template: biascorrect-qdm
             arguments:
               parameters:
                 - name: variable
                   value: "{{ inputs.parameters.variable-id }}"
                 - name: ref-zarr
                   value: "{{ tasks.preprocess-reference.outputs.parameters.out-zarr }}"
-                - name: hist-zarr
+                - name: train-zarr
                   value: "{{ tasks.preprocess-training.outputs.parameters.out-zarr }}"
+                - name: simulation-zarr
+                  value: "{{ tasks.preprocess-historical.outputs.parameters.out-zarr }}"
                 - name: kind
                   value: "{{ inputs.parameters.qdm-kind }}"
-          - name: biascorrect-historical
-            dependencies: [ train-qdm, preprocess-historical ]
-            template: apply-qdm
-            arguments:
-              parameters:
-                - name: variable
-                  value: "{{ inputs.parameters.variable-id }}"
-                - name: future-zarr
-                  value: "{{ tasks.preprocess-historical.outputs.parameters.out-zarr }}"
-                - name: qdm-model
-                  value: "{{ tasks.train-qdm.outputs.parameters.out-zarr }}"
-                - name: firstyear
+                - name: first-year
                   value: 1950
-                - name: lastyear
+                - name: last-year
                   value: 2014
-                - name: out-zarr
-                  value: "az://scratch/{{ workflow.name }}/biascorrected-historical.zarr"
-                - name: out-key
-                  value: "historical-{{ inputs.parameters.variable-id }}-qdm-years"
           - name: biascorrect-ssps
-            dependencies: [ train-qdm, preprocess-ssps]
-            template: apply-qdm
+            dependencies: [ preprocess-reference, preprocess-training, preprocess-ssps]
+            template: biascorrect-qdm
             arguments:
               parameters:
                 - name: variable
                   value: "{{ inputs.parameters.variable-id }}"
-                - name: future-zarr
+                - name: ref-zarr
+                  value: "{{ tasks.preprocess-reference.outputs.parameters.out-zarr }}"
+                - name: train-zarr
+                  value: "{{ tasks.preprocess-training.outputs.parameters.out-zarr }}"
+                - name: simulation-zarr
                   value: "{{ item.out-zarr }}"
-                - name: qdm-model
-                  value: "{{ tasks.train-qdm.outputs.parameters.out-zarr }}"
-                - name: firstyear
+                - name: kind
+                  value: "{{ inputs.parameters.qdm-kind }}"
+                - name: first-year
                   value: 2015
-                - name: lastyear
+                - name: last-year
                   value: 2100
-                - name: out-zarr
-                  value: "az://scratch/{{ workflow.name }}/biascorrected-{{=sprig.randAlphaNum(7)}}.zarr"
-                - name: out-key
-                  value: "{{=sprig.randAlphaNum(7)}}-{{ inputs.parameters.variable-id }}-qdm-years"
             withParam: "{{ tasks.preprocess-ssps.outputs.parameters }}"
 
 
@@ -336,179 +320,74 @@ spec:
         retryPolicy: "Always"
 
 
-    - name: apply-qdm
-      inputs:
-        parameters:
-          - name: variable
-          - name: future-zarr
-          - name: qdm-model
-          - name: firstyear
-          - name: lastyear
-          - name: out-zarr
-          - name: out-key
-            value: "qdm-years"
-      outputs:
-        parameters:
-          - name: out-zarr
-            valueFrom:
-              parameter: "{{ tasks.netcdfs2zarr.outputs.parameters.out-zarr }}"
-      dag:
-        tasks:
-          - name: qdm-adjust-year
-            template: qdm-adjust-year
-            arguments:
-              parameters:
-                - name: future-zarr
-                  value: "{{ inputs.parameters.future-zarr }}"
-                - name: variable
-                  value: "{{ inputs.parameters.variable }}"
-                - name: year
-                  value: "{{ item }}"
-                - name: qdm-model-zarr
-                  value: "{{ inputs.parameters.qdm-model }}"
-                - name: out-key
-                  value: "{{ workflow.name }}/{{ inputs.parameters.out-key }}/{{ item }}.nc"
-            withSequence:
-              start: "{{ inputs.parameters.firstyear }}"
-              end: "{{ inputs.parameters.lastyear }}"
-          - name: netcdfs2zarr
-            dependencies: [ qdm-adjust-year ]
-            template: netcdfs2zarr
-            arguments:
-              parameters:
-                - name: in-dir
-                  value: "scratch/{{ workflow.name }}/{{ inputs.parameters.out-key }}/"
-                - name: out-zarr
-                  value: "{{ inputs.parameters.out-zarr }}"
-
-
-    - name: train-qdm
+    - name: biascorrect-qdm
       inputs:
         parameters:
           - name: variable
           - name: ref-zarr
-          - name: hist-zarr
-          - name: out-zarr
-            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/out.zarr"
+          - name: train-zarr
+          - name: simulation-zarr
           - name: kind
+          - name: first-year
+          - name: last-year
       outputs:
         parameters:
           - name: out-zarr
-            value: "{{ inputs.parameters.out-zarr }}"
-      container:
-        image: downscalecmip6.azurecr.io/dodola:0.5.0
-        env:
-          - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
-              secretKeyRef:
-                name: workerstoragecreds-secret
-                key: azurestorageaccount
-          - name: AZURE_STORAGE_ACCOUNT_KEY
-            valueFrom:
-              secretKeyRef:
-                name: workerstoragecreds-secret
-                key: azurestoragekey
-        command: [ "dodola" ]
-        args:
-          - "train-qdm"
-          - "--historical"
-          - "{{ inputs.parameters.hist-zarr }}"
-          - "--reference"
-          - "{{ inputs.parameters.ref-zarr }}"
-          - "--out"
-          - "{{ inputs.parameters.out-zarr }}"
-          - "--variable"
-          - "{{ inputs.parameters.variable }}"
-          - "--kind"
-          - "{{ inputs.parameters.kind }}"
-        resources:
-          requests:
-            memory: 48Gi
-            cpu: "2000m"
-          limits:
-            memory: 48Gi
-            cpu: "2500m"
-        volumeMounts:
-          - name: out
-            mountPath: /mnt/out
-      volumes:
-        - name: out
-          emptyDir: { }
-      activeDeadlineSeconds: 172800
-      retryStrategy:
-        limit: 4
-        retryPolicy: "Always"
+              parameter: "{{ tasks.prime-output-zarrstore.outputs.parameters.out-zarr }}"
+      dag:
+        tasks:
+          - name: prime-output-zarrstore
+            template: prime-output-zarrstore
+            arguments:
+              parameters:
+                - name: variable
+                  value: "{{ inputs.parameters.variable }}"
+                - name: simulation-zarr
+                  value: "{{ inputs.parameters.simulation-zarr }}"
+                - name: first-year
+                  value: "{{ inputs.parameters.first-year }}"
+                - name: last-year
+                  value: "{{ inputs.parameters.last-year }}"
+          - name: with-lat-chunk
+            depends: "prime-output-zarrstore"
+            template: with-lat-chunk
+            arguments:
+              parameters:
+                - name: variable
+                  value: "{{ inputs.parameters.variable }}"
+                - name: ref-zarr
+                  value: "{{ inputs.parameters.ref-zarr }}"
+                - name: train-zarr
+                  value: "{{ inputs.parameters.train-zarr }}"
+                - name: simulation-zarr
+                  value: "{{ inputs.parameters.simulation-zarr }}"
+                - name: first-year
+                  value: "{{ inputs.parameters.first-year }}"
+                - name: last-year
+                  value: "{{ inputs.parameters.last-year }}"
+                - name: kind
+                  value: "{{ inputs.parameters.kind }}"
+                - name: lat-slice-min
+                  value: "{{=asInt(item) * 10 }}"
+                - name: lat-slice-max
+                  value: "{{=asInt(item) * 10 + 10 }}"
+                - name: out-zarr
+                  value: "{{ tasks.prime-output-zarrstore.outputs.parameters.out-zarr }}"
+            withSequence:
+              start: "0"
+              end: "17"
 
 
-    - name: qdm-adjust-year
+    - name: prime-output-zarrstore
       inputs:
         parameters:
-          - name: future-zarr
-          - name: year
-          - name: qdm-model-zarr
           - name: variable
-          - name: out-key
-            value: "{{ workflow.name }}/qdm-years/{{ inputs.parameters.year }}.nc"
-      outputs:
-        artifacts:
-          - name: adjusted
-            path: "/mnt/out/{{ inputs.parameters.year }}.nc"
-            archive:
-              none: { }
-            s3:
-              key: "{{ inputs.parameters.out-key }}"
-      container:
-        image: downscalecmip6.azurecr.io/dodola:0.5.0
-        env:
-          - name: AZURE_STORAGE_ACCOUNT_NAME
-            valueFrom:
-              secretKeyRef:
-                name: workerstoragecreds-secret
-                key: azurestorageaccount
-          - name: AZURE_STORAGE_ACCOUNT_KEY
-            valueFrom:
-              secretKeyRef:
-                name: workerstoragecreds-secret
-                key: azurestoragekey
-        command: [ dodola ]
-        args:
-          - "apply-qdm"
-          - "--simulation"
-          - "{{ inputs.parameters.future-zarr }}"
-          - "--out"
-          - "/mnt/out/{{ inputs.parameters.year }}.nc"
-          - "--year"
-          - "{{ inputs.parameters.year }}"
-          - "--variable"
-          - "{{ inputs.parameters.variable }}"
-          - "--qdm"
-          - "{{ inputs.parameters.qdm-model-zarr }}"
-        resources:
-          requests:
-            memory: 42Gi
-            cpu: "2000m"
-          limits:
-            memory: 42Gi
-            cpu: "2000m"
-        # emptyDir volume as k8sapi can't output to base image layer:
-        volumeMounts:
-          - name: out
-            mountPath: /mnt/out
-      volumes:
-        - name: out
-          emptyDir: { }
-      activeDeadlineSeconds: 3600
-      retryStrategy:
-        limit: 4
-        retryPolicy: "Always"
-
-
-    - name: netcdfs2zarr
-      inputs:
-        parameters:
-          - name: in-dir  # DIR with container containing all the nc files. No az://!
+          - name: simulation-zarr
+          - name: first-year
+          - name: last-year
           - name: out-zarr
-            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/out.zarr"
+            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/qdm_adjusted.zarr"
       outputs:
         parameters:
           - name: out-zarr
@@ -516,10 +395,6 @@ spec:
       script:
         image: downscalecmip6.azurecr.io/dodola:0.5.0
         env:
-          - name: IN
-            value: "{{ inputs.parameters.in-dir }}"
-          - name: OUT
-            value: "{{ inputs.parameters.out-zarr }}"
           - name: AZURE_STORAGE_ACCOUNT_NAME
             valueFrom:
               secretKeyRef:
@@ -532,43 +407,273 @@ spec:
                 key: azurestoragekey
         command: [ python ]
         source: |
-          # Real workflow begins here:
-          import os
-          import numpy as np
+          import dodola.repository
           import xarray as xr
-          from adlfs import AzureBlobFileSystem
 
+          nonlat_variables = ["lon", "time"]
 
-          fs = AzureBlobFileSystem()
-          # Grab dir of yearly NetCDFs, read into single remote Zarr.
-          local_stash = "/mnt/in/"
-          fs.get(rpath=os.environ.get("IN"), lpath=local_stash, recursive=True)
+          simulation_zarr = "{{ inputs.parameters.simulation-zarr }}"
+          out_zarr = "{{ inputs.parameters.out-zarr }}"
+          first_year = int({{ inputs.parameters.first-year }})
+          last_year = int({{ inputs.parameters.last-year }})
+          variable = "{{ inputs.parameters.variable }}"
 
-          d = xr.open_mfdataset(
-              f"{local_stash}*.nc",
-              concat_dim="time"
+          timeslice = slice(str(first_year), str(last_year + 1))
+
+          primed_out = dodola.repository.read(simulation_zarr).sel(time=timeslice).chunk({"time": -1, "lat": 10, "lon":-1})
+
+          print(primed_out)  # DEBUG
+
+          primed_out.to_zarr(
+            out_zarr,
+            mode="w",
+            compute=False,
+            consolidated=True,
           )
-          d.to_zarr(
-              os.environ.get("OUT"),
-              mode="w",
-              compute=True
-          )
+          print(f"Output written to {out_zarr}")  # DEBUG
+
+          # Append variables that do not depend on "lat"
+          if nonlat_variables:
+              primed_out[nonlat_variables].to_zarr(
+                  out_zarr,
+                  mode="a",
+                  compute=True,
+                  consolidated=True
+              )
         resources:
           requests:
-            memory: 42Gi
+            memory: 4Gi
             cpu: "1000m"
           limits:
-            memory: 42Gi
-            cpu: "8000m"
-        volumeMounts:
-          - name: in
-            mountPath: /mnt/in
-      volumes:
-        - name: in
-          emptyDir: { }
-      activeDeadlineSeconds: 480
+            memory: 4Gi
+            cpu: "1000m"
+      activeDeadlineSeconds: 900
       retryStrategy:
         limit: 4
+        retryPolicy: "Always"
+
+
+    - name: with-lat-chunk
+      inputs:
+        parameters:
+          - name: variable
+          - name: ref-zarr
+          - name: train-zarr
+          - name: simulation-zarr
+          - name: out-zarr
+          - name: kind
+          - name: lat-slice-min
+          - name: lat-slice-max
+          - name: first-year
+          - name: last-year
+      outputs:
+        parameters:
+          - name: out-zarr
+            valueFrom:
+              parameter: "{{ tasks.apply-qdm.outputs.parameters.out-zarr }}"
+      dag:
+        tasks:
+          - name: train-qdm
+            template: train-qdm
+            arguments:
+              parameters:
+                - name: variable
+                  value: "{{ inputs.parameters.variable }}"
+                - name: ref-zarr
+                  value: "{{ inputs.parameters.ref-zarr }}"
+                - name: train-zarr
+                  value: "{{ inputs.parameters.train-zarr }}"
+                - name: kind
+                  value: "{{ inputs.parameters.kind }}"
+                - name: lat-slice-min
+                  value: "{{ inputs.parameters.lat-slice-min }}"
+                - name: lat-slice-max
+                  value: "{{ inputs.parameters.lat-slice-max }}"
+          - name: apply-qdm
+            depends: "train-qdm"
+            template: apply-qdm
+            arguments:
+              parameters:
+                - name: variable
+                  value: "{{ inputs.parameters.variable }}"
+                - name: qdm-zarr
+                  value: "{{ tasks.train-qdm.outputs.parameters.out-zarr }}"
+                - name: simulation-zarr
+                  value: "{{ inputs.parameters.simulation-zarr }}"
+                - name: first-year
+                  value: "{{ inputs.parameters.first-year }}"
+                - name: last-year
+                  value: "{{ inputs.parameters.last-year }}"
+                - name: lat-slice-min
+                  value: "{{ inputs.parameters.lat-slice-min }}"
+                - name: lat-slice-max
+                  value: "{{ inputs.parameters.lat-slice-max }}"
+                - name: out-zarr
+                  value: "{{ inputs.parameters.out-zarr }}"
+
+    - name: train-qdm
+      inputs:
+        parameters:
+          - name: variable
+          - name: ref-zarr
+          - name: train-zarr
+          - name: kind
+          - name: lat-slice-min
+          - name: lat-slice-max
+          - name: out-zarr
+            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/qdm_model.zarr"
+      outputs:
+        parameters:
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-zarr }}"
+      script:
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
+        env:
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [ python ]
+        source: |
+          import os
+          import dodola.repository
+          from dodola.core import train_quantiledeltamapping
+
+          kind_map = {"multiplicative": "*", "additive": "+"}
+
+          ref_zarr = "{{ inputs.parameters.ref-zarr }}"
+          train_zarr = "{{ inputs.parameters.train-zarr }}"
+          out_zarr = "{{ inputs.parameters.out-zarr }}"
+          min_slice = int({{ inputs.parameters.lat-slice-min }})
+          max_slice = int({{ inputs.parameters.lat-slice-max }})
+          variable = "{{ inputs.parameters.variable }}"
+          kind = kind_map["{{ inputs.parameters.kind }}"]
+
+          latslice = slice(min_slice, max_slice)
+
+          print(f"reading {ref_zarr}")
+          reference = dodola.repository.read(ref_zarr).isel(lat=latslice)
+          print(f"reading {train_zarr}")
+          training = dodola.repository.read(train_zarr).isel(lat=latslice)
+
+          reference.load()
+          training.load()
+
+          qdm = train_quantiledeltamapping(
+              reference=reference,
+              historical=training,
+              variable=variable,
+              kind=kind,
+          )
+
+          dodola.repository.write(out_zarr, qdm.ds)
+          print(f"Output written to {out_zarr}")  # DEBUG
+        resources:
+          requests:
+            memory: 8Gi
+            cpu: "1000m"
+          limits:
+            memory: 8Gi
+            cpu: "2000m"
+      activeDeadlineSeconds: 900
+      retryStrategy:
+        limit: 1
+        retryPolicy: "Always"
+
+
+    - name: apply-qdm
+      inputs:
+        parameters:
+          - name: variable
+          - name: qdm-zarr
+          - name: simulation-zarr
+          - name: first-year
+          - name: last-year
+          - name: lat-slice-min
+          - name: lat-slice-max
+          - name: out-zarr
+            value: "az://scratch/{{ workflow.name }}/{{ pod.name }}/qdm_adjusted.zarr"
+      outputs:
+        parameters:
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-zarr }}"
+      script:
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
+        env:
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [ python ]
+        source: |
+          import dask.delayed
+          import dodola.repository
+          from dodola.core import adjust_quantiledeltamapping_year
+          import xarray as xr
+
+          nonlat_variables = ["lon", "time"]
+
+          qdm_zarr = "{{ inputs.parameters.qdm-zarr }}"
+          simulation_zarr = "{{ inputs.parameters.simulation-zarr }}"
+          out_zarr = "{{ inputs.parameters.out-zarr }}"
+          min_slice = int({{ inputs.parameters.lat-slice-min }})
+          max_slice = int({{ inputs.parameters.lat-slice-max }})
+          first_year = int({{ inputs.parameters.first-year }})
+          last_year = int({{ inputs.parameters.last-year }})
+          variable = "{{ inputs.parameters.variable }}"
+
+          latslice = slice(min_slice, max_slice)
+
+          print(f"slicing({min_slice}, {max_slice})")  # DEBUG
+
+          qdm = dodola.repository.read(qdm_zarr)
+          simulation = dodola.repository.read(simulation_zarr).isel(lat=latslice)
+
+          qdm.load()
+          simulation.load()
+          simulation_delayed = dask.delayed(simulation)
+          qdm_delayed = dask.delayed(qdm)
+
+          qdm_list = []
+          for year in range(first_year, last_year + 1):
+              adj = dask.delayed(adjust_quantiledeltamapping_year)(simulation_delayed, qdm_delayed, year, variable)
+              qdm_list.append(adj)
+
+          out_all_years = dask.delayed(xr.concat)(qdm_list, dim="time")
+          out_all_years = out_all_years.compute()
+
+          print(out_all_years)  # DEBUG
+
+          if nonlat_variables:
+              out_all_years = out_all_years.drop_vars(nonlat_variables)
+
+          out_all_years = out_all_years.transpose("time", "lat", "lon")
+
+          # Output to region of existing zarr store.
+          out_all_years.to_zarr(out_zarr, region={"lat": latslice}, mode="a")
+          print(f"Output written to {out_zarr}")  # DEBUG
+        resources:
+          requests:
+            memory: 32Gi
+            cpu: "1000m"
+          limits:
+            memory: 32Gi
+            cpu: "8000m"
+      activeDeadlineSeconds: 900
+      retryStrategy:
+        limit: 3
         retryPolicy: "Always"
 
 


### PR DESCRIPTION
This PR improves workflow QDM bias correction efficiency and walltime by orders of magnitude. In short, it operates on chunks along small latitudinal bands rather than year-to-year.

The change is applied to the legacy dc6 workflow as well as the newer WorkflowTemplate.

This PR also updates the legacy workflow default parameters to fit with the time window required by #99.