### PR TITLE
add parameter files for tasmax model runs

### DIFF
--- a/workflows/parameters/AWI-CM-1-1-MR-tasmax.yaml
+++ b/workflows/parameters/AWI-CM-1-1-MR-tasmax.yaml
@@ -1,0 +1,13 @@
+variable-id: "tasmax"
+source-id: "AWI-CM-1-1-MR"
+historical: |
+  [
+    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "AWI-CM-1-1-MR", "institution-id": "AWI", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20181218" }
+  ]
+ssps: |
+  [
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "AWI-CM-1-1-MR", "institution-id": "AWI", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190529" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "AWI-CM-1-1-MR", "institution-id": "AWI", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190529" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "AWI-CM-1-1-MR", "institution-id": "AWI", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190529" }
+  ]
+

--- a/workflows/parameters/BCC-CSM2-MR-tasmax.yaml
+++ b/workflows/parameters/BCC-CSM2-MR-tasmax.yaml
@@ -8,6 +8,6 @@ ssps: |
   [
     { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "BCC-CSM2-MR", "institution-id": "BCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190318" },
     { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "BCC-CSM2-MR", "institution-id": "BCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190318" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "BCC-CSM2-MR", "institution-id": "BCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190318" }
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "BCC-CSM2-MR", "institution-id": "BCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190315" }
   ]
 

--- a/workflows/parameters/BCC-CSM2-MR-tasmax.yaml
+++ b/workflows/parameters/BCC-CSM2-MR-tasmax.yaml
@@ -1,0 +1,13 @@
+variable-id: "tasmax"
+source-id: "BCC-CSM2-MR"
+historical: |
+  [
+    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "BCC-CSM2-MR", "institution-id": "BCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20181126" }
+  ]
+ssps: |
+  [
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "BCC-CSM2-MR", "institution-id": "BCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190318" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "BCC-CSM2-MR", "institution-id": "BCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190318" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "BCC-CSM2-MR", "institution-id": "BCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190318" }
+  ]
+

--- a/workflows/parameters/CNRM-CM6-1-tasmax.yaml
+++ b/workflows/parameters/CNRM-CM6-1-tasmax.yaml
@@ -1,0 +1,13 @@
+variable-id: "tasmax"
+source-id: "CNRM-CM6-1"
+historical: |
+  [
+    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "CNRM-CM6-1", "institution-id": "CNRM-CERFACS", "member-id": "r1i1p1f2", "grid-label": "gr", "version": "20180917" }
+  ]
+ssps: |
+  [
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "CNRM-CM6-1", "institution-id": "CNRM-CERFACS", "member-id": "r1i1p1f2", "grid-label": "gr", "version": "20190219" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "CNRM-CM6-1", "institution-id": "CNRM-CERFACS", "member-id": "r1i1p1f2", "grid-label": "gr", "version": "20190219" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "CNRM-CM6-1", "institution-id": "CNRM-CERFACS", "member-id": "r1i1p1f2", "grid-label": "gr", "version": "20190219" }
+  ]
+

--- a/workflows/parameters/CanESM5-tasmax.yaml
+++ b/workflows/parameters/CanESM5-tasmax.yaml
@@ -1,0 +1,12 @@
+variable-id: "tasmax"
+source-id: "CanESM5"
+historical: |
+  [
+    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "CanESM5", "institution-id": "CCCma", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190429" }
+  ]
+ssps: |
+  [
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "CanESM5", "institution-id": "CCCma", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190429" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "CanESM5", "institution-id": "CCCma", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190429" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "CanESM5", "institution-id": "CCCma", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190429" }
+  ]

--- a/workflows/parameters/EC-Earth3-tasmax.yaml
+++ b/workflows/parameters/EC-Earth3-tasmax.yaml
@@ -1,0 +1,12 @@
+variable-id: "tasmax"
+source-id: "EC-Earth3"
+historical: |
+  [
+    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "EC-Earth3", "institution-id": "EC-Earth-Consortium", "member-id": "r1i1p1f1", "grid-label": "gr", "version": "20200310" }
+  ]
+ssps: |
+  [
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "EC-Earth3", "institution-id": "EC-Earth-Consortium", "member-id": "r1i1p1f1", "grid-label": "gr", "version": "20200310" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "EC-Earth3", "institution-id": "EC-Earth-Consortium", "member-id": "r1i1p1f1", "grid-label": "gr", "version": "20200310" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "EC-Earth3", "institution-id": "EC-Earth-Consortium", "member-id": "r1i1p1f1", "grid-label": "gr", "version": "20200310" }
+  ]

--- a/workflows/parameters/FGOALS-g3-tasmax.yaml
+++ b/workflows/parameters/FGOALS-g3-tasmax.yaml
@@ -1,0 +1,12 @@
+variable-id: "tasmax"
+source-id: "FGOALS-g3"
+historical: |
+  [
+    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "FGOALS-g3", "institution-id": "CAS", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190826" }
+  ]
+ssps: |
+  [
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "FGOALS-g3", "institution-id": "CAS", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190820" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "FGOALS-g3", "institution-id": "CAS", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190820" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "FGOALS-g3", "institution-id": "CAS", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190820" }
+  ]

