### PR TITLE
Update tasmax yamls

### DIFF
--- a/workflows/parameters/ACCESS-CM2-tasmax.yaml
+++ b/workflows/parameters/ACCESS-CM2-tasmax.yaml
@@ -1,12 +1,33 @@
-variable-id: "tasmax"
-source-id: "ACCESS-CM2"
-historical: |
+jobs: |
   [
-    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "ACCESS-CM2", "institution-id": "CSIRO-ARCCSS", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20191108" }
-  ]
-ssps: |
-  [
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "ACCESS-CM2", "institution-id": "CSIRO-ARCCSS", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20191108" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "ACCESS-CM2", "institution-id": "CSIRO-ARCCSS", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20191108" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "ACCESS-CM2", "institution-id": "CSIRO-ARCCSS", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20210317" }
+    {
+      "target": "historical",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210317" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210317" }
+    }
   ]

--- a/workflows/parameters/ACCESS-ESM1-5-tasmax.yaml
+++ b/workflows/parameters/ACCESS-ESM1-5-tasmax.yaml
@@ -23,5 +23,11 @@ jobs: |
       "variable_id": "tasmax",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-ESM1-5", "institution_id": "CSIRO", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191115" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-ESM1-5", "institution_id": "CSIRO", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191115" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-ESM1-5", "institution_id": "CSIRO", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191115" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-ESM1-5", "institution_id": "CSIRO", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191115" }
     }
   ]

--- a/workflows/parameters/AWI-CM-1-1-MR-tasmax.yaml
+++ b/workflows/parameters/AWI-CM-1-1-MR-tasmax.yaml
@@ -23,5 +23,11 @@ jobs: |
       "variable_id": "tasmax",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "AWI-CM-1-1-MR", "institution_id": "AWI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20181218" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "AWI-CM-1-1-MR", "institution_id": "AWI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190529" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "AWI-CM-1-1-MR", "institution_id": "AWI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20181218" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "AWI-CM-1-1-MR", "institution_id": "AWI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190529" }
     }
   ]

--- a/workflows/parameters/BCC-CSM2-MR-tasmax.yaml
+++ b/workflows/parameters/BCC-CSM2-MR-tasmax.yaml
@@ -23,6 +23,12 @@ jobs: |
       "variable_id": "tasmax",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "BCC-CSM2-MR", "institution_id": "BCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20181126" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "BCC-CSM2-MR", "institution_id": "BCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190315" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "BCC-CSM2-MR", "institution_id": "BCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20181126" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "BCC-CSM2-MR", "institution_id": "BCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190318" }
     }
   ]
 

--- a/workflows/parameters/CAMS-CSM1-0-tasmax.yaml
+++ b/workflows/parameters/CAMS-CSM1-0-tasmax.yaml
@@ -1,12 +1,33 @@
-variable-id: "tasmax"
-source-id: "CAMS-CSM1-0"
-historical: |
+jobs: |
   [
-    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "CAMS-CSM1-0", "institution-id": "CAMS", "member-id": "r2i1p1f1", "grid-label": "gn", "version": "20201022" }
-  ]
-ssps: |
-  [
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "CAMS-CSM1-0", "institution-id": "CAMS", "member-id": "r2i1p1f1", "grid-label": "gn", "version": "20200720" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "CAMS-CSM1-0", "institution-id": "CAMS", "member-id": "r2i1p1f1", "grid-label": "gn", "version": "20200720" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "CAMS-CSM1-0", "institution-id": "CAMS", "member-id": "r2i1p1f1", "grid-label": "gn", "version": "20191106" }
+    {
+      "target": "historical",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CAMS-CSM1-0", "institution_id": "CAMS", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20201022" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "CAMS-CSM1-0", "institution_id": "CAMS", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20200720" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CAMS-CSM1-0", "institution_id": "CAMS", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20201022" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "CAMS-CSM1-0", "institution_id": "CAMS", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20200720" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CAMS-CSM1-0", "institution_id": "CAMS", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20201022" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "CAMS-CSM1-0", "institution_id": "CAMS", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20200720" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CAMS-CSM1-0", "institution_id": "CAMS", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20201022" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "CAMS-CSM1-0", "institution_id": "CAMS", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20191106" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CAMS-CSM1-0", "institution_id": "CAMS", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20201022" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "CAMS-CSM1-0", "institution_id": "CAMS", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20191106" }
+    }
   ]

