### PR TITLE
Bump argo workflows to v3.2.4 release

### DIFF
--- a/infrastructure/kubernetes-gcp/argo/kustomization.yaml
+++ b/infrastructure/kubernetes-gcp/argo/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/argoproj/argo-workflows/releases/download/v3.2.3/install.yaml
+  - https://github.com/argoproj/argo-workflows/releases/download/v3.2.4/install.yaml
   - argo-cildc6-org.yaml
   - argo-server-ingress.yaml
   - sso-client-externalsecret.yaml


### PR DESCRIPTION
This release has general fixes. We don't require this upgrade for any specific changes or fixes.
