### PR TITLE
Add workflow template for standardized fsspec URLs

### DIFF
--- a/workflows/templates/catalog.yaml
+++ b/workflows/templates/catalog.yaml
@@ -1,0 +1,137 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: catalog
+  annotations:
+    workflows.argoproj.io/description: >-
+      Templates to infer workflow fsspec URLs from Zarr metadata, parameters.
+    workflows.argoproj.io/tags: fsspec,az,zarr
+    workflows.argoproj.io/version: '>= 3.1.0'
+  labels:
+    component: utils
+spec:
+  templates:
+
+
+    - name: get-fsspec-url-from-zarr
+      inputs:
+        parameters:
+          - name: in-zarr
+          - name: base-url
+      outputs:
+        parameters:
+          - name: out-url
+            valueFrom:
+              path: "/tmp/url.txt"
+      script:
+        image: downscalecmip6.azurecr.io/dodola:0.6.0
+        env:
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [ python ]
+        source: |
+          import dodola.repository as storage
+
+          in_zarr = "{{ inputs.parameters.in-zarr }}"
+          base_url = "{{ inputs.parameters.base-url }}"
+
+          ds = storage.read(in_zarr)
+
+          print(f"{ds.attrs =}")
+
+          activity_id = ds.attrs["activity_id"]
+          institution_id = ds.attrs["institution_id"]
+          source_id = ds.attrs["source_id"]
+          experiment_id = ds.attrs["experiment_id"]
+          #member_id = ds.attrs["member_id"]  # DEBUG Not in GFDL attrs
+          member_id = ds.attrs["variant_label"]  # DEBUG
+          table_id = ds.attrs["table_id"]
+          variable_id = ds.attrs["variable_id"]
+          grid_label = ds.attrs["grid_label"]
+          version = "000000000000"
+
+          out_url = f"{base_url}/{activity_id}/{institution_id}/{source_id}/{experiment_id}/{member_id}/{table_id}/{variable_id}/{grid_label}/v{version}.zarr"
+
+          with open("/tmp/url.txt", "w") as fl:
+              fl.write(out_url)
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: "200m"
+          limits:
+            memory: 4Gi
+            cpu: "500m"
+      activeDeadlineSeconds: 90
+      retryStrategy:
+        limit: 2
+        retryPolicy: "Always"
+
+
+    - name: get-fsspec-url-from-parameters
+      inputs:
+        parameters:
+          - name: experiment-id
+          - name: activity-id
+          - name: table-id
+          - name: variable-id
+          - name: source-id
+          - name: institution-id
+          - name: member-id
+          - name: grid-label
+          - name: version
+            value: "000000000000"
+          - name: base-url
+      outputs:
+        parameters:
+          - name: out-url
+            valueFrom:
+              path: "/tmp/url.txt"
+      script:
+        image: downscalecmip6.azurecr.io/dodola:0.6.0
+        env:
+          - name: AZURE_STORAGE_ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestorageaccount
+          - name: AZURE_STORAGE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: workerstoragecreds-secret
+                key: azurestoragekey
+        command: [ python ]
+        source: |
+          base_url = "{{ inputs.parameters.base-url }}"
+          activity_id = "{{ inputs.parameters.activity-id }}"
+          institution_id = "{{ inputs.parameters.institution-id }}"
+          source_id = "{{ inputs.parameters.source-id }}"
+          experiment_id = "{{ inputs.parameters.experiment-id }}"
+          member_id = "{{ inputs.parameters.member-id }}"
+          table_id = "{{ inputs.parameters.table-id }}"
+          variable_id = "{{ inputs.parameters.variable-id }}"
+          grid_label = "{{ inputs.parameters.grid-label }}"
+          version = "{{ inputs.parameters.version }}"
+
+          out_url = f"{base_url}/{activity_id}/{institution_id}/{source_id}/{experiment_id}/{member_id}/{table_id}/{variable_id}/{grid_label}/v{version}.zarr"
+
+          with open("/tmp/url.txt", "w") as fl:
+              fl.write(out_url)
+        resources:
+          requests:
+            memory: 200Mi
+            cpu: "100m"
+          limits:
+            memory: 200Mi
+            cpu: "200m"
+      activeDeadlineSeconds: 90
+      retryStrategy:
+        limit: 2
+        retryPolicy: "Always"

--- a/workflows/templates/kustomization.yaml
+++ b/workflows/templates/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - catalog.yaml
   - clean-cmip6.yaml
   - clean-era5.yaml
   - biascorrect.yaml


### PR DESCRIPTION
Adds common patterns to get data URLs for major workflow inputs and output. This is a required addition for larger workflow refactoring (e.g. #184, #185).