### PR TITLE
Move cmip6-in-the-cloud download catalog to "noQC"

### DIFF
--- a/workflows/templates/download-cmip6.yaml
+++ b/workflows/templates/download-cmip6.yaml
@@ -267,7 +267,7 @@ spec:
           overwrite = overwrite_arg == "true"
 
           print("Searching catalog")
-          col = intake.open_esm_datastore("https://storage.googleapis.com/cmip6/pangeo-cmip6.json")
+          col = intake.open_esm_datastore("https://storage.googleapis.com/cmip6/pangeo-cmip6-noQC.json")
           cat = col.search(
               activity_id=os.environ.get("ACTIVITY_ID"),
               experiment_id=os.environ.get("EXPERIMENT_ID"),


### PR DESCRIPTION
Parameter files have references to records not in the QC'd CMIP6-in-the-cloud catalog. We need to use the non-QC'd catalog for access.