--- a/workflows/parameters/CMCC-ESM2-tasmax.yaml
+++ b/workflows/parameters/CMCC-ESM2-tasmax.yaml
@@ -1,12 +1,33 @@
-variable-id: "tasmax"
-source-id: "CMCC-ESM2"
-historical: |
+jobs: |
   [
-    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "CMCC-ESM2", "institution-id": "CMCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20210114" }
-  ]
-ssps: |
-  [
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "CMCC-ESM2", "institution-id": "CMCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20210202" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "CMCC-ESM2", "institution-id": "CMCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20210129" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "CMCC-ESM2", "institution-id": "CMCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20210126" }
+    {
+      "target": "historical",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210114" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210202" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210114" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210202" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210114" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210129" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210114" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210126" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210114" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210126" }
+    }
   ]

--- a/workflows/parameters/CNRM-CM6-1-tasmax.yaml
+++ b/workflows/parameters/CNRM-CM6-1-tasmax.yaml
@@ -23,6 +23,12 @@ jobs: |
       "variable_id": "tasmax",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CNRM-CM6-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20180917" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "CNRM-CM6-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20190219" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CNRM-CM6-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20180917" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "CNRM-CM6-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20190219" }
     }
   ]
 

--- a/workflows/parameters/CNRM-ESM2-1-tasmax.yaml
+++ b/workflows/parameters/CNRM-ESM2-1-tasmax.yaml
@@ -1,12 +1,33 @@
-variable-id: "tasmax"
-source-id: "CNRM-ESM2-1"
-historical: |
+jobs: |
   [
-    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "CNRM-ESM2-1", "institution-id": "CNRM-CERFACS", "member-id": "r1i1p1f2", "grid-label": "gr", "version": "20181206" }
-  ]
-ssps: |
-  [
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "CNRM-ESM2-1", "institution-id": "CNRM-CERFACS", "member-id": "r1i1p1f2", "grid-label": "gr", "version": "20191021" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "CNRM-ESM2-1", "institution-id": "CNRM-CERFACS", "member-id": "r1i1p1f2", "grid-label": "gr", "version": "20190328" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "CNRM-ESM2-1", "institution-id": "CNRM-CERFACS", "member-id": "r1i1p1f2", "grid-label": "gr", "version": "20190328" }
+    {
+      "target": "historical",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CNRM-ESM2-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20181206" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "CNRM-ESM2-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20191021" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CNRM-ESM2-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20181206" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "CNRM-ESM2-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20191021" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CNRM-ESM2-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20181206" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "CNRM-ESM2-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20190219" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CNRM-ESM2-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20181206" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "CNRM-ESM2-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20190219" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CNRM-ESM2-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20181206" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "CNRM-ESM2-1", "institution_id": "CNRM-CERFACS", "member_id": "r1i1p1f2", "grid_label": "gr", "version": "20191021" }
+    }
   ]

--- a/workflows/parameters/CanESM5-tasmax.yaml
+++ b/workflows/parameters/CanESM5-tasmax.yaml
@@ -23,6 +23,12 @@ jobs: |
       "variable_id": "tasmax",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CanESM5", "institution_id": "CCCma", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190429" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "CanESM5", "institution_id": "CCCma", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190429" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CanESM5", "institution_id": "CCCma", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190429" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "CanESM5", "institution_id": "CCCma", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190429" }
     }
   ]
 

--- a/workflows/parameters/EC-Earth3-Veg-LR-tasmax.yaml
+++ b/workflows/parameters/EC-Earth3-Veg-LR-tasmax.yaml
@@ -1,12 +1,33 @@
-variable-id: "tasmax"
-source-id: "EC-Earth3-Veg-LR"
-historical: |
+jobs: |
   [
-    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "EC-Earth3-Veg-LR", "institution-id": "EC-Earth-Consortium", "member-id": "r1i1p1f1", "grid-label": "gr", "version": "20200217" }
-  ]
-ssps: |
-  [
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "EC-Earth3-Veg-LR", "institution-id": "EC-Earth-Consortium", "member-id": "r1i1p1f1", "grid-label": "gr", "version": "20201123" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "EC-Earth3-Veg-LR", "institution-id": "EC-Earth-Consortium", "member-id": "r1i1p1f1", "grid-label": "gr", "version": "20201123" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "EC-Earth3-Veg-LR", "institution-id": "EC-Earth-Consortium", "member-id": "r1i1p1f1", "grid-label": "gr", "version": "20201201" }
+    {
+      "target": "historical",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg-LR", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200217" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg-LR", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20201123" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg-LR", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200217" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg-LR", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20201123" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg-LR", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200217" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg-LR", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20201123" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg-LR", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200217" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg-LR", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20201201" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg-LR", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200217" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg-LR", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20201201" }
+    }
   ]

