### PR TITLE
Add workflow template to transfer Zarr Stores between cloud storage

### DIFF
--- a/workflows/templates/kustomization.yaml
+++ b/workflows/templates/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - distributed-regrid.yaml
   - download-cmip6.yaml
   - downscale.yaml
+  - zarr-transfer.yaml

--- a/workflows/templates/zarr-transfer.yaml
+++ b/workflows/templates/zarr-transfer.yaml
@@ -1,0 +1,78 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: zarr-transfer
+  annotations:
+    workflows.argoproj.io/description: >-
+      Transfers a Zarr Store between cloud storage.
+
+      Zarr Store locations are specified with fsspec-style URLs.
+    workflows.argoproj.io/tags: zarr,gcp,az
+    workflows.argoproj.io/version: '>= 3.1.0'
+  labels:
+    component: utils
+spec:
+  entrypoint: zarr-transfer
+  arguments:
+    parameters:
+      - name: from-zarr
+        value: "az://some/path/to/store.zarr"
+      - name: to-zarr
+        value: "gs://impactlab-data-scratch/new/path/to/store.zarr"
+  templates:
+
+    - name: zarr-transfer
+      inputs:
+        parameters:
+          - name: from-zarr
+          - name: to-zarr
+      volumes:
+        - name: gcpkey
+          secret:
+            secretName: gcp-cil-scratch-sa
+      script:
+        image: downscalecmip6.azurecr.io/dodola:0.5.0
+        volumeMounts:
+          - name: gcpkey
+            mountPath: "/mnt/gcp-sa"
+            readOnly: true
+        env:
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: "/mnt/gcp-sa/key.json"
+        command: [ python ]
+        source: |
+          import dodola.repository
+
+          from_zarr = "{{ inputs.parameters.from-zarr}}"
+          to_zarr = "{{ inputs.parameters.to-zarr }}"
+
+          print(f"Transferring {from_zarr} to {to_zarr}...")
+
+          ds = dodola.repository.read(from_zarr)
+          dodola.repository.write(to_zarr, ds)
+
+          print("Done")  # DEBUG
+        resources:
+          requests:
+            memory: 48Gi
+            cpu: "100m"
+          limits:
+            memory: 48Gi
+            cpu: "12000m"
+      activeDeadlineSeconds: 3600
+      retryStrategy:
+        limit: 2
+        retryPolicy: "Always"
+        backoff:
+          duration: 30s
+          factor: 2


### PR DESCRIPTION
Adds a reusable workflow template to transfer Zarr Stores between cloud storage. Takes `fsspec`-style URLs as input.

Right now the workflow can move things around the DC6 storage account and into the CIL scratch bucket on GCP. The GCP service account and keys were created and manually placed into amaterasu as Secrets.

The workflow uses `xarray` to transfer Zarr Stores. Unfortunately, this means that Zarr data is currently read into memory before it is written, so it can only transfer files that fit within its memory allocation. This might be a problem for larger stores.
