### PR TITLE
Add end-to-end diurnal temperature range (dtr) workflowtemplate

### DIFF
--- a/workflows/templates/biascorrectdownscale.yaml
+++ b/workflows/templates/biascorrectdownscale.yaml
@@ -59,16 +59,12 @@ spec:
           - name: correct-wetday-frequency  # "true" or "false" STRING!
           - name: qdm-kind  # additive or multiplicative
       steps:
-        - - name: parameterize
-            template: parameterize
+        - - name: variable-id-switch
+            template: variable-id-switch
             arguments:
               parameters:
-                - name: target
-                  value: "{{ item.target }}"
-                - name: historical
-                  value: "{{ item.historical }}"
-                - name: ssp
-                  value: "{{ item.ssp }}"
+                - name: job
+                  value: "{{ item }}"
                 - name: regrid-method
                   value: "{{ inputs.parameters.regrid-method }}"
                 - name: correct-wetday-frequency
@@ -76,6 +72,82 @@ spec:
                 - name: qdm-kind
                   value: "{{ inputs.parameters.qdm-kind }}"
             withParam: "{{ inputs.parameters.jobs }}"
+
+    # We need different behavior for different variable_ids...
+    - name: variable-id-switch
+      inputs:
+        parameters:
+          - name: job
+          - name: regrid-method
+          - name: correct-wetday-frequency
+          - name: qdm-kind
+          - name: variable-id
+            value: "{{=jsonpath(inputs.parameters.job, '$.variable_id') }}"
+      steps:
+        - - name: parameterize-simple-job
+            template: parameterize
+            arguments:
+              parameters:
+                - name: target
+                  value: "{{=jsonpath(inputs.parameters.job, '$.target')}}"
+                - name: historical
+                  value: "{{=toJson(jsonpath(inputs.parameters.job, '$.historical'))}}"
+                - name: ssp
+                  value: "{{=toJson(jsonpath(inputs.parameters.job, '$.ssp'))}}"
+                - name: regrid-method
+                  value: "{{ inputs.parameters.regrid-method }}"
+                - name: correct-wetday-frequency
+                  value: "{{ inputs.parameters.correct-wetday-frequency }}"
+                - name: qdm-kind
+                  value: "{{ inputs.parameters.qdm-kind }}"
+            when: "{{ inputs.parameters.variable-id }} != 'dtr'"
+
+            # DTR has specs for tasmax and tasmin. dtr is cleaned and stored
+            # using metadata from its tasmin CMIP6 input. Use tasmin specs but
+            # switch variable_id to "dtr".
+          - name: parameterize-dtr-job
+            template: parameterize
+            arguments:
+              parameters:
+                - name: target
+                  value: "{{=jsonpath(inputs.parameters.job, '$.target')}}"
+                - name: historical
+                  value: >-
+                    {{=toJson(
+                      {
+                        "variable_id": "dtr",
+                        "activity_id": jsonpath(inputs.parameters.job, '$.tasmin.historical.activity_id'),
+                        "experiment_id": jsonpath(inputs.parameters.job, '$.tasmin.historical.experiment_id'),
+                        "table_id": jsonpath(inputs.parameters.job, '$.tasmin.historical.table_id'),
+                        "source_id": jsonpath(inputs.parameters.job, '$.tasmin.historical.source_id'),
+                        "institution_id": jsonpath(inputs.parameters.job, '$.tasmin.historical.institution_id'),
+                        "member_id": jsonpath(inputs.parameters.job, '$.tasmin.historical.member_id'),
+                        "grid_label": jsonpath(inputs.parameters.job, '$.tasmin.historical.grid_label'),
+                        "version": jsonpath(inputs.parameters.job, '$.tasmin.historical.version')
+                      }
+                    )}}
+                - name: ssp
+                  value: >-
+                    {{=toJson(
+                      {
+                        "variable_id": "dtr",
+                        "activity_id": jsonpath(inputs.parameters.job, '$.tasmin.ssp.activity_id'),
+                        "experiment_id": jsonpath(inputs.parameters.job, '$.tasmin.ssp.experiment_id'),
+                        "table_id": jsonpath(inputs.parameters.job, '$.tasmin.ssp.table_id'),
+                        "source_id": jsonpath(inputs.parameters.job, '$.tasmin.ssp.source_id'),
+                        "institution_id": jsonpath(inputs.parameters.job, '$.tasmin.ssp.institution_id'),
+                        "member_id": jsonpath(inputs.parameters.job, '$.tasmin.ssp.member_id'),
+                        "grid_label": jsonpath(inputs.parameters.job, '$.tasmin.ssp.grid_label'),
+                        "version": jsonpath(inputs.parameters.job, '$.tasmin.ssp.version')
+                      }
+                    )}}
+                - name: regrid-method
+                  value: "{{ inputs.parameters.regrid-method }}"
+                - name: correct-wetday-frequency
+                  value: "{{ inputs.parameters.correct-wetday-frequency }}"
+                - name: qdm-kind
+                  value: "{{ inputs.parameters.qdm-kind }}"
+            when: "{{ inputs.parameters.variable-id }} == 'dtr'"
 
 
       # Start work for target simulation, with target-specific configs.

