### PR TITLE
Add rough WorkflowTemplate for automated CMIP6 checks

### DIFF
--- a/workflows/templates/kustomization.yaml
+++ b/workflows/templates/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - biascorrectdownscale.yaml
   - distributed-regrid.yaml
   - download-cmip6.yaml
+  - qualitycontrol-check-cmip6.yaml
   - zarr-transfer.yaml

--- a/workflows/templates/qualitycontrol-check-cmip6.yaml
+++ b/workflows/templates/qualitycontrol-check-cmip6.yaml
@@ -1,0 +1,101 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: qualitycontrol-check-cmip6
+  annotations:
+    workflows.argoproj.io/description: >-
+      Automated quality-control check for CMIP6 data at various stages of dc6.
+
+      Input Zarr Store locations are specified with fsspec-style URLs. These
+      checks are specific to the Downscaling CMIP6 project.
+    workflows.argoproj.io/tags: zarr,qualitycontrol,cmip6,validate,dc6
+    workflows.argoproj.io/version: '>= 3.1.0'
+  labels:
+    component: qualitycontrol
+
+spec:
+  entrypoint: qualitycontrol-check-cmip6
+  arguments:
+    parameters:
+      - name: in-zarr
+        value: "gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20211022013318.zarr"
+      # Must be "tasmax", "tasmin", "dtr", "pr".
+      - name: variable
+        value: "tasmax"
+      # Must be "downscaled", "biascorrected", "cmip6".
+      - name: data
+        value: "downscaled"
+      # Must be "future" or "historical".
+      - name: time
+        value: "future"
+  workflowMetadata:
+    labels:
+      component: qualitycontrol
+  templates:
+
+    - name: qualitycontrol-check-cmip6
+      inputs:
+        parameters:
+          - name: in-zarr
+          - name: variable
+          - name: data
+          - name: time
+      script:
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        command: [python]
+        source: |
+          import dask
+          import numpy as np
+          from dodola.core import (_test_for_nans, _test_variable_names, _test_timesteps, _test_temp_range, _test_dtr_range, _test_negative_values, _test_maximum_precip)
+          from dodola.repository import read
+          import xarray as xr
+
+          in_zarr = "{{ inputs.parameters.in-zarr }}"
+          variable = "{{ inputs.parameters.variable }}"
+          data_type = "{{ inputs.parameters.data }}"
+          time_period = "{{ inputs.parameters.time }}"
+
+          print(f"Validating {in_zarr}")
+
+          ds = read(in_zarr)
+
+          # These only read in Zarr Store metadata -- not memory intensive.
+          _test_variable_names(ds, variable)
+          _test_timesteps(ds, data_type, time_period)
+
+          # Other test are done on annual selections with dask.delayed to
+          # avoid large memory errors.
+          @dask.delayed
+          def clear_memory_intensive_tests(f, v, t):
+              d = read(f).sel(time=str(t))
+
+              _test_for_nans(d, v)
+
+              if v == "tasmin" or v == "tasmax":
+                  _test_temp_range(d, v)
+              if v == "dtr":
+                  _test_dtr_range(d, v)
+              if v == "dtr" or v == "pr":
+                 _test_negative_values(d, v)
+              if v == "pr":
+                 _test_maximum_precip(d, v)
+
+              # Assumes error thrown if had problem before this.
+              return True
+
+          tasks = []
+          for t in np.unique(ds["time"].dt.year.data):
+              test_results = clear_memory_intensive_tests(in_zarr, variable, t)
+              tasks.append(test_results)
+          tasks = dask.compute(*tasks)
+          assert all(tasks)  # Likely don't need this
+          print(f"Validated")
+        resources:
+          requests:
+            memory: 8Gi
+            cpu: "2000m"
+          limits:
+            memory: 8Gi
+            cpu: "2000m"
+      activeDeadlineSeconds: 3600
+


### PR DESCRIPTION
This adds a WorkflowTemplate for automated checks to CMIP6 output at various stages of the downscaling workflow. This checks variable names, variable min/max values, NaNs, etc.

This depends on a development release of dodola so, take this as just a prototype. We'll need to solidify things as it gets used and tested.