### PR TITLE
Refactor "dc6" template to "biascorrect" for clarity

### DIFF
--- a/workflows/templates/biascorrect.yaml
+++ b/workflows/templates/biascorrect.yaml
@@ -1,14 +1,14 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: dc6
+  name: biascorrect
   labels:
-    component: dc6
+    component: biascorrect
 spec:
   workflowMetadata:
     labels:
-      component: dc6
-  entrypoint: biascorrect-variable
+      component: biascorrect
+  entrypoint: biascorrect
   arguments:
     parameters:
       - name: variable-id
@@ -32,7 +32,7 @@ spec:
         value: "additive"
   templates:
 
-    - name: biascorrect-variable
+    - name: biascorrect
       inputs:
         parameters:
           - name: variable-id

--- a/workflows/templates/kustomization.yaml
+++ b/workflows/templates/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - clean-cmip6.yaml
   - clean-era5.yaml
-  - dc6.yaml
+  - biascorrect.yaml
   - distributed-regrid.yaml
   - download-cmip6.yaml
   - downscale.yaml


### PR DESCRIPTION
For clarity, we're refactoring the "dc6" template to "biascorrect". This makes sense because the workflow isn't doing a fully bias-correction and downscaling, instead it's just a biascorrection. Hopefully this will make this more clear.