--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -50,18 +50,45 @@ spec:
         parameters:
           - name: jobs
       steps:
-        - - name: process-job
+        - - name: variable-id-switch
+            template: variable-id-switch
+            arguments:
+              parameters:
+                - name: job
+                  value: "{{ item }}"
+            withParam: "{{ inputs.parameters.jobs }}"
+
+
+    - name: variable-id-switch
+      inputs:
+        parameters:
+          - name: job
+          - name: variable-id
+            value: "{{=jsonpath(inputs.parameters.job, '$.variable_id') }}"
+      steps:
+        - - name: process-simple-job
             template: process-job
             arguments:
               parameters:
                 - name: target
-                  value: "{{ item.target }}"
+                  value: "{{=jsonpath(inputs.parameters.job, '$.target')}}"
                 - name: historical
-                  value: "{{ item.historical }}"
+                  value:  "{{=toJson(jsonpath(inputs.parameters.job, '$.historical'))}}"
                 - name: ssp
-                  value: "{{ item.ssp }}"
-            withParam: "{{ inputs.parameters.jobs }}"
-
+                  value:  "{{=toJson(jsonpath(inputs.parameters.job, '$.ssp'))}}"
+            when: "{{ inputs.parameters.variable-id }} != 'dtr'"
+          - name: process-dtr-dependencies
+            template: with-jobs
+            arguments:
+              parameters:
+                - name: jobs
+                  # Run the list CMIP6 tasmin and tasmax inputs we need to compute DTR.
+                  value: >-
+                    {{=toJson([
+                        jsonpath(inputs.parameters.job, '$.tasmin'),
+                        jsonpath(inputs.parameters.job, '$.tasmax')
+                    ])}}
+            when: "{{ inputs.parameters.variable-id }} == 'dtr'"
 
       # Do common tasks for cleaning/standardizing the job data, then break
       # into target-specific tasks.

--- a/workflows/templates/download-cmip6.yaml
+++ b/workflows/templates/download-cmip6.yaml
@@ -55,14 +55,53 @@ spec:
             value: "false"
       steps:
         - - name: divide
+            template: variable-id-switch
+            arguments:
+              parameters:
+                - name: job
+                  value: "{{ item }}"
+                - name: overwrite
+                  value: "{{ inputs.parameters.overwrite }}"
+            withParam: "{{ inputs.parameters.jobs }}"
+
+    - name: variable-id-switch
+      inputs:
+        parameters:
+          - name: job
+          - name: overwrite
+            value: "false"
+          - name: variable-id
+            value: "{{=jsonpath(inputs.parameters.job, '$.variable_id') }}"
+      steps:
+        - - name: with-simple-specification
             template: with-specification
             arguments:
               parameters:
                 - name: simulations
-                  value: "[{{ item.ssp }}, {{ item.historical }}]"
+                  value: >-
+                    {{=toJson([
+                        jsonpath(inputs.parameters.job, '$.ssp'),
+                        jsonpath(inputs.parameters.job, '$.historical')
+                    ])}}
                 - name: overwrite
                   value: "{{ inputs.parameters.overwrite }}"
-            withParam: "{{ inputs.parameters.jobs }}"
+            when: "{{ inputs.parameters.variable-id }} != 'dtr'"
+          - name: with-dtr-specification
+            template: with-specification
+            arguments:
+              parameters:
+                - name: simulations
+                  # Pool together all input CMIP6 tasmin and tasmax specs, historical and SSPs.
+                  value: >-
+                    {{=toJson([
+                        jsonpath(inputs.parameters.job, '$.tasmin.historical'),
+                        jsonpath(inputs.parameters.job, '$.tasmin.ssp'),
+                        jsonpath(inputs.parameters.job, '$.tasmax.historical'),
+                        jsonpath(inputs.parameters.job, '$.tasmax.ssp')
+                    ])}}
+                - name: overwrite
+                  value: "{{ inputs.parameters.overwrite }}"
+            when: "{{ inputs.parameters.variable-id }} == 'dtr'"
 
 
       # Break each specification into its components.

