### PR TITLE
Fix apply-aiqpd OOM, bad coordinate error with dodola v0.7.0

### DIFF
--- a/workflows/templates/biascorrectdownscale.yaml
+++ b/workflows/templates/biascorrectdownscale.yaml
@@ -1415,7 +1415,6 @@ spec:
               variable=variable
           )
 
-          downscaled_ds = downscaled_ds.reset_coords(["sim_q"], drop=True)
           if nonlat_variables:
               downscaled_ds = downscaled_ds.drop_vars(nonlat_variables)
 

--- a/workflows/templates/biascorrectdownscale.yaml
+++ b/workflows/templates/biascorrectdownscale.yaml
@@ -1441,7 +1441,7 @@ spec:
             memory: 24Gi
             cpu: "1000m"
           limits:
-            memory: 24Gi
+            memory: 38Gi
             cpu: "6000m"
       activeDeadlineSeconds: 900
       retryStrategy:


### PR DESCRIPTION
This fixes OOM errors and exceptions about dropping non-existant coordinates in the `apply-qdm` step of `workflows/templates/biascorrectdownscale.yaml`.

We had these errors pop up since we upgraded the step to `us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0`