### PR TITLE
Add WorkflowTemplate to compute dtr

### DIFF
--- a/workflows/templates/compute-dtr.yaml
+++ b/workflows/templates/compute-dtr.yaml
@@ -1,0 +1,401 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: compute-dtr
+  annotations:
+    workflows.argoproj.io/description: >-
+      Compute dataset of diurnal temperature range (DTR) from cleaned CMIP6 tasmin and tasmax.
+    workflows.argoproj.io/tags: utils,jobs,cmip6,dc6,dtr
+    workflows.argoproj.io/version: '>= 3.1.0'
+  labels:
+    component: utils
+spec:
+  entrypoint: compute-dtr-jobs
+  arguments:
+    parameters:
+      - name: jobs
+        value: |
+          [
+            {
+              "variable_id": "dtr",
+              "target": "ssp",
+              "tasmax": {
+                "target": "ssp",
+                "variable_id": "tasmax",
+                "historical": {"activity_id": "CMIP","experiment_id": "historical","table_id": "day","variable_id": "tasmax","source_id": "GFDL-ESM4","institution_id": "NOAA-GFDL","member_id": "r1i1p1f1","grid_label": "gr1","version": "20190726"},
+                "ssp": {"activity_id": "ScenarioMIP","experiment_id": "ssp370","table_id": "day","variable_id": "tasmax","source_id": "GFDL-ESM4","institution_id": "NOAA-GFDL","member_id": "r1i1p1f1","grid_label": "gr1","version": "20180701"}
+              },
+              "tasmin": {
+                "target": "ssp",
+                "variable_id": "tasmin",
+                "historical": {"activity_id": "CMIP","experiment_id": "historical","table_id": "day","variable_id": "tasmin","source_id": "GFDL-ESM4","institution_id": "NOAA-GFDL","member_id": "r1i1p1f1","grid_label": "gr1","version": "20190726"},
+                "ssp": {"activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "GFDL-ESM4", "institution_id": "NOAA-GFDL", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20180701"}
+              }
+            }
+          ]
+  templates:
+
+
+      # For each job, combine the ssp and historical specifications into a single JSON list.
+    - name: compute-dtr-jobs
+      inputs:
+        parameters:
+          - name: jobs
+      steps:
+        - - name: choose-target-period
+            template: choose-target-period
+            arguments:
+              parameters:
+                - name: tasmax
+                  value: "{{ item.tasmax }}"
+                - name: tasmin
+                  value: "{{ item.tasmin }}"
+                - name: target
+                  value: "{{ item.target }}"
+            withParam: "{{ inputs.parameters.jobs }}"
+
+    - name: choose-target-period
+      inputs:
+        parameters:
+          - name: tasmax
+          - name: tasmin
+          - name: target
+      steps:
+        - - name: compute-ssp-dtr
+            template: compute-dtr-with-specification
+            arguments:
+              parameters:
+                - name: tasmax-target
+                  value: "{{=toJson(jsonpath(inputs.parameters.tasmax, '$.ssp'))}}"
+                - name: tasmin-target
+                  value: "{{=toJson(jsonpath(inputs.parameters.tasmin, '$.ssp'))}}"
+                - name: tasmax-historical
+                  value: "{{=toJson(jsonpath(inputs.parameters.tasmax, '$.historical'))}}"
+                - name: tasmin-historical
+                  value: "{{=toJson(jsonpath(inputs.parameters.tasmin, '$.historical'))}}"
+            when: "{{inputs.parameters.target}} == ssp"
+          - name: compute-historical-dtr
+            template: compute-dtr-with-specification
+            arguments:
+              parameters:
+                - name: tasmax-target
+                  value: "{{=toJson(jsonpath(inputs.parameters.tasmax, '$.historical'))}}"
+                - name: tasmin-target
+                  value: "{{=toJson(jsonpath(inputs.parameters.tasmin, '$.historical'))}}"
+                - name: tasmax-historical
+                  value: "{{=toJson(jsonpath(inputs.parameters.tasmax, '$.historical'))}}"
+                - name: tasmin-historical
+                  value: "{{=toJson(jsonpath(inputs.parameters.tasmin, '$.historical'))}}"
+            when: "{{inputs.parameters.target}} == historical"
+
+
+    - name: compute-dtr-with-specification
+      inputs:
+        parameters:
+          - name: tasmax-target
+          - name: tasmin-target
+          - name: tasmax-historical
+          - name: tasmin-historical
+      outputs:
+        parameters:
+          - name: simulation-zarr
+            valueFrom:
+              parameter: "{{ tasks.get-clean-dtr-simulation-url.outputs.parameters.out-url }}"
+          - name: training-zarr
+            valueFrom:
+              parameter: "{{ tasks.get-clean-dtr-training-url.outputs.parameters.out-url }}"
+      dag:
+        tasks:
+          - name: get-clean-tasmin-training-url
+            templateRef:
+              name: catalog
+              template: get-fsspec-url-from-parameters
+            arguments:
+              parameters:
+                - name: experiment-id
+                  value: "training"
+                - name: activity-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-historical'], '$.activity_id')}}"
+                - name: table-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-historical'], '$.table_id')}}"
+                - name: variable-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-historical'], '$.variable_id')}}"
+                - name: source-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-historical'], '$.source_id')}}"
+                - name: institution-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-historical'], '$.institution_id')}}"
+                - name: member-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-historical'], '$.member_id')}}"
+                - name: grid-label
+                  value: "{{=jsonpath(inputs.parameters['tasmin-historical'], '$.grid_label')}}"
+                - name: version
+                  value: "{{=jsonpath(inputs.parameters['tasmin-historical'], '$.version')}}"
+                - name: base-url
+                  value: "gs://clean-b1dbca25/cmip6"
+          - name: get-clean-tasmax-training-url
+            templateRef:
+              name: catalog
+              template: get-fsspec-url-from-parameters
+            arguments:
+              parameters:
+                - name: experiment-id
+                  value: "training"
+                - name: activity-id
+                  value: "{{=jsonpath(inputs.parameters['tasmax-historical'], '$.activity_id')}}"
+                - name: table-id
+                  value: "{{=jsonpath(inputs.parameters['tasmax-historical'], '$.table_id')}}"
+                - name: variable-id
+                  value: "{{=jsonpath(inputs.parameters['tasmax-historical'], '$.variable_id')}}"
+                - name: source-id
+                  value: "{{=jsonpath(inputs.parameters['tasmax-historical'], '$.source_id')}}"
+                - name: institution-id
+                  value: "{{=jsonpath(inputs.parameters['tasmax-historical'], '$.institution_id')}}"
+                - name: member-id
+                  value: "{{=jsonpath(inputs.parameters['tasmax-historical'], '$.member_id')}}"
+                - name: grid-label
+                  value: "{{=jsonpath(inputs.parameters['tasmax-historical'], '$.grid_label')}}"
+                - name: version
+                  value: "{{=jsonpath(inputs.parameters['tasmax-historical'], '$.version')}}"
+                - name: base-url
+                  value: "gs://clean-b1dbca25/cmip6"
+          - name: get-clean-tasmin-simulation-url
+            templateRef:
+              name: catalog
+              template: get-fsspec-url-from-parameters
+            arguments:
+              parameters:
+                - name: experiment-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-target'], '$.experiment_id')}}"
+                - name: activity-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-target'], '$.activity_id')}}"
+                - name: table-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-target'], '$.table_id')}}"
+                - name: variable-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-target'], '$.variable_id')}}"
+                - name: source-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-target'], '$.source_id')}}"
+                - name: institution-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-target'], '$.institution_id')}}"
+                - name: member-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-target'], '$.member_id')}}"
+                - name: grid-label
+                  value: "{{=jsonpath(inputs.parameters['tasmin-target'], '$.grid_label')}}"
+                - name: version
+                  value: "{{=jsonpath(inputs.parameters['tasmin-target'], '$.version')}}"
+                - name: base-url
+                  value: "gs://clean-b1dbca25/cmip6"
+          - name: get-clean-tasmax-simulation-url
+            templateRef:
+              name: catalog
+              template: get-fsspec-url-from-parameters
+            arguments:
+              parameters:
+                - name: experiment-id
+                  value: "{{=jsonpath(inputs.parameters['tasmax-target'], '$.experiment_id')}}"
+                - name: activity-id
+                  value: "{{=jsonpath(inputs.parameters['tasmax-target'], '$.activity_id')}}"
+                - name: table-id
+                  value: "{{=jsonpath(inputs.parameters['tasmax-target'], '$.table_id')}}"
+                - name: variable-id
+                  value: "{{=jsonpath(inputs.parameters['tasmax-target'], '$.variable_id')}}"
+                - name: source-id
+                  value: "{{=jsonpath(inputs.parameters['tasmax-target'], '$.source_id')}}"
+                - name: institution-id
+                  value: "{{=jsonpath(inputs.parameters['tasmax-target'], '$.institution_id')}}"
+                - name: member-id
+                  value: "{{=jsonpath(inputs.parameters['tasmax-target'], '$.member_id')}}"
+                - name: grid-label
+                  value: "{{=jsonpath(inputs.parameters['tasmax-target'], '$.grid_label')}}"
+                - name: version
+                  value: "{{=jsonpath(inputs.parameters['tasmax-target'], '$.version')}}"
+                - name: base-url
+                  value: "gs://clean-b1dbca25/cmip6"
+          - name: get-clean-dtr-simulation-url
+            templateRef:
+              name: catalog
+              template: get-fsspec-url-from-parameters
+            arguments:
+              parameters:
+                - name: experiment-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-target'], '$.experiment_id')}}"
+                - name: activity-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-target'], '$.activity_id')}}"
+                - name: table-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-target'], '$.table_id')}}"
+                - name: variable-id
+                  value: "dtr"
+                - name: source-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-target'], '$.source_id')}}"
+                - name: institution-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-target'], '$.institution_id')}}"
+                - name: member-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-target'], '$.member_id')}}"
+                - name: grid-label
+                  value: "{{=jsonpath(inputs.parameters['tasmin-target'], '$.grid_label')}}"
+                - name: version
+                  value: "{{=jsonpath(inputs.parameters['tasmin-target'], '$.version')}}"
+                - name: base-url
+                  value: "gs://clean-b1dbca25/cmip6"
+          - name: get-clean-dtr-training-url
+            templateRef:
+              name: catalog
+              template: get-fsspec-url-from-parameters
+            arguments:
+              parameters:
+                - name: experiment-id
+                  value: training
+                - name: activity-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-historical'], '$.activity_id')}}"
+                - name: table-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-historical'], '$.table_id')}}"
+                - name: variable-id
+                  value: "dtr"
+                - name: source-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-historical'], '$.source_id')}}"
+                - name: institution-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-historical'], '$.institution_id')}}"
+                - name: member-id
+                  value: "{{=jsonpath(inputs.parameters['tasmin-historical'], '$.member_id')}}"
+                - name: grid-label
+                  value: "{{=jsonpath(inputs.parameters['tasmin-historical'], '$.grid_label')}}"
+                - name: version
+                  value: "{{=jsonpath(inputs.parameters['tasmin-historical'], '$.version')}}"
+                - name: base-url
+                  value: "gs://clean-b1dbca25/cmip6"
+          - name: create-simulation-dtr-metadata
+            depends: "get-clean-tasmin-simulation-url"
+            templateRef:
+              name: create-output-metadata-json
+              template: create-output-metadata-json
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ tasks.get-clean-tasmin-simulation-url.outputs.parameters.out-url }}"
+                - name: workflowstep
+                  value: clean
+          - name: create-training-dtr-metadata
+            depends: "get-clean-tasmin-training-url"
+            templateRef:
+              name: create-output-metadata-json
+              template: create-output-metadata-json
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ tasks.get-clean-tasmin-training-url.outputs.parameters.out-url }}"
+                - name: workflowstep
+                  value: clean
+          - name: compute-training-dtr
+            template: compute-dtr
+            depends: >-
+              create-training-dtr-metadata
+              && get-clean-dtr-training-url
+              && get-clean-tasmin-training-url
+              && get-clean-tasmax-training-url
+            arguments:
+              parameters:
+                - name: tasmax-zarr
+                  value: "{{ tasks.get-clean-tasmax-training-url.outputs.parameters.out-url }}"
+                - name: tasmin-zarr
+                  value: "{{ tasks.get-clean-tasmin-training-url.outputs.parameters.out-url }}"
+                - name: out-zarr
+                  value: "{{ tasks.get-clean-dtr-training-url.outputs.parameters.out-url }}"
+              artifacts:
+                - name: global-attrs-json
+                  from: "{{ tasks.create-training-dtr-metadata.artifacts.global-attrs-json }}"
+          - name: compute-simulation-dtr
+            template: compute-dtr
+            depends: >-
+              create-simulation-dtr-metadata
+              && get-clean-dtr-simulation-url
+              && get-clean-tasmin-simulation-url
+              && get-clean-tasmax-simulation-url
+            arguments:
+              parameters:
+                - name: tasmax-zarr
+                  value: "{{ tasks.get-clean-tasmax-simulation-url.outputs.parameters.out-url }}"
+                - name: tasmin-zarr
+                  value: "{{ tasks.get-clean-tasmin-simulation-url.outputs.parameters.out-url }}"
+                - name: out-zarr
+                  value: "{{ tasks.get-clean-dtr-simulation-url.outputs.parameters.out-url }}"
+              artifacts:
+                - name: global-attrs-json
+                  from: "{{ tasks.create-simulation-dtr-metadata.artifacts.global-attrs-json }}"
+          - name: validate-simulation-dtr
+            depends: compute-simulation-dtr
+            templateRef:
+              name: qualitycontrol-check-cmip6
+              template: qualitycontrol-check-cmip6
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ tasks.compute-simulation-dtr.outputs.parameters.out-zarr }}"
+                - name: variable
+                  value: "dtr"
+                - name: data
+                  value: "cmip6"
+                - name: time
+                  value: >-
+                    {{=jsonpath(inputs.parameters['tasmin-target'], '$.experiment_id') == 'historical' ? 'historical' : 'future'}}
+
+
+    - name: compute-dtr
+      inputs:
+        parameters:
+          - name: tasmax-zarr
+          - name: tasmin-zarr
+          - name: out-zarr
+        artifacts:
+          - name: global-attrs-json
+            path: /tmp/global_attrs.json
+      outputs:
+        parameters:
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-zarr }}"
+      script:
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.9.0
+        command: [ python ]
+        source: |
+          import dodola.repository
+          import xarray as xr
+
+          tasmin_zarr = "{{ inputs.parameters.tasmin-zarr }}"
+          tasmax_zarr = "{{ inputs.parameters.tasmax-zarr }}"
+          out_zarr = "{{ inputs.parameters.out-zarr }}"
+
+          tasmin_ds = xr.open_zarr(tasmin_zarr)
+          print(f"Read {tasmin_zarr}")  # DEBUG
+          tasmax_ds = xr.open_zarr(tasmax_zarr)
+          print(f"Read {tasmax_zarr}")  # DEBUG
+
+          assert tasmin_ds["tasmin"].attrs["units"] == tasmin_ds["tasmax"].attrs["units"]
+
+          dtr_ds = (tasmax_ds["tasmax"] - tasmin["tasmin"]).to_dataset(name="dtr")
+
+          # We're copying all attrs from `tasmin` to `dtr`, including shared variables.
+          dtr_ds.attrs = tasmin.attrs
+          dtr_ds.attrs["variable_id"] = "dtr"
+          for k, v in tasmin.variables.items():
+              if k in dtr_ds:
+                  dtr_ds[k].attrs = v.attrs
+
+          dtr_ds["dtr"].attrs = {
+            "long_name": "Diurnal Near-Surface Air Temperature Range",
+            "original_name": "dtr",
+            "standard_name": "air_temperature",
+            "units": tasmin_ds["tasmin"].attrs["units"],
+          }
+          dtr_ds.attrs = dodola.repository.read_attrs("/tmp/global_attrs.json")
+
+          dodola.repository.write(out_zarr, dtr_ds)
+          print(f"Written to {out_zarr}")
+        resources:
+          requests:
+            memory: 16Gi
+            cpu: "1000m"
+          limits:
+            memory: 16Gi
+            cpu: "2000m"
+      activeDeadlineSeconds: 3600
+      retryStrategy:
+        limit: 2
+        retryPolicy: "Always"

--- a/workflows/templates/kustomization.yaml
+++ b/workflows/templates/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - catalog.yaml
   - clean-cmip6.yaml
   - clean-era5.yaml
+  - compute-dtr.yaml
   - create-output-metadata-json.yaml
   - distributed-regrid.yaml
   - download-cmip6.yaml


### PR DESCRIPTION
Adds workflowtemplate required for downscaling diurnal temperature range (DTR). DTR is derived from daily minimum and maximum air temperature (tasmin, tasmax) and so it needs to be computed from existing data.

This workflow computes "cleaned" DTR simulation data, and QDM training data. These outputs are required for bias correction and downscaling. It needs to be given existing cleaned, CMIP6 tasmin and tasmax data.

The workflow itself looks intimidating because it juggles the needed metadata to get URLs for tasmin and tasmax data and output dtr data. The actual computation is just using the input and output URLs to read data and subtracting tasmin and tasmax from each other.

The output dtr data gets the majority of its metadata from input tasmin.

This WorkflowTemplate has been linted but not extensively tested. It should be considered a working prototype.