--- a/workflows/templates/e2e-dtr-jobs.yaml
+++ b/workflows/templates/e2e-dtr-jobs.yaml
@@ -1,0 +1,85 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: e2e-dtr-jobs
+  annotations:
+    workflows.argoproj.io/description: >-
+      Download, clean, biascorrect, and downscale a list of CMIP6 diurnal temperature range (dtr) data.
+    workflows.argoproj.io/tags: e2e,jobs,cmip6,dc6,dtr
+    workflows.argoproj.io/version: '>= 3.1.0'
+  labels:
+    component: e2e
+spec:
+  entrypoint: e2e-dtr-jobs
+  arguments:
+    parameters:
+      - name: jobs
+        value: |
+          [
+            {
+              "variable_id": "dtr",
+              "target": "ssp",
+              "tasmax": {
+                "target": "ssp",
+                "variable_id": "tasmax",
+                "historical": {"activity_id": "CMIP","experiment_id": "historical","table_id": "day","variable_id": "tasmax","source_id": "GFDL-ESM4","institution_id": "NOAA-GFDL","member_id": "r1i1p1f1","grid_label": "gr1","version": "20190726"},
+                "ssp": {"activity_id": "ScenarioMIP","experiment_id": "ssp370","table_id": "day","variable_id": "tasmax","source_id": "GFDL-ESM4","institution_id": "NOAA-GFDL","member_id": "r1i1p1f1","grid_label": "gr1","version": "20180701"}
+              },
+              "tasmin": {
+                "target": "ssp",
+                "variable_id": "tasmin",
+                "historical": {"activity_id": "CMIP","experiment_id": "historical","table_id": "day","variable_id": "tasmin","source_id": "GFDL-ESM4","institution_id": "NOAA-GFDL","member_id": "r1i1p1f1","grid_label": "gr1","version": "20190726"},
+                "ssp": {"activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "GFDL-ESM4", "institution_id": "NOAA-GFDL", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20180701"}
+              }
+            }
+          ]
+  templates:
+
+
+    - name: e2e-dtr-jobs
+      inputs:
+        parameters:
+          - name: jobs
+      steps:
+        # DTR is a derived variable, so this downloads CMIP6 inputs required
+        # to compute DTR.
+        - - name: download
+            templateRef:
+              name: download-cmip6
+              template: with-jobs
+            arguments:
+              parameters:
+                - name: jobs
+                  value: "{{ inputs.parameters.jobs }}"
+        # Like the download step, this is just cleaning the CMIP6 inputs
+        # required to compute DTR.
+        - - name: clean
+            templateRef:
+              name: clean-cmip6
+              template: with-jobs
+            arguments:
+              parameters:
+                - name: jobs
+                  value: "{{ inputs.parameters.jobs }}"
+        - - name: compute-dtr
+            templateRef:
+              name: compute-dtr
+              template: with-jobs
+            arguments:
+              parameters:
+                - name: jobs
+                  value: "{{ inputs.parameters.jobs }}"
+        - - name: biascorrectdownscale
+            templateRef:
+              name: biascorrectdownscale
+              template: with-jobs
+            arguments:
+              parameters:
+                - name: jobs
+                  value: "{{ inputs.parameters.jobs }}"
+                - name: regrid-method
+                  value: "bilinear"
+                - name: correct-wetday-frequency
+                  value: "false"
+                - name: qdm-kind
+                  value: "multiplicative"

--- a/workflows/templates/kustomization.yaml
+++ b/workflows/templates/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - create-output-metadata-json.yaml
   - distributed-regrid.yaml
   - download-cmip6.yaml
+  - e2e-dtr-jobs.yaml
   - e2e-pr-jobs.yaml
   - e2e-tasmax-jobs.yaml
   - qdm.yaml


### PR DESCRIPTION
This adds a workflow template for end-to-end diurnal temperature range (DTR) downscaling.

DTR is derived from cleaned tasmin and tasmax so this requires more complex input parameters. Added a "variable-id-switch" at the head of the main download, clean, and downscale/biascorrect templates to switch initial parameter parsing between what we need for "dtr" (and it's tasmin and tasmax inputs) and what we need for other, simpler variables.