### PR TITLE
Pin QDM, QPLAD templates to dodola:0.9.0 for metadata improvements

### DIFF
--- a/workflows/templates/qdm.yaml
+++ b/workflows/templates/qdm.yaml
@@ -379,7 +379,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.9.0
         command: [ dodola ]
         args:
           - "prime-qdm-output-zarrstore"
@@ -418,7 +418,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.9.0
         command: [ "dodola" ]
         args:
           - "train-qdm"
@@ -464,7 +464,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.9.0
         command: [ dodola ]
         args:
           - "apply-qdm"

--- a/workflows/templates/qplad.yaml
+++ b/workflows/templates/qplad.yaml
@@ -416,7 +416,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.9.0
         command: [ dodola ]
         args:
           - "train-qplad"
@@ -459,7 +459,7 @@ spec:
           - name: global-attrs-json
             path: /tmp/global_attrs.json
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.9.0
         command: [ dodola ]
         args:
           - "apply-qplad"
@@ -502,7 +502,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.9.0
         command: [ dodola ]
         args:
           - "prime-qplad-output-zarrstore"


### PR DESCRIPTION
Pins floating dodola:dev containers to dodola:0.9.0 in QDM and QPLAD workflowtemplates. This version includes needed metadata improvements and passing that we were previously getting from development releases.