### PR TITLE
Bump ingress-nginx chart to 4.0.1

### DIFF
--- a/infrastructure/kubernetes/ingress-nginx/Chart.yaml
+++ b/infrastructure/kubernetes/ingress-nginx/Chart.yaml
@@ -16,5 +16,5 @@ appVersion: "0.0.1"
 
 dependencies:
   - name: ingress-nginx
-    version: "3.34.0"
+    version: "4.0.1"
     repository: 'https://kubernetes.github.io/ingress-nginx'


### PR DESCRIPTION
Bump ingress-nginx chart to 4.0.1 (app version >= v1.0.0).