### PR TITLE
Fix OOM error on EC-Earth3 in standardize step of "clean-cmip6"

### DIFF
--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -361,8 +361,8 @@ spec:
           - "{{ inputs.parameters.out-zarr }}"
         resources:
           requests:
-            memory: 16Gi
-            cpu: "2000m"
+            memory: 32Gi
+            cpu: "500m"
           limits:
             memory: 32Gi  # Bump for large EC-Earth3 data.
             cpu: "6000m"

--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -364,11 +364,11 @@ spec:
             memory: 16Gi
             cpu: "2000m"
           limits:
-            memory: 32Gi  # Bump for large EC-Earth3-Veg output.
+            memory: 32Gi  # Bump for large EC-Earth3 data.
             cpu: "6000m"
       activeDeadlineSeconds: 3600
       retryStrategy:
-        limit: 2
+        limit: 4
         retryPolicy: "Always"
 
 

--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -364,8 +364,8 @@ spec:
             memory: 16Gi
             cpu: "2000m"
           limits:
-            memory: 16Gi
-            cpu: "2000m"
+            memory: 32Gi  # Bump for large EC-Earth3-Veg output.
+            cpu: "6000m"
       activeDeadlineSeconds: 3600
       retryStrategy:
         limit: 2

--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -364,7 +364,7 @@ spec:
             memory: 32Gi
             cpu: "500m"
           limits:
-            memory: 32Gi  # Bump for large EC-Earth3 data.
+            memory: 38Gi  # Bump for large EC-Earth3 data.
             cpu: "6000m"
       activeDeadlineSeconds: 3600
       retryStrategy:

--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -361,7 +361,7 @@ spec:
           - "{{ inputs.parameters.out-zarr }}"
         resources:
           requests:
-            memory: 32Gi
+            memory: 16Gi
             cpu: "500m"
           limits:
             memory: 48Gi  # Bump for large EC-Earth3 data.

--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -364,7 +364,7 @@ spec:
             memory: 32Gi
             cpu: "500m"
           limits:
-            memory: 38Gi  # Bump for large EC-Earth3 data.
+            memory: 48Gi  # Bump for large EC-Earth3 data.
             cpu: "6000m"
       activeDeadlineSeconds: 3600
       retryStrategy:


### PR DESCRIPTION
Increases memory limit for "clean-cmip6" standardize step so EC-Earth3* GCMs fit.

Related to #209.