### PR TITLE
add science validation for use with papermill

### DIFF
--- a/notebooks/downscaling_pipeline/global_validation_papermill.ipynb
+++ b/notebooks/downscaling_pipeline/global_validation_papermill.ipynb
@@ -1,0 +1,307 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Global Validation ###\n",
+    "\n",
+    "This notebook combines several validation notebooks: `global_validation_tasmax_v2.ipynb` and `global_validation_dtr_v2.ipynb` along with `check_aiqpd_downscaled_data.ipynb` to create a \"master\" global validation notebook. It also borrows validation code from the ERA-5 workflow, `validate_era5_hourlyORdaily_files.ipynb`. It is intended to be run with `papermill`. \n",
+    "\n",
+    "### Data Sources ###\n",
+    "\n",
+    "Coarse Resolution: \n",
+    "- CMIP6 \n",
+    "- Bias corrected data \n",
+    "- ERA-5\n",
+    "\n",
+    "Fine Resolution: \n",
+    "- Bias corrected data \n",
+    "- Downscaled data \n",
+    "- ERA-5 (fine resolution)\n",
+    "- ERA-5 (coarse resolution resampled to fine resolution) \n",
+    "\n",
+    "### Types of Validation ### \n",
+    "\n",
+    "Basic: \n",
+    "- maxes, means, mins  \n",
+    "    - CMIP6, bias corrected and downscaled \n",
+    "    - historical (1995-2014), 2020-2040, 2040-2060, 2060-2080, 2080-2100 \n",
+    "- differences between historical and future time periods for bias corrected and downscaled\n",
+    "- differences between bias corrected and downscaled data \n",
+    "\n",
+    "Variable-specific: \n",
+    "- GMST\n",
+    "- days over 95 (TO-DO)\n",
+    "- max # of consecutive dry days, highest precip amt over 5-day rolling window (TO-DO) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline \n",
+    "import xarray as xr\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from cartopy import config\n",
+    "import cartopy.crs as ccrs\n",
+    "import cartopy.feature as cfeature\n",
+    "import os \n",
+    "import gcsfs \n",
+    "from matplotlib import cm\n",
+    "import warnings \n",
+    "\n",
+    "from validation import *"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set Validation Parameters ###"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# variable options: 'tasmax', 'tasmin', 'dtr', 'pr'\n",
+    "variable = 'tasmax'\n",
+    "# ssp options: 'ssp126', 'ssp245', 'ssp370', 'ssp585'\n",
+    "ssp = 'ssp370'\n",
+    "\n",
+    "# data output types for running validation \n",
+    "cmip6 = True\n",
+    "bias_corrected = True\n",
+    "downscaled = True\n",
+    "# projection time period options: '2020_2040', '2040_2060', '2060_2080', '2080_2100'\n",
+    "projection_time_period = '2080_2100'\n",
+    "\n",
+    "# validation plot options\n",
+    "basic_diagnostics = True\n",
+    "\n",
+    "# options: 'mean', 'max', 'min'\n",
+    "basic_diag_type = 'mean'\n",
+    "\n",
+    "gmst = True\n",
+    "difference_plots = True\n",
+    "\n",
+    "# options: 'downscaled_minus_biascorrected' , 'change_from_historical'\n",
+    "diff_type = 'downscaled_minus_biascorrected'\n",
+    "\n",
+    "# contains the gcs URLs to zarr locations for each specified dataset\n",
+    "data_dict = {'coarse': {'cmip6': {'historical': 'scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-858077599/out.zarr', \n",
+    "                                  ssp: 'scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-269778292/out.zarr'}, \n",
+    "                        'bias_corrected': {'historical': 'az://biascorrected-stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr', \n",
+    "                                                                                      ssp: 'az://biascorrected-stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr'}, \n",
+    "                        'ERA-5':'az://scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-131793962/out.zarr'}, \n",
+    "             'fine': {'bias_corrected': {'historical': 'az://scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-1362934973/regridded.zarr', \n",
+    "                                         ssp: 'az://scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-377595554/regridded.zarr'}, \n",
+    "                      'downscaled': {'historical': 'az://downscaled-stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr', \n",
+    "                                     ssp: 'az://downscaled-stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr'}, \n",
+    "                      'ERA-5_fine': 'az://scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-491178896/rechunked.zarr', \n",
+    "                      'ERA-5_coarse': 'az://scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-1213790070/rechunked.zarr'}}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# we only plot gmst if validation variable is tasmax \n",
+    "if variable != 'tasmax': \n",
+    "    gmst = False\n",
+    "    warnings.warn(\"gmst plotting option changed to False since validation variable is not tasmax\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### other data inputs ### "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "units = {'tasmax': 'K', 'tasmin': 'K', 'dtr': 'K', 'pr': 'mm'}\n",
+    "years = {'hist': {'start_yr': '1995', 'end_yr': '2014'}, \n",
+    "              '2020_2040': {'start_yr': '2020', 'end_yr': '2040'}, \n",
+    "              '2040_2060': {'start_yr': '2040', 'end_yr': '2060'}, \n",
+    "              '2060_2080': {'start_yr': '2060', 'end_yr': '2080'}, \n",
+    "              '2080_2100': {'start_yr': '2080', 'end_yr': '2100'}}\n",
+    "years_test = {'hist': {'start_yr': '1995', 'end_yr': '2014'}, \n",
+    "              '2020_2040': {'start_yr': '2020', 'end_yr': '2040'}, \n",
+    "              '2040_2060': {'start_yr': '2040', 'end_yr': '2060'}}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Validation ### "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### basic diagnostic plots: means, maxes, mins ### "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if cmip6 and basic_diagnostics: \n",
+    "    plot_diagnostic_climo_periods(read_gcs_zarr(data_dict['coarse']['cmip6']['historical']), \n",
+    "                                  read_gcs_zarr(data_dict['coarse']['cmip6'][ssp]), \n",
+    "                                  ssp, years, variable, basic_diag_type, 'cmip6', \n",
+    "                                  units, vmin=280, vmax=320)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if bias_corrected and basic_diagnostics: \n",
+    "    plot_diagnostic_climo_periods(read_gcs_zarr(data_dict['coarse']['bias_corrected']['historical']), \n",
+    "                                  read_gcs_zarr(data_dict['coarse']['bias_corrected'][ssp]), \n",
+    "                                  ssp, years, variable, basic_diag_type, 'bias_corrected', \n",
+    "                                  units, vmin=280, vmax=320)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if downscaled and basic_diagnostics: \n",
+    "    plot_diagnostic_climo_periods(read_gcs_zarr(data_dict['coarse']['downscaled']['historical']), \n",
+    "                                  read_gcs_zarr(data_dict['coarse']['downscaled'][ssp]), \n",
+    "                                  ssp, years, variable, basic_diag_type, 'downscaled', \n",
+    "                                  units, vmin=280, vmax=320)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### GMST ### "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if gmst: \n",
+    "    plot_gmst_diagnostic(read_gcs_zarr(data_dict['coarse']['cmip6']['historical']), \n",
+    "                         read_gcs_zarr(data_dict['coarse']['cmip6'][ssp]), \n",
+    "                         read_gcs_zarr(data_dict['coarse']['bias_corrected']['historical']), \n",
+    "                         read_gcs_zarr(data_dict['coarse']['bias_corrected'][ssp]), \n",
+    "                         variable=variable, ssp=ssp, ds_hist_downscaled=None, ds_fut_downscaled=None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Difference plots: bias corrected and downscaled OR historical/future (bias corrected and downscaled data outputs) ###"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if bias_corrected and difference_plots:\n",
+    "    plot_bias_correction_downscale_differences(read_gcs_zarr(data_dict['fine']['bias_corrected']['historical']), \n",
+    "                                               read_gcs_zarr(data_dict['fine']['downscaled']['historical']), \n",
+    "                                               read_gcs_zarr(data_dict['fine']['bias_corrected'][ssp]), \n",
+    "                                               read_gcs_zarr(data_dict['fine']['downscaled'][ssp]), \n",
+    "                                               diff_type, 'bias_corrected', variable,\n",
+    "                                                   ssp=ssp, time_period=projection_time_period)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if downscaled and difference_plots:\n",
+    "    plot_bias_correction_downscale_differences(read_gcs_zarr(data_dict['fine']['bias_corrected']['historical']), \n",
+    "                                               read_gcs_zarr(data_dict['fine']['downscaled']['historical']), \n",
+    "                                               read_gcs_zarr(data_dict['fine']['bias_corrected'][ssp]), \n",
+    "                                               read_gcs_zarr(data_dict['fine']['downscaled'][ssp]), \n",
+    "                                               diff_type, 'downscaled', variable,\n",
+    "                                                   ssp=ssp, time_period=projection_time_period)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### TO-DO: Days over 95 degrees F/extreme precip metrics ###"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/downscaling_pipeline/science_validation.py
+++ b/notebooks/downscaling_pipeline/science_validation.py
@@ -1,0 +1,158 @@
+import xarray as xr
+import numpy as np
+import matplotlib.pyplot as plt
+from cartopy import config
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+import os 
+from matplotlib import cm
+import gcsfs
+    
+def plot_diagnostic_climo_periods(ds_hist, ds_future, ssp, years, variable, metric, data_type, units, vmin=240, vmax=320, transform = ccrs.PlateCarree()):    
+    """
+    plot mean, max, min tasmax, dtr, precip for CMIP6, bias corrected and downscaled data 
+    """
+    fig, axes = plt.subplots(1, 5, figsize=(20, 6), subplot_kw={'projection': ccrs.PlateCarree()})
+    cmap = cm.cividis 
+    
+    for i, key in enumerate(years): 
+        # different dataset for historical, select years 
+        if i == 0:
+            da = ds_hist[variable].sel(time=slice(years[key]['start_yr'], years[key]['end_yr']))
+        else:
+            da = ds_future[variable].sel(time=slice(years[key]['start_yr'], years[key]['end_yr']))
+    
+        if metric == 'mean': 
+            data = da.mean(dim='time').load()
+        elif metric == 'max':
+            data = da.max(dim='time').load()
+        elif metric == 'min':
+            data = da.min(dim='time').load()
+        
+        
+        im = data.plot(ax=axes[i], 
+                  cmap=cmap,
+                  transform=ccrs.PlateCarree(), add_colorbar=False, vmin=vmin, vmax=vmax)
+
+        axes[i].coastlines()
+        axes[i].add_feature(cfeature.BORDERS, linestyle=":")
+        if i == 2:
+            axes[i].set_title('{} {}, {} \n {}'.format(metric, data_type, ssp, key))
+        else: 
+            axes[i].set_title("{}".format(key))
+    
+    # Adjust the location of the subplots on the page to make room for the colorbar
+    fig.subplots_adjust(bottom=0.02, top=0.9, left=0.05, right=0.95,
+                        wspace=0.1, hspace=0.01)
+
+    # Add a colorbar axis at the bottom of the graph
+    cbar_ax = fig.add_axes([0.2, 0.2, 0.6, 0.06])
+
+    # Draw the colorbar
+    cbar_title = '{} ({})'.format(variable, units[variable])
+    cbar=fig.colorbar(im, cax=cbar_ax, label=cbar_title, orientation='horizontal')
+    
+def _compute_gmst(da, lat_name='lat', lon_name='lon'):
+    lat_weights = np.cos(da[lat_name] * np.pi/180.)
+    ones = xr.DataArray(np.ones(da.shape), dims=da.dims, coords=da.coords)
+    weights = ones * lat_weights
+    masked_weights = weights.where(~da.isnull(), 0)
+    
+    gmst = (
+        (da * masked_weights).sum(dim=(lat_name, lon_name))
+        / (masked_weights).sum(dim=(lat_name, lon_name)))
+    
+    return gmst
+
+def plot_gmst_diagnostic(ds_hist_cmip6, ds_fut_cmip6, ds_hist_bc, ds_fut_bc, variable='tasmax', 
+                         ssp='370', ds_hist_downscaled=None, ds_fut_downscaled=None):
+    """
+    plot GMST diagnostic for cmip6, bias corrected and downscaled data. Downscaled is usually not included since there is not much added benefit
+    of computing it on the downscaled data.
+    Takes in annual mean DataArray of the above, eager. 
+    """
+    da_cmip6_hist = ds_hist_cmip6[variable].groupby('time.year').mean()
+    gmst_hist_cmip6 = _compute_gmst(da_cmip6_hist.load())
+    
+    da_cmip6_fut = ds_fut_cmip6[variable].groupby('time.year').mean()
+    gmst_fut_cmip6 = _compute_gmst(da_cmip6_fut.load())
+    
+    da_bc_hist = ds_hist_bc[variable].groupby('time.year').mean()
+    gmst_hist_bc = _compute_gmst(da_bc_hist.load())
+    
+    da_bc_fut = ds_fut_bc[variable].groupby('time.year').mean()
+    gmst_fut_bc = _compute_gmst(da_bc_fut.load())
+    
+    if ds_hist_downscaled is not None: 
+        da_ds_hist = ds_hist_downscaled[variable].groupby('time.year').mean()
+        gmst_hist_ds = _compute_gmst(da_ds_hist.load())
+        
+        da_ds_fut = ds_fut_downscaled[variable].groupby('time.year').mean()
+        gmst_fut_ds = _compute_gmst(da_ds_fut.load())
+        
+    fig = plt.figure(figsize=(12, 4))
+    gmst_hist_cmip6.plot(linestyle=':', color='black')
+    gmst_fut_cmip6.plot(linestyle=':', color='black', label='cmip6')
+
+    gmst_hist_bc.plot(color='green')
+    gmst_fut_bc.plot(color='green', label='bias corrected')
+    
+    if ds_hist_downscaled is not None: 
+        gmst_hist_ds.plot(color='blue')
+        gmst_fut_ds.plot(color='blue', label='downscaled')
+    
+    plt.legend()
+    plt.title('Global Mean {} {}'.format(variable, ssp))
+
+def plot_bias_correction_downscale_differences(da_hist_bc, da_hist_ds, da_future_bc, da_future_ds, plot_type, data_type, variable,
+                                               ssp='370', time_period='2080_2100'):
+    """
+    plot differences between bias corrected historical and future, downscaled historical and future, or bias corrected and downscaled. 
+    produces two subplots, one for historical and one for the specified future time period 
+    plot_type options: downscaled_minus_biascorrected, change_from_historical (takes bias corrected or downscaled)
+    data_type options: bias_corrected, downscaled
+    """
+    fig, axes = plt.subplots(1, 2, figsize=(20, 6), subplot_kw={'projection': ccrs.PlateCarree()})
+
+    if plot_type == 'change_from_historical':
+        if data_type == 'bias_corrected':
+            diff1 = da_hist_bc
+            diff2 = da_future_bc - da_hist_bc
+        elif data_type == 'downscaled':
+            diff1 = da_hist_ds
+            diff2 = da_future_ds - da_hist_ds
+        suptitle = "{} change from historical: {}".format(ssp, data_type)
+        cmap = cm.viridis
+    elif plot_type == 'downscaled_minus_biascorrected':
+        diff1 = da_hist_ds - da_hist_bc
+        diff2 = da_future_ds - da_future_bc
+        suptitle = "{} downscaled minus bias corrected".format(ssp)
+        cmap = cm.bwr
+
+    cbar_label = "{} ({})".format(variable, units[variable])
+    diff1.plot(ax=axes[0], cmap=cmap, transform=ccrs.PlateCarree(), robust=True, cbar_kwargs={'label': cbar_label})
+    diff2.plot(ax=axes[1], cmap=cmap, transform=ccrs.PlateCarree(), robust=True, cbar_kwargs={'label': cbar_label})
+
+    axes[0].coastlines()
+    axes[0].add_feature(cfeature.BORDERS, linestyle=":")
+    axes[0].set_title('historical (1995 - 2014)')
+    axes[1].set_title(time_period)
+    plt.suptitle(suptitle)
+
+    axes[1].coastlines()
+    axes[1].add_feature(cfeature.BORDERS, linestyle=":")
+
+    plt.tight_layout()
+
+def read_gcs_zarr(zarr_url, token='/opt/gcsfuse_tokens/impactlab-data.json', check=False):
+    """
+    takes in a GCSFS zarr url, bucket token, and returns a dataset 
+    Note that you will need to have the proper bucket authentication. 
+    """
+    fs = gcsfs.GCSFileSystem(token=token)
+    
+    store_path = fs.get_mapper(zarr_url, check=check)
+    ds = xr.open_zarr(store_path)
+    
+    return ds 
+    


