### PR TITLE
Add back fleshed-out storage containers

### DIFF
--- a/infrastructure/terraform/modules/storage_account/main.tf
+++ b/infrastructure/terraform/modules/storage_account/main.tf
@@ -30,6 +30,7 @@ resource "azurerm_storage_account" "storageacc" {
   }
 }
 
+
 resource "azurerm_storage_data_lake_gen2_filesystem" "raw" {
   name               = "raw"
   storage_account_id = azurerm_storage_account.storageacc.id
@@ -38,8 +39,41 @@ resource "azurerm_storage_data_lake_gen2_filesystem" "raw" {
   }
 }
 
+resource "azurerm_storage_data_lake_gen2_filesystem" "raw-cmip6" {
+  name               = "raw"
+  storage_account_id = azurerm_storage_account.storageacc.id
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "azurerm_storage_data_lake_gen2_filesystem" "raw-era5" {
+  name               = "raw"
+  storage_account_id = azurerm_storage_account.storageacc.id
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+
 resource "azurerm_storage_data_lake_gen2_filesystem" "clean" {
   name               = "clean"
+  storage_account_id = azurerm_storage_account.storageacc.id
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "azurerm_storage_data_lake_gen2_filesystem" "clean-cmip6" {
+  name               = "clean-cmip6"
+  storage_account_id = azurerm_storage_account.storageacc.id
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "azurerm_storage_data_lake_gen2_filesystem" "clean-era5" {
+  name               = "clean-era5"
   storage_account_id = azurerm_storage_account.storageacc.id
   lifecycle {
     prevent_destroy = true
@@ -53,6 +87,7 @@ resource "azurerm_storage_data_lake_gen2_filesystem" "clean-dev" {
     prevent_destroy = false
   }
 }
+
 
 resource "azurerm_storage_data_lake_gen2_filesystem" "biascorrected" {
   name               = "biascorrected"
@@ -96,6 +131,7 @@ resource "azurerm_storage_data_lake_gen2_filesystem" "support" {
   }
 }
 
+
 resource "azurerm_storage_data_lake_gen2_filesystem" "qc" {
   name               = "qualitycontrol"
   storage_account_id = azurerm_storage_account.storageacc.id
@@ -103,6 +139,7 @@ resource "azurerm_storage_data_lake_gen2_filesystem" "qc" {
     prevent_destroy = true
   }
 }
+
 
 resource "azurerm_storage_data_lake_gen2_filesystem" "qcstage" {
   name               = "qualitycontrol-stage"


### PR DESCRIPTION
We're adding back the more specialized Azure storage containers so that we can explicitly share key data with different stakeholders in a single data lake.

Related to #152.