### PR TITLE
Swap QDM workflow scripts for dodola commands

### DIFF
--- a/workflows/templates/qdm.yaml
+++ b/workflows/templates/qdm.yaml
@@ -348,70 +348,23 @@ spec:
           - name: last-year
           - name: out-zarr
             value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/qdm_adjusted.zarr"
-          - name: include-quantiles
-            value: "false"
       outputs:
         parameters:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
-      script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
-        env:
-          - name: ARGO_WORKFLOW_NAME
-            value: "{{ workflow.name }}"
-          - name: ARGO_WORKFLOW_UID
-            value: "{{ workflow.uid }}"
-          - name: DC6_VERSION_ID
-            value: "v{{workflow.creationTimestamp.Y}}{{workflow.creationTimestamp.m}}{{workflow.creationTimestamp.d}}{{workflow.creationTimestamp.H}}{{workflow.creationTimestamp.M}}{{workflow.creationTimestamp.S}}"
-        command: [ python ]
-        source: |
-          import os
-          import dodola.repository
-          import xarray as xr
-
-          nonlat_variables = ["lon", "time"]
-          quantiles_variable = "sim_q"
-
-          simulation_zarr = "{{ inputs.parameters.simulation-zarr }}"
-          qdm_out_zarr = "{{ inputs.parameters.out-zarr }}"
-          first_year = int({{ inputs.parameters.first-year }})
-          last_year = int({{ inputs.parameters.last-year }})
-          variable = "{{ inputs.parameters.variable }}"
-          include_quantiles = "{{ inputs.parameters.include-quantiles }}".lower() == "true"
-          print(f"{include_quantiles=}")  # DEBUG
-
-          timeslice = slice(str(first_year), str(last_year))  # This is inclusive!
-
-          primed_out = dodola.repository.read(simulation_zarr).sel(time=timeslice).chunk({"time": 73, "lat": 10, "lon":180})
-          if include_quantiles:
-              primed_out[quantiles_variable] = xr.zeros_like(primed_out[variable])
-
-          # Add downscaling metadata to attrs
-          primed_out.attrs["dc6_workflow_name"] = os.environ["ARGO_WORKFLOW_NAME"]
-          primed_out.attrs["dc6_workflow_uid"] = os.environ["ARGO_WORKFLOW_UID"]
-          primed_out.attrs["dc6_version_id"] = os.environ["DC6_VERSION_ID"]
-
-          print(f"{primed_out=}")  # DEBUG
-
-          primed_out.to_zarr(
-              qdm_out_zarr,
-              mode="w",
-              compute=False,
-              consolidated=True,
-              safe_chunks=False
-          )
-          print(f"Output written to {qdm_out_zarr}")  # DEBUG
-
-          # Append variables that do not depend on "lat"
-          if nonlat_variables:
-              primed_out[nonlat_variables].to_zarr(
-                  qdm_out_zarr,
-                  mode="a",
-                  compute=True,
-                  consolidated=True,
-                  safe_chunks=False
-              )
-              print(f"Non-latitude variables written to to {qdm_out_zarr}")  # DEBUG
+      container:
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        command: [ dodola ]
+        args:
+          - "prime-qdm-output-zarrstore"
+          - "--simulation={{ inputs.parameters.simulation-zarr }}"
+          - "--variable={{ inputs.parameters.variable }}"
+          - "--years={{ inputs.parameters.first-year }},{{ inputs.parameters.last-year }}"
+          - "--out={{ inputs.parameters.out-zarr }}"
+          - "--zarr-region-dims=lat"
+          - "--new-attrs=dc6_workflow_name={{ workflow.name }}"
+          - "--new-attrs=dc6_workflow_uid={{ workflow.uid }}"
+          - "--new-attrs=dc6_version_id=v{{workflow.creationTimestamp.Y}}{{workflow.creationTimestamp.m}}{{workflow.creationTimestamp.d}}{{workflow.creationTimestamp.H}}{{workflow.creationTimestamp.M}}{{workflow.creationTimestamp.S}}"
         resources:
           requests:
             memory: 4Gi
@@ -450,8 +403,7 @@ spec:
           - "--reference={{ inputs.parameters.ref-zarr }}"
           - "--out={{ inputs.parameters.out-zarr }}"
           - "--kind={{ inputs.parameters.kind }}"
-          - "--iselslice"
-          - "lat={{ inputs.parameters.lat-slice-min }},{{ inputs.parameters.lat-slice-max }}"
+          - "--iselslice=lat={{ inputs.parameters.lat-slice-min }},{{ inputs.parameters.lat-slice-max }}"
         resources:
           requests:
             memory: 24Gi
@@ -478,78 +430,27 @@ spec:
           - name: last-year
           - name: lat-slice-min
           - name: lat-slice-max
-          - name: include-quantiles
-            value: "true"
           - name: out-zarr
             value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/qdm_adjusted.zarr"
       outputs:
         parameters:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