### PR DESCRIPTION
 This PR adds science validation to be run with `papermill` for cleaned CMIP6, bias corrected and downscaled data for tasmax, tasmin, dtr and precip. 

Science validation options include: 
- min, max, means for CMIP6, bias corrected, downscaled data 
- GMST
- difference plots (future and historical, bias corrected and downscaled) 

For the first two diagnostics, the entire future projection period is included. For the difference plots, a future climatology is specified (default is 2080-2100). 

Each validation option is parameterized and thus the notebook can be run with, for example, only producing global plots of mean CMIP6. Or the difference between 2080-2100 and 1995-2014 bias corrected data. Or only GMST. 

Future add-ons may include days over 95, land/ocean means, and extreme precip metrics. 

An example of running this validation for downscaled tasmax, ssp370, 

```
papermill path/to/global_validation_papermill.ipynb gcsbucket/path/ -p variable 'tasmax' -p ssp 'ssp370' -p downscaled True -p -p cmip6 False -p bias_corrected False -p basic_diag_type 'max' -p diff_type 'change_from_historical' -p data_dict {'coarse': {'cmip6': {'historical': 'scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-858077599/out.zarr', 
                                  ssp: 'scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-269778292/out.zarr'}, 
                        'bias_corrected': {'historical': 'az://biascorrected-stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr', 
                                                                                      ssp: 'az://biascorrected-stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr'}, 
                        'ERA-5':'az://scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-131793962/out.zarr'}, 
             'fine': {'bias_corrected': {'historical': 'az://scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-1362934973/regridded.zarr', 
                                         ssp: 'az://scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-377595554/regridded.zarr'}, 
                      'downscaled': {'historical': 'az://downscaled-stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr', 
                                     ssp: 'az://downscaled-stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr'}, 
                      'ERA-5_fine': 'az://scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-491178896/rechunked.zarr', 
                      'ERA-5_coarse': 'az://scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-1213790070/rechunked.zarr'}}
```

We can also use a yaml file and list the parameters in that and feed it in with 

```
papermill path/to/global_validation_papermill.ipynb gcsbucket/path/ -f parameters.yaml
```