### PR TITLE
Pin all dodola:dev image refs to new dodola:0.7.0 release

### DIFF
--- a/workflows/templates/biascorrectdownscale.yaml
+++ b/workflows/templates/biascorrectdownscale.yaml
@@ -831,7 +831,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
         env:
           - name: ARGO_WORKFLOW_NAME
             value: "{{ workflow.name }}"
@@ -975,7 +975,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
         command: [ python ]
         source: |
           import os
@@ -1043,7 +1043,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
         command: [ python ]
         source: |
           import dask.delayed
@@ -1286,7 +1286,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
         command: [ python ]
         source: |
           import os
@@ -1370,7 +1370,7 @@ spec:
           - name: out-zarr
             value: "gs://scratch-170cd6ec/{{ workflow.name }}/{{ pod.name }}/aiqpd_adjusted.zarr"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
         command: [ python ]
         source: |
           import dodola.repository
@@ -1467,7 +1467,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
         env:
           - name: ARGO_WORKFLOW_NAME
             value: "{{ workflow.name }}"

--- a/workflows/templates/distributed-regrid.yaml
+++ b/workflows/templates/distributed-regrid.yaml
@@ -100,7 +100,7 @@ spec:
             valueFrom:
               path: "/tmp/lastyear.txt"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -200,7 +200,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"

--- a/workflows/templates/qualitycontrol-check-cmip6.yaml
+++ b/workflows/templates/qualitycontrol-check-cmip6.yaml
@@ -41,7 +41,7 @@ spec:
           - name: data
           - name: time
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
         command: [python]
         source: |
           import dask

--- a/workflows/templates/regrid.yaml
+++ b/workflows/templates/regrid.yaml
@@ -25,7 +25,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
         command: [ "dodola" ]
         args:
           - "regrid"


### PR DESCRIPTION
We have a new v0.7.0 release of dodola and lots of workflow steps using the older `dev` image. This PR pins all those floating dev image references to the 0.7.0 release.