--- a/workflows/parameters/FGOALS-g3-tasmax.yaml
+++ b/workflows/parameters/FGOALS-g3-tasmax.yaml
@@ -7,6 +7,6 @@ historical: |
 ssps: |
   [
     { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "FGOALS-g3", "institution-id": "CAS", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190820" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "FGOALS-g3", "institution-id": "CAS", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190820" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "FGOALS-g3", "institution-id": "CAS", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190820" }
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "FGOALS-g3", "institution-id": "CAS", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190818" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "FGOALS-g3", "institution-id": "CAS", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190818" }
   ]

--- a/workflows/parameters/INM-CM5-0-tasmax.yaml
+++ b/workflows/parameters/INM-CM5-0-tasmax.yaml
@@ -7,6 +7,6 @@ historical: |
 ssps: |
   [
     { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "INM-CM5-0", "institution-id": "INM", "member-id": "r1i1p1f1", "grid-label": "gr1", "version": "20190618" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "INM-CM5-0", "institution-id": "INM", "member-id": "r1i1p1f1", "grid-label": "gr1", "version": "20190618" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "INM-CM5-0", "institution-id": "INM", "member-id": "r1i1p1f1", "grid-label": "gr1", "version": "20190618" }
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "INM-CM5-0", "institution-id": "INM", "member-id": "r1i1p1f1", "grid-label": "gr1", "version": "20190619" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "INM-CM5-0", "institution-id": "INM", "member-id": "r1i1p1f1", "grid-label": "gr1", "version": "20190619" }
   ]

--- a/workflows/parameters/INM-CM5-0-tasmax.yaml
+++ b/workflows/parameters/INM-CM5-0-tasmax.yaml
@@ -1,0 +1,12 @@
+variable-id: "tasmax"
+source-id: "INM-CM5-0"
+historical: |
+  [
+    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "INM-CM5-0", "institution-id": "INM", "member-id": "r1i1p1f1", "grid-label": "gr1", "version": "20190610" }
+  ]
+ssps: |
+  [
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "INM-CM5-0", "institution-id": "INM", "member-id": "r1i1p1f1", "grid-label": "gr1", "version": "20190618" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "INM-CM5-0", "institution-id": "INM", "member-id": "r1i1p1f1", "grid-label": "gr1", "version": "20190618" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "INM-CM5-0", "institution-id": "INM", "member-id": "r1i1p1f1", "grid-label": "gr1", "version": "20190618" }
+  ]

--- a/workflows/parameters/KACE-1-0-G-tasmax.yaml
+++ b/workflows/parameters/KACE-1-0-G-tasmax.yaml
@@ -1,0 +1,13 @@
+variable-id: "tasmax"
+source-id: "KACE-1-0-G"
+historical: |
+  [
+    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "KACE-1-0-G", "institution-id": "NIMS-KMA", "member-id": "r1i1p1f1", "grid-label": "gr", "version": "20200316" }
+  ]
+ssps: |
+  [
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "KACE-1-0-G", "institution-id": "NIMS-KMA", "member-id": "r1i1p1f1", "grid-label": "gr", "version": "20200317" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "KACE-1-0-G", "institution-id": "NIMS-KMA", "member-id": "r1i1p1f1", "grid-label": "gr", "version": "20200317" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "KACE-1-0-G", "institution-id": "NIMS-KMA", "member-id": "r1i1p1f1", "grid-label": "gr", "version": "20200317" }
+  ]
+

--- a/workflows/parameters/MIROC6-tasmax.yaml
+++ b/workflows/parameters/MIROC6-tasmax.yaml
@@ -1,0 +1,12 @@
+variable-id: "tasmax"
+source-id: "MIROC6"
+historical: |
+  [
+    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "MIROC6", "institution-id": "MIROC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20191016" }
+  ]
+ssps: |
+  [
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "MIROC6", "institution-id": "MIROC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20191016" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "MIROC6", "institution-id": "MIROC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20191016" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "MIROC6", "institution-id": "MIROC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20191016" }
+  ]

--- a/workflows/parameters/NorESM2-LM-tasmax.yaml
+++ b/workflows/parameters/NorESM2-LM-tasmax.yaml
@@ -1,0 +1,13 @@
+variable-id: "tasmax"
+source-id: "NorESM2-LM"
+historical: |
+  [
+    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "NorESM2-LM", "institution-id": "NCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190815" }
+  ]
+ssps: |
+  [
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "NorESM2-LM", "institution-id": "NCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20191108" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "NorESM2-LM", "institution-id": "NCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20191108" },
+    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "NorESM2-LM", "institution-id": "NCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20191108" }
+  ]
+


### PR DESCRIPTION
 This PR adds .yaml files for running `tasmax` for the following models: AWI-CM-1-1-MR, BCC-CSM2-MR, CNRM-CM6-1, CanESM5, EC-Earth3, FOALS-g3, INM-CM5-0, KACE-1-0-G, MIROC6, NorESM2-LM. 