### PR TITLE
Temporarily delete working nodepool for upgrade

### DIFF
--- a/infrastructure/terraform/modules/aks_cluster/main.tf
+++ b/infrastructure/terraform/modules/aks_cluster/main.tf
@@ -87,32 +87,32 @@ resource "azurerm_kubernetes_cluster" "k8scluster" {
   }
 }
 
-resource "azurerm_kubernetes_cluster_node_pool" "nodepoolworker" {
-  name                  = "worker"
-  kubernetes_cluster_id = azurerm_kubernetes_cluster.k8scluster.id
-  orchestrator_version  = var.kubernetes_version
-  vm_size               = "Standard_E8as_v4"
-  node_count            = 0
-  enable_auto_scaling   = true
-  min_count             = 0
-  max_count             = 15
-  priority              = "Spot"
-  spot_max_price        = -1
-  eviction_policy       = "Delete"
-  node_labels = {
-    "kubernetes.azure.com/scalesetpriority" = "spot"
-    "dedicated"                             = "worker"
-  }
-  node_taints = [
-    "dedicated=worker:NoSchedule",
-    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule"
-  ]
-  tags = {
-    managed-by = "terraform"
-  }
-  lifecycle {
-    ignore_changes = [
-      node_count
-    ]
-  }
-}
+# resource "azurerm_kubernetes_cluster_node_pool" "nodepoolworker" {
+#   name                  = "worker"
+#   kubernetes_cluster_id = azurerm_kubernetes_cluster.k8scluster.id
+#   orchestrator_version  = var.kubernetes_version
+#   vm_size               = "Standard_E8as_v4"
+#   node_count            = 0
+#   enable_auto_scaling   = true
+#   min_count             = 0
+#   max_count             = 15
+#   priority              = "Spot"
+#   spot_max_price        = -1
+#   eviction_policy       = "Delete"
+#   node_labels = {
+#     "kubernetes.azure.com/scalesetpriority" = "spot"
+#     "dedicated"                             = "worker"
+#   }
+#   node_taints = [
+#     "dedicated=worker:NoSchedule",
+#     "kubernetes.azure.com/scalesetpriority=spot:NoSchedule"
+#   ]
+#   tags = {
+#     managed-by = "terraform"
+#   }
+#   lifecycle {
+#     ignore_changes = [
+#       node_count
+#     ]
+#   }
+# }


### PR DESCRIPTION
Temporarily deleting working node pool while upgrading the code Kubernetes cluster version. We're doing this because AKS does not allow upgrading spot node pools. It's easier to delete the node pool and then reprovision it once the upgrade is complete.
