### PR TITLE
retrieving json manifest

### DIFF
--- a/notebooks/downscaling_pipeline/global_validation_manual.ipynb
+++ b/notebooks/downscaling_pipeline/global_validation_manual.ipynb
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,24 +80,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a69c566890c241269b3f09af9180355b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(HTML(value='<h2>GatewayCluster</h2>'), HBox(children=(HTML(value='\\n<div>\\n<style scoped>\\n    …"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "cluster"
    ]
@@ -111,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {
     "tags": [
      "parameters"
@@ -120,9 +105,12 @@
    "outputs": [],
    "source": [
     "# variable options: 'tasmax', 'tasmin', 'dtr', 'pr'\n",
+    "argo_token = 'YOUR_TOKEN_HERE'\n",
+    "workflow = 'e2e-tasmax-xxptd'\n",
     "variable = 'tasmax'\n",
     "# ssp options: 'ssp126', 'ssp245', 'ssp370', 'ssp585'\n",
     "ssp = 'ssp370'\n",
+    "gcm = 'GFDL-ESM4'\n",
     "\n",
     "# data output types for running validation \n",
     "cmip6 = False\n",
@@ -144,25 +132,62 @@
     "difference_plots = True\n",
     "\n",
     "# options: 'downscaled_minus_biascorrected' , 'change_from_historical'\n",
-    "diff_type = 'downscaled_minus_biascorrected'\n",
-    "\n",
-    "# contains the gcs URLs to zarr locations for each specified dataset\n",
-    "data_dict = {'coarse': {'cmip6': {'historical': 'scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-858077599/out.zarr', \n",
-    "                                  ssp: 'gs://scratch-170cd6ec/biascorrectdownscale-dev-5srdw/biascorrectdownscale-dev-5srdw-1680019548/rechunked.zarr'}, \n",
-    "                        'bias_corrected': {'historical': 'az://biascorrected-stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr', \n",
-    "                                                                                      ssp: 'gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20211103182935.zarr'}, \n",
-    "                        'ERA-5':'gs://scratch-170cd6ec/biascorrectdownscale-dev-5srdw/biascorrectdownscale-dev-5srdw-3837233090/rechunked.zarr'}, \n",
-    "             'fine': {'bias_corrected': {'historical': 'az://scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-1362934973/regridded.zarr', \n",
-    "                                         ssp: 'gs://scratch-170cd6ec/biascorrectdownscale-dev-5srdw/biascorrectdownscale-dev-5srdw-3979837439/regridded.zarr'}, \n",
-    "                      'downscaled': {'historical': 'az//downscaled-stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr', \n",
-    "                                     ssp: 'gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20211103182935.zarr'}, \n",
-    "                      'ERA-5_fine': 'gs://scratch-170cd6ec/biascorrectdownscale-dev-5srdw/biascorrectdownscale-dev-5srdw-1429197081/rechunked.zarr', \n",
-    "                      'ERA-5_coarse': 'gs://scratch-170cd6ec/biascorrectdownscale-dev-5srdw/biascorrectdownscale-dev-5srdw-3458674675/rechunked.zarr'}}\n"
+    "diff_type = 'downscaled_minus_biascorrected'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# retrieve the worfklow manifest\n",
+    "manifest = get_manifest(workflow, argo_token)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# collect intermediary output file paths (gcs URLs to zarr locations for each specified dataset)\n",
+    "data_dict = collect_paths(manifest, gcm, ssp, variable)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'coarse': {'cmip6': {'ssp370': 'gs://scratch-170cd6ec/983aa953-cfcd-41d3-9870-a50e6cfb97b9/e2e-tasmax-xxptd-4084393016/preprocessed.zarr',\n",
+       "   'historical': 'scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-858077599/out.zarr'},\n",
+       "  'bias_corrected': {'ssp370': 'gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20211111035926.zarr',\n",
+       "   'historical': 'az://biascorrected-stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr'},\n",
+       "  'ERA-5': 'gs://scratch-170cd6ec/983aa953-cfcd-41d3-9870-a50e6cfb97b9/e2e-tasmax-xxptd-4018380438/preprocessed.zarr'},\n",
+       " 'fine': {'bias_corrected': {'ssp370': 'gs://scratch-170cd6ec/983aa953-cfcd-41d3-9870-a50e6cfb97b9/e2e-tasmax-xxptd-34953611/regridded.zarr',\n",
+       "   'historical': 'az://scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-1362934973/regridded.zarr'},\n",
+       "  'downscaled': {'ssp370': 'gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20211111035926.zarr',\n",
+       "   'historical': 'az//downscaled-stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr'},\n",
+       "  'ERA-5_fine': 'gs://scratch-170cd6ec/983aa953-cfcd-41d3-9870-a50e6cfb97b9/e2e-tasmax-xxptd-3570039645/rechunked.zarr',\n",
+       "  'ERA-5_coarse': 'gs://scratch-170cd6ec/983aa953-cfcd-41d3-9870-a50e6cfb97b9/e2e-tasmax-xxptd-4119488463/rechunked.zarr'}}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -220,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -280,7 +305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {

--- a/notebooks/downscaling_pipeline/science_validation_manual.py
+++ b/notebooks/downscaling_pipeline/science_validation_manual.py
@@ -241,5 +241,4 @@ def get_manifest(workflow_uid, auth_token, argo_url='https://argo.cildc6.org/api
     dict
         representation of the workflow manifest in dict format parsed form json file
     """
-    return requests.get(url=f'{argo_url}/{workflow_location}/{namespace}/' + workflow_uid,
-                              headers={'Authorization': auth_token}).json()
+    return requests.get(url=f'{argo_url}/{workflow_location}/{namespace}/' + workflow_uid, headers={'Authorization': auth_token}).json()

--- a/notebooks/downscaling_pipeline/science_validation_manual.py
+++ b/notebooks/downscaling_pipeline/science_validation_manual.py
@@ -205,22 +205,22 @@ def collect_paths(manifest, gcm='GFDL-ESM4', ssp='ssp370', var='tasmax'):
     data_dict = {
         'coarse': {
             'cmip6': {
-                'ssp': f(manifest, f'{var_token}{ssp_token}{gcm_token}(?=.*biascorrect)(?=.*preprocess-simulation)')['path'],
+                ssp: f(manifest, f'{var_token}{ssp_token}{gcm_token}(?=.*biascorrect)(?=.*preprocess-simulation)')['path'],
                 'historical': 'scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-858077599/out.zarr'
             },
             'bias_corrected': {
-                'ssp': f(manifest, f'{var_token}{ssp_token}{gcm_token}(?=.*rechunk-biascorrected)')['path'],
+                ssp: f(manifest, f'{var_token}{ssp_token}{gcm_token}(?=.*rechunk-biascorrected)')['path'],
                 'historical': 'az://biascorrected-stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr'
             },
             'ERA-5': f(manifest, f'{var_token}{ssp_token}{gcm_token}(?=.*biascorrect)(?=.*preprocess-reference)')['path']
         },
         'fine': {
             'bias_corrected': {
-                'ssp': f(manifest, f'{var_token}{ssp_token}{gcm_token}(?=.*preprocess-biascorrected)(?=.*regrid)(?=.*prime-regrid-zarr)')['path'],
+                ssp: f(manifest, f'{var_token}{ssp_token}{gcm_token}(?=.*preprocess-biascorrected)(?=.*regrid)(?=.*prime-regrid-zarr)')['path'],
                 'historical': 'az://scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-1362934973/regridded.zarr'
             },
             'downscaled': {
-                'ssp': f(manifest, f'{var_token}{ssp_token}{gcm_token}(?=.*prime-qplad-output-zarr)')['path'],
+                ssp: f(manifest, f'{var_token}{ssp_token}{gcm_token}(?=.*prime-qplad-output-zarr)')['path'],
                 'historical': 'az//downscaled-stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr'
             },
             'ERA-5_fine': f(manifest, f'{var_token}{ssp_token}{gcm_token}(?=.*create-fine-reference)(?=.*move-chunks-to-space)')['path'],

--- a/notebooks/downscaling_pipeline/science_validation_manual.py
+++ b/notebooks/downscaling_pipeline/science_validation_manual.py
@@ -182,8 +182,8 @@ def read_gcs_zarr(zarr_url, token='/opt/gcsfuse_tokens/impactlab-data.json', che
 
 def collect_paths(manifest, gcm='GFDL-ESM4', ssp='ssp370', var='tasmax'):
     """
-    collect intermediary output file paths to be validated : CMIP6, ERA-5, bias corrected, and downscaled for
-    low and high resolution.
+    collect intermediary output file paths to be validated from an argo manifest : CMIP6, ERA-5, bias corrected, and downscaled output
+    data, both in low and high resolution. Depends on a precise version of the workflow template names.
 
     Parameters
     ---------

--- a/notebooks/downscaling_pipeline/science_validation_manual.py
+++ b/notebooks/downscaling_pipeline/science_validation_manual.py
@@ -178,7 +178,7 @@ def read_gcs_zarr(zarr_url, token='/opt/gcsfuse_tokens/impactlab-data.json', che
     ds = xr.open_zarr(store_path)
     
     return ds 
-    
+
 def get_output_paths(manifest, regex):
     """
     lists status.nodes in an argo manifest, and grabs intermediary output files paths using the node tree represented by
@@ -188,7 +188,7 @@ def get_output_paths(manifest, regex):
     ----------
     manifest : dict
     regex : str
-        regular expression syntax str to filter nodes based on which templates where executed within a given node and before that given
+        regular expression syntax str to filter nodes based on which templates were executed within a given node and before that given
         node in the tree.
     Returns
     ------

--- a/notebooks/downscaling_pipeline/science_validation_manual.py
+++ b/notebooks/downscaling_pipeline/science_validation_manual.py
@@ -8,6 +8,7 @@ import os
 from matplotlib import cm
 import gcsfs
 import re
+import requests
 
 def plot_diagnostic_climo_periods(ds_future, ssp, years, variable, metric, data_type, units, ds_hist=None, vmin=240, vmax=320, transform = ccrs.PlateCarree()):    
     """
@@ -217,3 +218,28 @@ def get_output_paths(manifest, regex):
         raise Exception('I could not identify any node in the manifest')
 
     return ({'path': out_zarr_path, 'nodeId': nodeId})
+
+def get_manifest(workflow_uid, auth_token, argo_url='https://argo.cildc6.org/api/v1', workflow_location='workflows', namespace='default'):
+
+    """
+    make an http request to retrieve a workflow manifest from an argo server
+
+    Parameters
+    ----------
+    workflow_uid: str
+        unique workflow identifier
+    auth_token: str
+        argo server authentication
+    argo_url: str
+        url of argo server
+    workflow_location: str
+        probably only 'workflows' or 'archived_workflows'
+    namespace: str
+        argo namespace
+    Returns
+    -------
+    dict
+        representation of the workflow manifest in dict format parsed form json file
+    """
+    return requests.get(url=f'{argo_url}/{workflow_location}/{namespace}/' + workflow_uid,
+                              headers={'Authorization': auth_token}).json()

--- a/notebooks/downscaling_pipeline/science_validation_manual.py
+++ b/notebooks/downscaling_pipeline/science_validation_manual.py
@@ -215,10 +215,10 @@ def collect_paths(manifest, gcm='GFDL-ESM4', ssp='ssp370', var='tasmax'):
     f = get_output_path
     data_dict = {
         'coarse': {
-            k : f(manifest, f'{var_token}{ssp_token}{gcm_token}{v}')['path'] for k,v in node_names_tokens['coarse'].items()
+            k : {'ssp': f(manifest, f'{var_token}{ssp_token}{gcm_token}{v}')['path']} for k,v in node_names_tokens['coarse'].items()
         },
         'fine': {
-            k : f(manifest, f'{var_token}{ssp_token}{gcm_token}{v}')['path'] for k,v in node_names_tokens['fine'].items()
+            k : {'ssp': f(manifest, f'{var_token}{ssp_token}{gcm_token}{v}')['path']} for k,v in node_names_tokens['fine'].items()
         }
     }
 
@@ -290,4 +290,3 @@ def get_manifest(workflow_uid, auth_token, argo_url='https://argo.cildc6.org/api
         representation of the workflow manifest in dict format parsed form json file
     """
     return requests.get(url=f'{argo_url}/{workflow_location}/{namespace}/' + workflow_uid, headers={'Authorization': auth_token}).json()
-

--- a/notebooks/downscaling_pipeline/science_validation_manual.py
+++ b/notebooks/downscaling_pipeline/science_validation_manual.py
@@ -222,6 +222,12 @@ def collect_paths(manifest, gcm='GFDL-ESM4', ssp='ssp370', var='tasmax'):
         }
     }
 
+    # hard coded historical data paths
+    data_dict['coarse']['cmip6']['historical'] = 'scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-858077599/out.zarr'
+    data_dict['coarse']['bias_corrected']['historical'] = 'az://biascorrected-stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr'
+    data_dict['fine']['bias_corrected']['historical'] = 'az://scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-1362934973/regridded.zarr'
+    data_dict['fine']['downscaled']['historical'] = 'az//downscaled-stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr'
+
     return data_dict
 
 def get_output_path(manifest, regex):

--- a/notebooks/downscaling_pipeline/science_validation_manual.py
+++ b/notebooks/downscaling_pipeline/science_validation_manual.py
@@ -7,7 +7,8 @@ import cartopy.feature as cfeature
 import os 
 from matplotlib import cm
 import gcsfs
-    
+import re
+
 def plot_diagnostic_climo_periods(ds_future, ssp, years, variable, metric, data_type, units, ds_hist=None, vmin=240, vmax=320, transform = ccrs.PlateCarree()):    
     """
     plot mean, max, min tasmax, dtr, precip for CMIP6, bias corrected and downscaled data 
@@ -178,3 +179,41 @@ def read_gcs_zarr(zarr_url, token='/opt/gcsfuse_tokens/impactlab-data.json', che
     
     return ds 
     
+def get_output_paths(manifest, regex):
+    """
+    lists status.nodes in an argo manifest, and grabs intermediary output files paths using the node tree represented by
+    status.nodes[*].name. Keeps only nodes of type 'Pod' and phase 'succeeded'.
+
+    Parameters
+    ----------
+    manifest : dict
+    regex : str
+        regular expression syntax str to filter nodes based on which templates where executed within a given node and before that given
+        node in the tree.
+    Returns
+    ------
+    dict:
+        path : str, the path to the intermediary output file
+        nodeId: the id of the manifest node that outputted this file
+    """
+
+    out_zarr_path = None
+    nodeId = None
+    i = 0
+
+    for node in manifest['status']['nodes']:
+        this_node = manifest['status']['nodes'][node]
+        if this_node['type'] == 'Pod' and this_node['phase'] == 'Succeeded' and re.search(regex, this_node['name']):
+            i = i + 1
+            if i > 1:
+                raise Exception('I could not identify a unique node in the manifest. Id of the first match : ' + nodeId)
+            nodeId = this_node['id']
+            if 'outputs' in this_node and 'parameters' in this_node['outputs']:
+                for param in this_node['outputs']['parameters']:
+                    if param['name'] == 'out-zarr':
+                        out_zarr_path = param['value']
+
+    if out_zarr_path is None and nodeId is None:
+        raise Exception('I could not identify any node in the manifest')
+
+    return ({'path': out_zarr_path, 'nodeId': nodeId})

--- a/notebooks/downscaling_pipeline/science_validation_manual.py
+++ b/notebooks/downscaling_pipeline/science_validation_manual.py
@@ -196,37 +196,37 @@ def collect_paths(manifest, gcm='GFDL-ESM4', ssp='ssp370', var='tasmax'):
     -------
     dict
     """
-    node_names_tokens = {
-        'coarse': {
-            'cmip6': '(?=.*biascorrect)(?=.*preprocess-simulation)',
-            'bias_corrected': '(?=.*rechunk-biascorrected)',
-            'ERA-5': '(?=.*biascorrect)(?=.*preprocess-reference)'
-        },
-        'fine': {
-            'bias_corrected': '(?=.*preprocess-biascorrected)(?=.*regrid)(?=.*prime-regrid-zarr)',
-            'downscaled': '(?=.*prime-qplad-output-zarr)',
-            'ERA-5_fine': '(?=.*create-fine-reference)(?=.*move-chunks-to-space)',
-            'ERA-5_coarse': '(?=.*create-coarse-reference)(?=.*move-chunks-to-space)'
-        }
-    }
+
     var_token  = f'(?=.*"variable_id":"{var}")'
     ssp_token = f'(?=.*"experiment_id":"{ssp}")'
     gcm_token = f'(?=.*"source_id":"{gcm}")'
     f = get_output_path
+
     data_dict = {
         'coarse': {
-            k : {'ssp': f(manifest, f'{var_token}{ssp_token}{gcm_token}{v}')['path']} for k,v in node_names_tokens['coarse'].items()
+            'cmip6': {
+                'ssp': f(manifest, f'{var_token}{ssp_token}{gcm_token}(?=.*biascorrect)(?=.*preprocess-simulation)')['path'],
+                'historical': 'scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-858077599/out.zarr'
+            },
+            'bias_corrected': {
+                'ssp': f(manifest, f'{var_token}{ssp_token}{gcm_token}(?=.*rechunk-biascorrected)')['path'],
+                'historical': 'az://biascorrected-stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr'
+            },
+            'ERA-5': f(manifest, f'{var_token}{ssp_token}{gcm_token}(?=.*biascorrect)(?=.*preprocess-reference)')['path']
         },
         'fine': {
-            k : {'ssp': f(manifest, f'{var_token}{ssp_token}{gcm_token}{v}')['path']} for k,v in node_names_tokens['fine'].items()
+            'bias_corrected': {
+                'ssp': f(manifest, f'{var_token}{ssp_token}{gcm_token}(?=.*preprocess-biascorrected)(?=.*regrid)(?=.*prime-regrid-zarr)')['path'],
+                'historical': 'az://scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-1362934973/regridded.zarr'
+            },
+            'downscaled': {
+                'ssp': f(manifest, f'{var_token}{ssp_token}{gcm_token}(?=.*prime-qplad-output-zarr)')['path'],
+                'historical': 'az//downscaled-stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr'
+            },
+            'ERA-5_fine': f(manifest, f'{var_token}{ssp_token}{gcm_token}(?=.*create-fine-reference)(?=.*move-chunks-to-space)')['path'],
+            'ERA-5_coarse': f(manifest, f'{var_token}{ssp_token}{gcm_token}(?=.*create-coarse-reference)(?=.*move-chunks-to-space)')['path']
         }
     }
-
-    # hard coded historical data paths
-    data_dict['coarse']['cmip6']['historical'] = 'scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-858077599/out.zarr'
-    data_dict['coarse']['bias_corrected']['historical'] = 'az://biascorrected-stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr'
-    data_dict['fine']['bias_corrected']['historical'] = 'az://scratch/biascorrectdownscale-bk6n8/biascorrectdownscale-bk6n8-1362934973/regridded.zarr'
-    data_dict['fine']['downscaled']['historical'] = 'az//downscaled-stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20210920214427.zarr'
 
     return data_dict
 


### PR DESCRIPTION
@dgergel I added a function to automatically build the `data_dict` that was defined in the notebook. This function is called `collect_paths`. It is called in the notebook, but defined in `science_validation_manual.py` and makes use of what I wrote in https://github.com/ClimateImpactLab/downscaleCMIP6/pull/326. 

Notes : 

1. Now the notebook uses a more up to date workflow. One can change the workflow id at the top of the notebook and, if the template names/tree have not changed, the parsing happens automatically. 
2. one needs to replace the `argo_token` object value at the top of the notebook by his/her personal token. Like @brews said, if we use this a lot, we might want to have a token just for this purpose. But on second thought, I don't think we'd want to have that token pushed to a remote repository anyways? 
3. The notebook runs fine as is in this PR. 

A request : could double check if my understanding of the spec is correct ? you can simply look at `collect_paths()` and the `regex` expression I used to get each path. That expression shows you which `template` I thought a given output file path should come from. Maybe @brews eyes would be helpful as well ?

