### PR TITLE
Fix reference to non-existant GFDL ssp370 for historical precip run

### DIFF
--- a/workflows/parameters/GFDL-CM4-pr.yaml
+++ b/workflows/parameters/GFDL-CM4-pr.yaml
@@ -4,7 +4,7 @@ jobs: |
       "target": "historical",
       "variable_id": "pr",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "GFDL-CM4", "institution_id": "NOAA-GFDL", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20180701" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "GFDL-CM4", "institution_id": "NOAA-GFDL", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20180701" }
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "GFDL-CM4", "institution_id": "NOAA-GFDL", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20180701" }
     },
     {
       "target": "ssp",


### PR DESCRIPTION
This parameter file references ssp370 for the historical downscaling run. That's coming up empty in the download step and throwing an error. 

This changes the run to append ssp245 onto historical instead.