### PR TITLE
Fix bad overwrite param passing from "e2e-tasmax"

### DIFF
--- a/workflows/templates/download-cmip6.yaml
+++ b/workflows/templates/download-cmip6.yaml
@@ -51,6 +51,8 @@ spec:
       inputs:
         parameters:
           - name: jobs
+          - name: overwrite
+            value: "false"
       steps:
         - - name: divide
             template: with-specification
@@ -58,6 +60,8 @@ spec:
               parameters:
                 - name: simulations
                   value: "[{{ item.ssp }}, {{ item.historical }}]"
+                - name: overwrite
+                  value: "{{ inputs.parameters.overwrite }}"
             withParam: "{{ inputs.parameters.jobs }}"
 
 
@@ -66,6 +70,7 @@ spec:
       inputs:
         parameters:
           - name: simulations
+          - name: overwrite
       steps:
         - - name: process
             template: download-cmip6
@@ -89,6 +94,8 @@ spec:
                   value: "{{item.grid_label}}"
                 - name: version
                   value: "{{item.version}}"
+                - name: overwrite
+                  value: "{{ inputs.parameters.overwrite }}"
             withParam: "{{ inputs.parameters.simulations }}"
 
 
@@ -104,6 +111,7 @@ spec:
           - name: member-id
           - name: grid-label
           - name: version
+          - name: overwrite
       outputs:
         parameters:
           - name: out-zarr
@@ -160,6 +168,8 @@ spec:
                   value: "{{inputs.parameters.version}}"
                 - name: out-url
                   value: "{{ steps.get-destination-url.outputs.parameters.out-url }}"
+                - name: overwrite
+                  value: "{{ inputs.parameters.overwrite }}"
 
 
     - name: download-gcm
@@ -176,7 +186,6 @@ spec:
           - name: version
           - name: out-url
           - name: overwrite
-            value: "{{workflow.parameters.overwrite}}"
       outputs:
         parameters:
           - name: out-zarr
@@ -212,6 +221,10 @@ spec:
           import zarr
 
           outpath = os.environ.get("OUTPATH")
+
+          overwrite_arg = "{{ inputs.parameters.overwrite }}".lower()
+          if overwrite_arg not in ["true", "false"]:
+              raise ValueError(f"Argument for `overwrite` must be 'true' or 'false', got {overwrite_arg}"
           overwrite = "{{ inputs.parameters.overwrite }}".lower() == "true"
 
           print("Searching catalog")

--- a/workflows/templates/download-cmip6.yaml
+++ b/workflows/templates/download-cmip6.yaml
@@ -224,7 +224,7 @@ spec:
 
           overwrite_arg = "{{ inputs.parameters.overwrite }}".lower()
           if overwrite_arg not in ["true", "false"]:
-              raise ValueError(f"Argument for `overwrite` must be 'true' or 'false', got {overwrite_arg}"
+              raise ValueError(f"Argument for `overwrite` must be 'true' or 'false', got {overwrite_arg}")
           overwrite = "{{ inputs.parameters.overwrite }}".lower() == "true"
 
           print("Searching catalog")


### PR DESCRIPTION
In a [recent e2e-tasmax test run](https://argo.cildc6.org/workflows/default/e2e-tasmax-jobs-lvvh5) I noticed that the "download" steps where using `"{{workflow.parameters.overwrite}}"` as their argument for `overwrite`. This indicates that the `"{{workflow.parameters.overwrite}}"` never had the opportunity to evaluate to "true" or "false" or some user input.

This PR fixes this bug by changing the `download-gcm` template in `workflows/templates/download-cmip6.yaml` so that it *only* accepts `"true"` or `"false"` and raises `ValueError` otherwise.

In addition, overwrite is now set to `"false"` by default in `with-jobs` -- the WorkflowTemplate's entrypoint -- and passed through to the pod, instead of forcing the pod to grab it from the global `workflow.parameters`. In other words, `overwrite` should be passed as an explicit argument rather than quietly grabbed from a (potentially non-existent) global variable. This PR makes that fix.