### PR TITLE
Fix cmip6 clean chunking bug

### DIFF
--- a/workflows/parameters/CNRM-CM6-1-tasmin.yaml
+++ b/workflows/parameters/CNRM-CM6-1-tasmin.yaml
@@ -1,0 +1,28 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "CNRM-CM6-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20180917" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "CNRM-CM6-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20190219" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "CNRM-CM6-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20180917" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "CNRM-CM6-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20190219" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "CNRM-CM6-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20180917" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "CNRM-CM6-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20190219" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "CNRM-CM6-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20180917" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "CNRM-CM6-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20190219" }
+    }
+  ]
+

--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -500,14 +500,20 @@ spec:
           print(ds2)  # DEBUG
 
           ds = xr.concat([ds1, ds2], dim="time").sortby("time")
+
+          # some models have axis_nbounds dim instead of bnds
+          if "axis_nbounds" in ds.dims:
+              ds = ds.rename({"axis_nbounds": "bnds"})
           ds = ds.chunk({"time": 365, "lat": -1, "lon": -1, "bnds": 2})
 
           # Hack to get around issue with writing chunks to zarr in xarray v0.17.0
           for v in ds.data_vars.keys():
               del ds[v].encoding["chunks"]
           # TODO: For whatever reason these where not removed in the above loop, even if iter over ds.keys()...
-          del ds["lat_bnds"].encoding["chunks"]
-          del ds["lon_bnds"].encoding["chunks"]
+          if "lat_bnds" in ds.coords:
+              del ds["lat_bnds"].encoding["chunks"]
+          if "lon_bnds" in ds.coords:
+              del ds["lon_bnds"].encoding["chunks"]
 
           print(os.environ.get("OUT_ZARR"))  # DEBUG
           ds.to_zarr(


### PR DESCRIPTION
 - [X] closes #208 
 
This PR fixes a chunking issue that was resulting in an error for the cmip6-clean workflow for CNRM-ESM2-1 and CNRM-6-1 models. 