--- a/workflows/parameters/EC-Earth3-Veg-tasmax.yaml
+++ b/workflows/parameters/EC-Earth3-Veg-tasmax.yaml
@@ -1,12 +1,33 @@
-variable-id: "tasmax"
-source-id: "EC-Earth3-Veg"
-historical: |
+jobs: |
   [
-    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "EC-Earth3-Veg", "institution-id": "EC-Earth-Consortium", "member-id": "r1i1p1f1", "grid-label": "gr", "version": "20200225" }
-  ]
-ssps: |
-  [
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "EC-Earth3-Veg", "institution-id": "EC-Earth-Consortium", "member-id": "r1i1p1f1", "grid-label": "gr", "version": "20200225" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "EC-Earth3-Veg", "institution-id": "EC-Earth-Consortium", "member-id": "r1i1p1f1", "grid-label": "gr", "version": "20200225" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "EC-Earth3-Veg", "institution-id": "EC-Earth-Consortium", "member-id": "r1i1p1f1", "grid-label": "gr", "version": "20200225" }
+    {
+      "target": "historical",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200225" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200225" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200225" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200225" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200225" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200225" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200225" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200225" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200225" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-Veg", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200225" }
+    }
   ]

--- a/workflows/parameters/EC-Earth3-tasmax.yaml
+++ b/workflows/parameters/EC-Earth3-tasmax.yaml
@@ -23,6 +23,12 @@ jobs: |
       "variable_id": "tasmax",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200310" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200310" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200310" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200310" }
     }
   ]
 

--- a/workflows/parameters/FGOALS-g3-tasmax.yaml
+++ b/workflows/parameters/FGOALS-g3-tasmax.yaml
@@ -23,6 +23,12 @@ jobs: |
       "variable_id": "tasmax",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190826" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190818" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190826" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190819" }
     }
   ]
 

--- a/workflows/parameters/INM-CM4-8-pr.yaml
+++ b/workflows/parameters/INM-CM4-8-pr.yaml
@@ -1,0 +1,33 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190530" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190603" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190530" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190603" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190530" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190603" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190530" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190603" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190530" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190603" }
+    }
+  ]

--- a/workflows/parameters/INM-CM4-8-tasmax.yaml
+++ b/workflows/parameters/INM-CM4-8-tasmax.yaml
@@ -1,12 +1,33 @@
-variable-id: "tasmax"
-source-id: "INM-CM4-8"
-historical: |
+jobs: |
   [
-    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "INM-CM4-8", "institution-id": "INM", "member-id": "r1i1p1f1", "grid-label": "gr1", "version": "20190530" }
-  ]
-ssps: |
-  [
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "INM-CM4-8", "institution-id": "INM", "member-id": "r1i1p1f1", "grid-label": "gr1", "version": "20190603" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "INM-CM4-8", "institution-id": "INM", "member-id": "r1i1p1f1", "grid-label": "gr1", "version": "20190603" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "INM-CM4-8", "institution-id": "INM", "member-id": "r1i1p1f1", "grid-label": "gr1", "version": "20190603" }
+    {
+      "target": "historical",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190530" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190603" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190530" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190603" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190530" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190603" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190530" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190603" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190530" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190603" }
+    }
   ]

--- a/workflows/parameters/INM-CM4-8-tasmin.yaml
+++ b/workflows/parameters/INM-CM4-8-tasmin.yaml
@@ -1,0 +1,33 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190530" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190603" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190530" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190603" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190530" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190603" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190530" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190603" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190530" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM4-8", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190603" }
+    }
+  ]

--- a/workflows/parameters/INM-CM5-0-pr.yaml
+++ b/workflows/parameters/INM-CM5-0-pr.yaml
@@ -1,0 +1,34 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190610" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190618" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190610" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190618" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190610" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190619" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190610" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190619" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190610" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "pr", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190724" }
+    }
+  ]
+

--- a/workflows/parameters/INM-CM5-0-tasmax.yaml
+++ b/workflows/parameters/INM-CM5-0-tasmax.yaml
@@ -23,6 +23,12 @@ jobs: |
       "variable_id": "tasmax",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190610" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190619" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190610" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190724" }
     }
   ]
 

--- a/workflows/parameters/INM-CM5-0-tasmin.yaml
+++ b/workflows/parameters/INM-CM5-0-tasmin.yaml
@@ -1,0 +1,34 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190610" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190618" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190610" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190618" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190610" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190619" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190610" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190619" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190610" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmin", "source_id": "INM-CM5-0", "institution_id": "INM", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190724" }
+    }
+  ]
+

--- a/workflows/parameters/MIROC6-pr.yaml
+++ b/workflows/parameters/MIROC6-pr.yaml
@@ -1,0 +1,33 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "pr", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "pr", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" }
+    }
+  ]

--- a/workflows/parameters/MIROC6-tasmax.yaml
+++ b/workflows/parameters/MIROC6-tasmax.yaml
@@ -23,5 +23,11 @@ jobs: |
       "variable_id": "tasmax",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" }
     }
   ]

