### PR TITLE
Add automated QC/validation checks to major workflow outputs

### DIFF
--- a/workflows/templates/biascorrectdownscale.yaml
+++ b/workflows/templates/biascorrectdownscale.yaml
@@ -340,6 +340,22 @@ spec:
                   value: "{{ inputs.parameters.first-year }}"
                 - name: last-year
                   value: "{{ inputs.parameters.last-year }}"
+          - name: validate-biascorrected
+            depends: qdm
+            templateRef:
+              name: qualitycontrol-check-cmip6
+              template: qualitycontrol-check-cmip6
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ tasks.qdm.outputs.parameters.out-zarr }}"
+                - name: variable
+                  value: "{{=jsonpath(inputs.parameters.simulation, '$.variable_id')}}"
+                - name: data
+                  value: "bias_corrected"
+                - name: time
+                  value: >-
+                    {{=jsonpath(inputs.parameters.simulation, '$.experiment_id') == 'historical' ? 'historical' : 'future'}}
           - name: preprocess-biascorrected
             template: preprocess-biascorrected
             depends: qdm
@@ -390,6 +406,22 @@ spec:
             withSequence:
               start: "0"
               end: "359"
+          - name: validate-downscaled
+            depends: aiqpd && prime-aiqpd-biascorrected-output-zarr
+            templateRef:
+              name: qualitycontrol-check-cmip6
+              template: qualitycontrol-check-cmip6
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ tasks.prime-aiqpd-biascorrected-output-zarr.outputs.parameters.out-zarr }}"
+                - name: variable
+                  value: "{{=jsonpath(inputs.parameters.simulation, '$.variable_id')}}"
+                - name: data
+                  value: "downscaled"
+                - name: time
+                  value: >-
+                    {{=jsonpath(inputs.parameters.simulation, '$.experiment_id') == 'historical' ? 'historical' : 'future'}}
 
 
       # Regridding and rechunking required for GCM simulations before bias correction.

--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -269,6 +269,20 @@ spec:
                   value: "{{ steps.remove-late-ssp.outputs.parameters.out-zarr }}"
                 - name: out-zarr
                   value: "{{ steps.get-output-clean-historical-url.outputs.parameters.out-url }}"
+        - - name: validate-historical
+            templateRef:
+              name: qualitycontrol-check-cmip6
+              template: qualitycontrol-check-cmip6
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ steps.get-output-clean-historical-url.outputs.parameters.out-url }}"
+                - name: variable
+                  value: "{{=jsonpath(inputs.parameters['target-json'], '$.variable_id')}}"
+                - name: data
+                  value: "cmip6"
+                - name: time
+                  value: "historical"
 
 
     - name: process-ssp
@@ -330,6 +344,20 @@ spec:
                   value: "{{ steps.remove-early-historical.outputs.parameters.out-zarr }}"
                 - name: out-zarr
                   value: "{{ steps.get-output-clean-ssp-url.outputs.parameters.out-url }}"
+        - - name: validate-ssp
+            templateRef:
+              name: qualitycontrol-check-cmip6
+              template: qualitycontrol-check-cmip6
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ steps.get-output-clean-ssp-url.outputs.parameters.out-url }}"
+                - name: variable
+                  value: "{{=jsonpath(inputs.parameters['target-json'], '$.variable_id')}}"
+                - name: data
+                  value: "cmip6"
+                - name: time
+                  value: "future"
 
 
     - name: standardize-cmip6


### PR DESCRIPTION
Adds steps to clean-cmip6 and downscalebiascorrect workflowTemplates so that qualitycontrol-check-cmip6 is run on output for

- cleaned historical CMIP6 output
- cleaned "future" (SSP) CMIP6 output
- biascorrected output
- downscaled output