### PR TITLE
Switch workflow QDM and QPLAD to set output metadata with JSON

### DIFF
--- a/workflows/templates/qdm.yaml
+++ b/workflows/templates/qdm.yaml
@@ -234,7 +234,18 @@ spec:
               parameter: "{{ tasks.prime-qdm-output-zarrstore.outputs.parameters.out-zarr }}"
       dag:
         tasks:
+          - name: create-qdm-output-metadata
+            templateRef:
+              name: create-output-metadata-json
+              template: create-output-metadata-json
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ inputs.parameters.simulation-zarr }}"
+                - name: workflowstep
+                  value: biascorrect
           - name: prime-qdm-output-zarrstore
+            depends: "create-qdm-output-metadata"
             template: prime-qdm-output-zarrstore
             arguments:
               parameters:
@@ -248,8 +259,11 @@ spec:
                   value: "{{ inputs.parameters.last-year }}"
                 - name: include-quantiles
                   value: "{{ inputs.parameters.include-quantiles }}"
+              artifacts:
+                - name: global-attrs-json
+                  from: "{{ tasks.create-qdm-output-metadata.outputs.artifacts.global-attrs-json }}"
           - name: with-lat-chunk
-            depends: "prime-qdm-output-zarrstore"
+            depends: "prime-qdm-output-zarrstore && create-qdm-output-metadata"
             template: with-lat-chunk
             arguments:
               parameters:
@@ -276,6 +290,9 @@ spec:
                   value: "{{=asInt(item) * 10 }}"
                 - name: lat-slice-max
                   value: "{{=asInt(item) * 10 + 10 }}"
+              artifacts:
+                - name: global-attrs-json
+                  from: "{{ tasks.create-qdm-output-metadata.outputs.artifacts.global-attrs-json }}"
             withSequence:
               start: "0"
               end: "17"
@@ -295,6 +312,8 @@ spec:
           - name: last-year
           - name: include-quantiles
           - name: out-zarr
+        artifacts:
+          - name: global-attrs-json
       dag:
         tasks:
           - name: train-qdm
@@ -338,6 +357,10 @@ spec:
                   value: "{{ inputs.parameters.include-quantiles }}"
                 - name: out-zarr
                   value: "{{ inputs.parameters.out-zarr }}"
+              artifacts:
+                - name: global-attrs-json
+                  from: "{{ inputs.artifacts.global-attrs-json }}"
+
 
     - name: prime-qdm-output-zarrstore
       inputs:
@@ -348,12 +371,15 @@ spec:
           - name: last-year
           - name: out-zarr
             value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/qdm_adjusted.zarr"
+        artifacts:
+          - name: global-attrs-json
+            path: /tmp/global_attrs.json
       outputs:
         parameters:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
         command: [ dodola ]
         args:
           - "prime-qdm-output-zarrstore"
@@ -362,9 +388,7 @@ spec:
           - "--years={{ inputs.parameters.first-year }},{{ inputs.parameters.last-year }}"
           - "--out={{ inputs.parameters.out-zarr }}"
           - "--zarr-region-dims=lat"
-          - "--new-attrs=dc6_workflow_name={{ workflow.name }}"
-          - "--new-attrs=dc6_workflow_uid={{ workflow.uid }}"
-          - "--new-attrs=dc6_version_id=v{{workflow.creationTimestamp.Y}}{{workflow.creationTimestamp.m}}{{workflow.creationTimestamp.d}}{{workflow.creationTimestamp.H}}{{workflow.creationTimestamp.M}}{{workflow.creationTimestamp.S}}"
+          - "--root-attrs-json-file=/tmp/global_attrs.json"
         resources:
           requests:
             memory: 4Gi
@@ -432,12 +456,15 @@ spec:
           - name: lat-slice-max
           - name: out-zarr
             value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/qdm_adjusted.zarr"
+        artifacts:
+          - name: global-attrs-json
+            path: /tmp/global_attrs.json
       outputs:
         parameters:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
         command: [ dodola ]
         args:
           - "apply-qdm"
@@ -448,9 +475,7 @@ spec:
           - "--out={{ inputs.parameters.out-zarr }}"
           - "--iselslice=lat={{ inputs.parameters.lat-slice-min }},{{ inputs.parameters.lat-slice-max }}"
           - "--out-zarr-region=lat={{ inputs.parameters.lat-slice-min }},{{ inputs.parameters.lat-slice-max }}"
-          - "--new-attrs=dc6_workflow_name={{ workflow.name }}"
-          - "--new-attrs=dc6_workflow_uid={{ workflow.uid }}"
-          - "--new-attrs=dc6_version_id=v{{workflow.creationTimestamp.Y}}{{workflow.creationTimestamp.m}}{{workflow.creationTimestamp.d}}{{workflow.creationTimestamp.H}}{{workflow.creationTimestamp.M}}{{workflow.creationTimestamp.S}}"
+          - "--root-attrs-json-file=/tmp/global_attrs.json"
         resources:
           requests:
             memory: 32Gi

--- a/workflows/templates/qplad.yaml
+++ b/workflows/templates/qplad.yaml
@@ -356,8 +356,6 @@ spec:
           - name: out-zarr
         artifacts:
           - name: global-attrs-json
-      # Avoid overwhelming Google Cloud Storage API quotas for single object.
-      parallelism: 180
       steps:
         - - name: train-qplad
             template: train-qplad