--- a/workflows/parameters/MIROC6-tasmin.yaml
+++ b/workflows/parameters/MIROC6-tasmin.yaml
@@ -1,0 +1,33 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmin", "source_id": "MIROC6", "institution_id": "MIROC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191016" }
+    }
+  ]

--- a/workflows/parameters/MPI-ESM1-2-LR-pr.yaml
+++ b/workflows/parameters/MPI-ESM1-2-LR-pr.yaml
@@ -1,0 +1,33 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+    }
+  ]

--- a/workflows/parameters/MPI-ESM1-2-LR-tasmax.yaml
+++ b/workflows/parameters/MPI-ESM1-2-LR-tasmax.yaml
@@ -1,12 +1,33 @@
-variable-id: "tasmax"
-source-id: "MPI-ESM1-2-LR"
-historical: |
+jobs: |
   [
-    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "MPI-ESM1-2-LR", "institution-id": "MPI-M", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190710" }
-  ]
-ssps: |
-  [
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "MPI-ESM1-2-LR", "institution-id": "MPI-M", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190710" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "MPI-ESM1-2-LR", "institution-id": "MPI-M", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190710" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "MPI-ESM1-2-LR", "institution-id": "MPI-M", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190710" }
+    {
+      "target": "historical",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+    }
   ]

--- a/workflows/parameters/MPI-ESM1-2-LR-tasmin.yaml
+++ b/workflows/parameters/MPI-ESM1-2-LR-tasmin.yaml
@@ -1,0 +1,33 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM1-2-LR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+    }
+  ]

--- a/workflows/parameters/MRI-ESM2-0-tasmax.yaml
+++ b/workflows/parameters/MRI-ESM2-0-tasmax.yaml
@@ -1,12 +1,33 @@
-variable-id: "tasmax"
-source-id: "MRI-ESM2-0"
-historical: |
+jobs: |
   [
-    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "MRI-ESM2-0", "institution-id": "MRI", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190603" }
-  ]
-ssps: |
-  [
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "MRI-ESM2-0", "institution-id": "MRI", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190603" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "MRI-ESM2-0", "institution-id": "MRI", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20190603" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "MRI-ESM2-0", "institution-id": "MRI", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20191108" }
+    {
+      "target": "historical",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    }
   ]

--- a/workflows/parameters/NorESM2-LM-pr.yaml
+++ b/workflows/parameters/NorESM2-LM-pr.yaml
@@ -1,0 +1,33 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    }
+  ]

--- a/workflows/parameters/NorESM2-LM-tasmax.yaml
+++ b/workflows/parameters/NorESM2-LM-tasmax.yaml
@@ -23,5 +23,11 @@ jobs: |
       "variable_id": "tasmax",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
     }
   ]

--- a/workflows/parameters/NorESM2-LM-tasmin.yaml
+++ b/workflows/parameters/NorESM2-LM-tasmin.yaml
@@ -1,0 +1,33 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-LM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    }
+  ]

--- a/workflows/parameters/NorESM2-MM-pr.yaml
+++ b/workflows/parameters/NorESM2-MM-pr.yaml
@@ -1,0 +1,33 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    }
+  ]

--- a/workflows/parameters/NorESM2-MM-tasmax.yaml
+++ b/workflows/parameters/NorESM2-MM-tasmax.yaml
@@ -1,12 +1,33 @@
-variable-id: "tasmax"
-source-id: "NorESM2-MM"
-historical: |
+jobs: |
   [
-    { "activity-id": "CMIP", "experiment-id": "historical", "table-id": "day", "variable-id": "tasmax", "source-id": "NorESM2-MM", "institution-id": "NCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20191108" }
-  ]
-ssps: |
-  [
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp370", "table-id": "day", "variable-id": "tasmax", "source-id": "NorESM2-MM", "institution-id": "NCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20191108" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp245", "table-id": "day", "variable-id": "tasmax", "source-id": "NorESM2-MM", "institution-id": "NCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20191108" },
-    { "activity-id": "ScenarioMIP", "experiment-id": "ssp126", "table-id": "day", "variable-id": "tasmax", "source-id": "NorESM2-MM", "institution-id": "NCC", "member-id": "r1i1p1f1", "grid-label": "gn", "version": "20191108" }
+    {
+      "target": "historical",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    }
   ]

--- a/workflows/parameters/NorESM2-MM-tasmin.yaml
+++ b/workflows/parameters/NorESM2-MM-tasmin.yaml
@@ -1,0 +1,33 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    }
+  ]


### PR DESCRIPTION
 This PR updates tasmax parameter files to the updated spec, adds SSP5-8.5 to the tasmax parameter files that were missing it, and adds tasmin and pr parameter files for all models that already had parameter files for tasmax. A few remaining parameter files will be added in a follow-up PR. 