### PR TITLE
Bump AKS k8s cluster version

### DIFF
--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -14,7 +14,7 @@ variable "k8scluster_name" {
 }
 
 variable "kubernetes_version" {
-  default     = "1.19.7"
+  default     = "1.19.9"
   description = "The Kubernetes version to use in AKS"
 }
 


### PR DESCRIPTION
This PR increases the version of the AKS Kubernetes version in Terraform so that we have improved support and responsiveness.