--- a/workflows/templates/qplad.yaml
+++ b/workflows/templates/qplad.yaml
@@ -356,6 +356,8 @@ spec:
           - name: out-zarr
         artifacts:
           - name: global-attrs-json
+      # Avoid overwhelming Google Cloud Storage API quotas for single object.
+      parallelism: 180
       steps:
         - - name: train-qplad
             template: train-qplad

--- a/workflows/templates/qplad.yaml
+++ b/workflows/templates/qplad.yaml
@@ -290,6 +290,16 @@ spec:
             valueFrom:
               parameter: "{{ steps.prime-qplad-output-zarr.outputs.parameters.out-zarr }}"
       steps:
+        - - name: create-qplad-output-metadata
+            templateRef:
+              name: create-output-metadata-json
+              template: create-output-metadata-json
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ inputs.parameters.simulation-zarr }}"
+                - name: workflowstep
+                  value: downscale
         - - name: prime-qplad-output-zarr
             template: prime-qplad-output-zarr
             arguments:
@@ -300,6 +310,9 @@ spec:
                   value: "{{ inputs.parameters.variable-id}}"
                 - name: out-zarr
                   value: "{{ inputs.parameters.out-zarr }}"
+              artifacts:
+                - name: global-attrs-json
+                  from: "{{ steps.create-qplad-output-metadata.outputs.artifacts.global-attrs-json }}"
         - - name: with-lat-chunk
             template: with-lat-chunk
             arguments:
@@ -321,6 +334,9 @@ spec:
                   value: "{{=asInt(item) * 2 }}"
                 - name: lat-slice-max
                   value: "{{=asInt(item) * 2 + 2 }}"
+              artifacts:
+                - name: global-attrs-json
+                  from: "{{ steps.create-qplad-output-metadata.outputs.artifacts.global-attrs-json }}"
             # Also, looping over 2 pixel chunk latitude bands:
             withSequence:
               start: "0"
@@ -338,6 +354,8 @@ spec:
           - name: lat-slice-min
           - name: lat-slice-max
           - name: out-zarr
+        artifacts:
+          - name: global-attrs-json
       steps:
         - - name: train-qplad
             template: train-qplad
@@ -373,6 +391,9 @@ spec:
                   value: "{{ inputs.parameters.lat-slice-max }}"
                 - name: out-zarr
                   value: "{{ inputs.parameters.out-zarr }}"
+              artifacts:
+                - name: global-attrs-json
+                  from: "{{ inputs.artifacts.global-attrs-json }}"
 
 
     - name: train-qplad
@@ -434,8 +455,11 @@ spec:
           - name: lat-slice-max
           - name: out-zarr
             value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/qplad_adjusted.zarr"
+        artifacts:
+          - name: global-attrs-json
+            path: /tmp/global_attrs.json
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
         command: [ dodola ]
         args:
           - "apply-qplad"
@@ -445,9 +469,7 @@ spec:
           - "--out={{ inputs.parameters.out-zarr }}"
           - "--iselslice=lat={{ inputs.parameters.lat-slice-min }},{{ inputs.parameters.lat-slice-max }}"
           - "--out-zarr-region=lat={{ inputs.parameters.lat-slice-min }},{{ inputs.parameters.lat-slice-max }}"
-          - "--new-attrs=dc6_workflow_name={{ workflow.name }}"
-          - "--new-attrs=dc6_workflow_uid={{ workflow.uid }}"
-          - "--new-attrs=dc6_version_id=v{{workflow.creationTimestamp.Y}}{{workflow.creationTimestamp.m}}{{workflow.creationTimestamp.d}}{{workflow.creationTimestamp.H}}{{workflow.creationTimestamp.M}}{{workflow.creationTimestamp.S}}"
+          - "--root-attrs-json-file=/tmp/global_attrs.json"
         resources:
           requests:
             memory: 38Gi
@@ -472,12 +494,15 @@ spec:
           - name: variable
           - name: out-zarr
             value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/downscaled.zarr"
+        artifacts:
+          - name: global-attrs-json
+            path: /tmp/global_attrs.json
       outputs:
         parameters:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
         command: [ dodola ]
         args:
           - "prime-qplad-output-zarrstore"
@@ -485,9 +510,7 @@ spec:
           - "--variable={{ inputs.parameters.variable }}"
           - "--out={{ inputs.parameters.out-zarr }}"
           - "--zarr-region-dims=lat"
-          - "--new-attrs=dc6_workflow_name={{ workflow.name }}"
-          - "--new-attrs=dc6_workflow_uid={{ workflow.uid }}"
-          - "--new-attrs=dc6_version_id=v{{workflow.creationTimestamp.Y}}{{workflow.creationTimestamp.m}}{{workflow.creationTimestamp.d}}{{workflow.creationTimestamp.H}}{{workflow.creationTimestamp.M}}{{workflow.creationTimestamp.S}}"
+          - "--root-attrs-json-file=/tmp/global_attrs.json"
         resources:
           requests:
             memory: 4Gi


### PR DESCRIPTION
Under this PR output from QDM and QPLAD steps will have metadata set by a JSON file created in a new workflow step (using WorkflowTemplate from #319).

This JSON file includes recent updates to output metadata (Close #179 ).