### PR TITLE
Promote e2e-tasmax into e2e-tasmax-jobs template, refactor parameters

### DIFF
--- a/workflows/templates/biascorrectdownscale.yaml
+++ b/workflows/templates/biascorrectdownscale.yaml
@@ -43,9 +43,9 @@ spec:
           ]
       - name: regrid-method
         value: "bilinear"
-      - name: correct-wetday-frequency  # "true" or "false" STRING!
+      - name: correct-wetday-frequency
         value: "false"
-      - name: qdm-kind #additive or multiplicative
+      - name: qdm-kind
         value: "additive"
   templates:
 
@@ -55,6 +55,9 @@ spec:
       inputs:
         parameters:
           - name: jobs
+          - name: regrid-method
+          - name: correct-wetday-frequency  # "true" or "false" STRING!
+          - name: qdm-kind  # additive or multiplicative
       steps:
         - - name: parameterize
             template: parameterize
@@ -66,6 +69,12 @@ spec:
                   value: "{{ item.historical }}"
                 - name: ssp
                   value: "{{ item.ssp }}"
+                - name: regrid-method
+                  value: "{{ inputs.parameters.regrid-method }}"
+                - name: correct-wetday-frequency
+                  value: "{{ inputs.parameters.correct-wetday-frequency }}"
+                - name: qdm-kind
+                  value: "{{ inputs.parameters.qdm-kind }}"
             withParam: "{{ inputs.parameters.jobs }}"
 
 
@@ -77,11 +86,8 @@ spec:
           - name: ssp
           - name: historical
           - name: regrid-method
-            value: "{{ workflow.parameters.regrid-method }}"
           - name: qdm-kind
-            value: "{{ workflow.parameters.qdm-kind }}"
           - name: correct-wetday-frequency
-            value: "{{ workflow.parameters.correct-wetday-frequency }}"
           - name: domainfile1x1
             value: "gs://support-c23ff1a3/domain.1x1.zarr"
           - name: domainfile0p25x0p25

--- a/workflows/templates/e2e-tasmax-jobs.yaml
+++ b/workflows/templates/e2e-tasmax-jobs.yaml
@@ -1,19 +1,18 @@
 apiVersion: argoproj.io/v1alpha1
-kind: Workflow
+kind: WorkflowTemplate
 metadata:
-  generateName: e2e-tasmax-
+  name: e2e-tasmax-jobs
+  annotations:
+    workflows.argoproj.io/description: >-
+      Download, clean, biascorrect, and downscale a list of CMIP6 "tasmax" data.
+    workflows.argoproj.io/tags: e2e,jobs,cmip6,dc6
+    workflows.argoproj.io/version: '>= 3.1.0'
+  labels:
+    component: e2e
 spec:
-  entrypoint: e2e-tasmax
+  entrypoint: e2e-tasmax-jobs
   arguments:
     parameters:
-      - name: overwrite
-        value: "false"
-      - name: regrid-method
-        value: "bilinear"
-      - name: qdm-kind
-        value: "additive"
-      - name: correct-wetday-frequency
-        value: "false"
       - name: jobs
         value: |
           [
@@ -45,7 +44,7 @@ spec:
             }
           ]
   templates:
-    - name: e2e-tasmax
+    - name: e2e-tasmax-jobs
       inputs:
         parameters:
           - name: jobs
@@ -74,3 +73,10 @@ spec:
               parameters:
                 - name: jobs
                   value: "{{ inputs.parameters.jobs }}"
+                - name: regrid-method
+                  value: "bilinear"
+                - name: correct-wetday-frequency
+                  value: "false"
+                - name: qdm-kind
+                  value: "additive"
+

--- a/workflows/templates/kustomization.yaml
+++ b/workflows/templates/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - create-output-metadata-json.yaml
   - distributed-regrid.yaml
   - download-cmip6.yaml
+  - e2e-tasmax-jobs.yaml
   - qdm.yaml
   - qualitycontrol-check-cmip6.yaml
   - rechunk.yaml


### PR DESCRIPTION
"workflows/e2e-tasmax.yaml" will see lots of play, so we're promoting it to a full WorkflowTemplate. This makes it easier to reuse and keep track of resource use.

There are some parameters refactored in this commit. This is so that the things that make a "tasmax" run a "tasmax" run are set as parameters in the e2e workflowtemplate. Previously, we just relied on default parameters to set tasmax-appropriate values. The change here makes parameters more explicit. This will make things cleaner when we start running other parameters.
