### PR TITLE
Fix potentially non-unique argo scratch paths

### DIFF
--- a/infrastructure/kubernetes-az/argo/patches/workflow-controller-configmap.yaml
+++ b/infrastructure/kubernetes-az/argo/patches/workflow-controller-configmap.yaml
@@ -54,7 +54,7 @@ data:
       secretKeySecret:
         name: artifactrepocreds-secret
         key: secretkey
-      keyFormat: "{{workflow.name}}/{{pod.name}}"
+      keyFormat: "{{workflow.uid}}/{{pod.name}}"
 
   sso: |
     issuer: https://login.microsoftonline.com/e26d3ccf-6270-4235-94ec-857966b171c1/v2.0

--- a/infrastructure/kubernetes-gcp/argo/patches/workflow-controller-configmap.yaml
+++ b/infrastructure/kubernetes-gcp/argo/patches/workflow-controller-configmap.yaml
@@ -62,7 +62,7 @@ data:
     archiveLogs: true
     gcs:
       bucket: scratch-170cd6ec
-      keyFormat: "{{workflow.name}}/{{pod.name}}"
+      keyFormat: "{{workflow.uid}}/{{pod.name}}"
 
   persistence: |
     connectionPool:

--- a/workflows/templates/aiqpd.yaml
+++ b/workflows/templates/aiqpd.yaml
@@ -20,7 +20,7 @@ spec:
       - name: reference-zarr
         value: "gs://clean-b1dbca25/reanalysis/ERA-5/F320/tasmax.1995-2015.F320.zarr"
       - name: out-zarr
-        value: "gs://scratch-170cd6ec/{{ workflow.name }}/{{ pod.name }}/downscaled.zarr"
+        value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/downscaled.zarr"
       - name: regrid-method
         value: "bilinear"
       - name: qdm-kind
@@ -389,7 +389,7 @@ spec:
           - name: time-sel-stop
             value: "2015-01-15"
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.name }}/{{ pod.name }}/aiqpd-model.zarr"
+            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/aiqpd-model.zarr"
       outputs:
         parameters:
           - name: out-zarr
@@ -477,7 +477,7 @@ spec:
           - name: lat-slice-min
           - name: lat-slice-max
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.name }}/{{ pod.name }}/aiqpd_adjusted.zarr"
+            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/aiqpd_adjusted.zarr"
       script:
         image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
         command: [ python ]
@@ -567,7 +567,7 @@ spec:
           - name: simulation-zarr
           - name: variable
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.name }}/{{ pod.name }}/downscaled.zarr"
+            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/downscaled.zarr"
           - name: nonlat-variables
             value: "time lon"
       outputs:

--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -365,7 +365,7 @@ spec:
         parameters:
           - name: in-zarr
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.name }}/{{ pod.name }}/standardized.zarr"
+            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/standardized.zarr"
       outputs:
         parameters:
           - name: out-zarr
@@ -400,7 +400,7 @@ spec:
           - name: from-time
           - name: to-time
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.name }}/{{ pod.name }}/timesliced.zarr"
+            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/timesliced.zarr"
       outputs:
         parameters:
           - name: out-zarr
@@ -467,7 +467,7 @@ spec:
           - name: in1-zarr
           - name: in2-zarr
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.name }}/{{ pod.name }}/concatenated.zarr"
+            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/concatenated.zarr"
       outputs:
         parameters:
           - name: out-zarr

--- a/workflows/templates/distributed-regrid.yaml
+++ b/workflows/templates/distributed-regrid.yaml
@@ -88,7 +88,7 @@ spec:
           - name: nontime-variables
             value: "lat lon"
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.name }}/{{ pod.name }}/regridded.zarr"
+            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/regridded.zarr"
       outputs:
         parameters:
           - name: out-zarr

--- a/workflows/templates/qdm.yaml
+++ b/workflows/templates/qdm.yaml
@@ -102,7 +102,7 @@ spec:
         parameters:
           - name: in-zarr
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.name }}/{{ pod.name }}/preprocessed.zarr"
+            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/preprocessed.zarr"
           - name: regrid-method
           - name: domain-file
           - name: correct-wetday-frequency
@@ -322,7 +322,7 @@ spec:
           - name: first-year
           - name: last-year
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.name }}/{{ pod.name }}/qdm_adjusted.zarr"
+            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/qdm_adjusted.zarr"
           - name: include-quantiles
             value: "false"
       outputs:
@@ -410,7 +410,7 @@ spec:
           - name: lat-slice-max
           - name: kind
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.name }}/{{ pod.name }}/qdm_model.zarr"
+            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/qdm_model.zarr"
       outputs:
         parameters:
           - name: out-zarr
@@ -456,7 +456,7 @@ spec:
           - name: include-quantiles
             value: "true"
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.name }}/{{ pod.name }}/qdm_adjusted.zarr"
+            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/qdm_adjusted.zarr"
       outputs:
         parameters:
           - name: out-zarr

--- a/workflows/templates/rechunk.yaml
+++ b/workflows/templates/rechunk.yaml
@@ -17,7 +17,7 @@ spec:
         parameters:
           - name: in-zarr
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.name }}/{{ pod.name }}/rechunked.zarr"
+            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/rechunked.zarr"
           - name: time-chunk
             value: 365
           - name: lat-chunk

--- a/workflows/templates/regrid.yaml
+++ b/workflows/templates/regrid.yaml
@@ -17,7 +17,7 @@ spec:
         parameters:
           - name: in-zarr
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.name }}/{{ pod.name }}/out.zarr"
+            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/out.zarr"
           - name: regrid-method
           - name: domain-file
       outputs:


### PR DESCRIPTION
Fixes the possibility of having intermediate scratch output clashing due to forced workflow name. This fix is to use the workflow UID instead, which is guaranteed to be unique.

This might cause some problems accessing archived logs stored in the scratch bucket.