-      script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
-        command: [ python ]
-        source: |
-          import dask.delayed
-          import dodola.repository
-          from dodola.core import adjust_quantiledeltamapping_year
-          import xarray as xr
-
-          nonlat_variables = ["lon", "time"]
-          quantile_variable = "sim_q"
-
-          qdm_zarr = "{{ inputs.parameters.qdm-zarr }}"
-          simulation_zarr = "{{ inputs.parameters.simulation-zarr }}"
-          qdm_out_zarr = "{{ inputs.parameters.out-zarr }}"
-          min_slice = int({{ inputs.parameters.lat-slice-min }})
-          max_slice = int({{ inputs.parameters.lat-slice-max }})
-          first_year = int({{ inputs.parameters.first-year }})
-          last_year = int({{ inputs.parameters.last-year }})
-          variable = "{{ inputs.parameters.variable }}"
-          include_quantiles = "{{ inputs.parameters.include-quantiles }}".lower() == "true"
-          print(f"{include_quantiles=}")  # DEBUG
-
-          latslice = slice(min_slice, max_slice)
-
-          print(f"slicing({min_slice}, {max_slice})")  # DEBUG
-
-          qdm = dodola.repository.read(qdm_zarr)
-          simulation = dodola.repository.read(simulation_zarr).isel(lat=latslice)
-
-          qdm.load()
-          simulation.load()
-
-          # TODO: Return this to dask.delayeds instead of raw for loops.
-          qdm_list = []
-          for year in range(first_year, last_year + 1):
-              adj = adjust_quantiledeltamapping_year(
-                  simulation=simulation,
-                  qdm=qdm,
-                  year=year,
-                  variable=variable,
-                  include_quantiles=include_quantiles
-              )
-              qdm_list.append(adj.astype("float32"))
-
-          out_all_years = xr.concat(qdm_list, dim="time")
-          out_all_years = out_all_years.reset_coords(quantile_variable)
-
-          if nonlat_variables:
-              out_all_years = out_all_years.drop_vars(nonlat_variables)
-
-          out_all_years = out_all_years.transpose("time", "lat", "lon")
-
-          with xr.open_zarr(qdm_out_zarr) as out_store:
-              out_all_years.attrs |= out_store.attrs
-              for k, v in out_store.variables.items():
-                  if k in out_all_years:
-                      out_all_years[k].attrs |= v.attrs
-
-          print(f"{out_all_years=}")  # DEBUG
-
-          # Output to region of existing zarr store.
-          out_all_years.to_zarr(qdm_out_zarr, region={"lat": latslice}, mode="a")
-          print(f"Output written to {qdm_out_zarr}")  # DEBUG
+      container:
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        command: [ dodola ]
+        args:
+          - "apply-qdm"
+          - "--simulation={{ inputs.parameters.simulation-zarr}}"
+          - "--qdm={{ inputs.parameters.qdm-zarr}}"
+          - "--years={{ inputs.parameters.first-year }},{{ inputs.parameters.last-year }}"
+          - "--variable={{ inputs.parameters.variable }}"
+          - "--out={{ inputs.parameters.out-zarr }}"
+          - "--iselslice=lat={{ inputs.parameters.lat-slice-min }},{{ inputs.parameters.lat-slice-max }}"
+          - "--out-zarr-region=lat={{ inputs.parameters.lat-slice-min }},{{ inputs.parameters.lat-slice-max }}"
+          - "--new-attrs=dc6_workflow_name={{ workflow.name }}"
+          - "--new-attrs=dc6_workflow_uid={{ workflow.uid }}"
+          - "--new-attrs=dc6_version_id=v{{workflow.creationTimestamp.Y}}{{workflow.creationTimestamp.m}}{{workflow.creationTimestamp.d}}{{workflow.creationTimestamp.H}}{{workflow.creationTimestamp.M}}{{workflow.creationTimestamp.S}}"
         resources:
           requests:
             memory: 32Gi

--- a/workflows/templates/qdm.yaml
+++ b/workflows/templates/qdm.yaml
@@ -10,6 +10,31 @@ metadata:
   labels:
     component: biascorrect
 spec:
+  entrypoint: main
+  arguments:
+    parameters:
+      - name: simulation-zarr
+        value: "gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20180701.zarr"
+      - name: variable-id
+        value: "tasmax"
+      - name: training-zarr
+        value: "gs://clean-b1dbca25/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/training/r1i1p1f1/day/tasmax/gr1/v20190726.zarr"
+      - name: reference-zarr
+        value: "gs://clean-b1dbca25/reanalysis/ERA-5/F320/tasmax.1995-2015.F320.zarr"
+      - name: out-zarr
+        value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/biascorrected.zarr"
+      - name: regrid-method
+        value: "bilinear"
+      - name: qdm-kind
+        value: "additive"
+      - name: domainfile1x1
+        value: "gs://support-c23ff1a3/domain.1x1.zarr"
+      - name: correct-wetday-frequency
+        value: "false"
+      - name: first-year
+        value: 2015
+      - name: last-year
+        value: 2100
   templates:
 
     - name: main


### PR DESCRIPTION
This swaps the qdm-apply and output priming scripts in `workflows/templates/qdm.yaml` for newly added dodola commands (from https://github.com/ClimateImpactLab/dodola/pull/129).

This consolidates QDM logic, makes workflows a bit more simple, and should make it easier to test key points in the workflow (in dodola, not here).

These steps in the workflow still depend on dev and have not been released. Consider these prototypes.

This PR also adds example input parameters to test the qdm workflowtemplate.