### PR TITLE
Upgrade all workflow dodola images to v0.8.0 release

### DIFF
--- a/workflows/templates/catalog.yaml
+++ b/workflows/templates/catalog.yaml
@@ -24,7 +24,7 @@ spec:
             valueFrom:
               path: "/tmp/url.txt"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.6.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         command: [ python ]
         source: |
           import dodola.repository as storage
@@ -84,7 +84,7 @@ spec:
             valueFrom:
               path: "/tmp/url.txt"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.6.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         command: [ python ]
         source: |
           base_url = "{{ inputs.parameters.base-url }}"

--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -371,7 +371,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.5.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         command: [ "dodola" ]
         args:
           - "cleancmip6"
@@ -406,7 +406,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.5.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -473,7 +473,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.5.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         env:
           - name: IN1_ZARR
             value: "{{ inputs.parameters.in1-zarr }}"

--- a/workflows/templates/clean-era5.yaml
+++ b/workflows/templates/clean-era5.yaml
@@ -43,7 +43,7 @@ spec:
       - name: out-zarr
         value: "{{ inputs.parameters.out-zarr }}"
     container:
-      image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.5.0
+      image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
       env:
       - name: IN_ZARR
         value: "{{  inputs.parameters.in-zarr }}"
@@ -89,7 +89,7 @@ spec:
       - name: out-zarr
         value: "{{ inputs.parameters.out-zarr }}"
     script:
-      image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.5.0
+      image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
       env:
       - name: IN_ZARR
         value: "{{  inputs.parameters.in-zarr }}"

--- a/workflows/templates/distributed-regrid.yaml
+++ b/workflows/templates/distributed-regrid.yaml
@@ -100,7 +100,7 @@ spec:
             valueFrom:
               path: "/tmp/lastyear.txt"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -200,7 +200,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"

--- a/workflows/templates/download-cmip6.yaml
+++ b/workflows/templates/download-cmip6.yaml
@@ -182,7 +182,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-url }}"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.6.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         env:
           - name: ACTIVITY_ID
             value: "{{inputs.parameters.activity-id}}"

--- a/workflows/templates/qdm.yaml
+++ b/workflows/templates/qdm.yaml
@@ -353,7 +353,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         command: [ dodola ]
         args:
           - "prime-qdm-output-zarrstore"
@@ -394,7 +394,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         command: [ "dodola" ]
         args:
           - "train-qdm"
@@ -437,7 +437,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         command: [ dodola ]
         args:
           - "apply-qdm"

--- a/workflows/templates/qdm.yaml
+++ b/workflows/templates/qdm.yaml
@@ -138,7 +138,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         command: [ python ]
         source: |
           import logging

--- a/workflows/templates/qplad.yaml
+++ b/workflows/templates/qplad.yaml
@@ -395,7 +395,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         command: [ dodola ]
         args:
           - "train-qplad"
@@ -435,7 +435,7 @@ spec:
           - name: out-zarr
             value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/qplad_adjusted.zarr"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         command: [ dodola ]
         args:
           - "apply-qplad"
@@ -477,7 +477,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         command: [ dodola ]
         args:
           - "prime-qplad-output-zarrstore"

--- a/workflows/templates/qualitycontrol-check-cmip6.yaml
+++ b/workflows/templates/qualitycontrol-check-cmip6.yaml
@@ -40,7 +40,7 @@ spec:
           - name: data
           - name: time
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         command: [python]
         source: |
           import dask

--- a/workflows/templates/rechunk.yaml
+++ b/workflows/templates/rechunk.yaml
@@ -31,7 +31,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.5.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         command: [ dodola ]
         args:
           - "rechunk"

--- a/workflows/templates/regrid.yaml
+++ b/workflows/templates/regrid.yaml
@@ -25,7 +25,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.7.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         command: [ "dodola" ]
         args:
           - "regrid"

--- a/workflows/templates/zarr-transfer.yaml
+++ b/workflows/templates/zarr-transfer.yaml
@@ -31,7 +31,7 @@ spec:
           secret:
             secretName: gcp-cil-scratch-sa
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.5.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
         volumeMounts:
           - name: gcpkey
             mountPath: "/mnt/gcp-sa"


### PR DESCRIPTION
This upgrades all argo workflow dodola images to the recent v0.8.0 release.

This is important for workflow steps previously at `dev`, because now they're pinned to a stable release. Other images are upgrade because v0.8.0 includes logging improvements, which are a helpful addition all around.