### PR TITLE
Workaround x509 cert signed by unknown authority from argo-server

### DIFF
--- a/infrastructure/kubernetes/argo/kustomization.yaml
+++ b/infrastructure/kubernetes/argo/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/argoproj/argo-workflows/releases/download/v3.1.9/install.yaml
+  - https://github.com/argoproj/argo-workflows/releases/download/v3.1.8/install.yaml
   - sso-secrets
   - argo-server-ingress.yaml
 


### PR DESCRIPTION
Downgrade from Argo Workflows v3.1.9 to v3.1.8 to work around "x509: certificate signed by unknown authority" warning from argo-server TLS new certificate.

Related to https://github.com/argoproj/argo-workflows/pull/6566?