### PR TITLE
Fix pod evictions due to memory pressure

### DIFF
--- a/infrastructure/terraform/modules/aks_cluster/main.tf
+++ b/infrastructure/terraform/modules/aks_cluster/main.tf
@@ -95,7 +95,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "nodepoolworker" {
   node_count            = 0
   enable_auto_scaling   = true
   min_count             = 0
-  max_count             = 20
+  max_count             = 15
   priority              = "Spot"
   spot_max_price        = -1
   eviction_policy       = "Delete"


### PR DESCRIPTION
Reducing the worker node max count should allow the core node pool to scale more freely without bumping its head on Azure regional CPU quotas.
