### PR TITLE
Allow 0 < dtr < 70 through QC, bump QDM, QPLAD dodola to v0.10.0 release

### DIFF
--- a/workflows/templates/qdm.yaml
+++ b/workflows/templates/qdm.yaml
@@ -138,7 +138,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.10.0
         command: [ python ]
         source: |
           import logging
@@ -379,7 +379,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.9.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.10.0
         command: [ dodola ]
         args:
           - "prime-qdm-output-zarrstore"
@@ -418,7 +418,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.9.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.10.0
         command: [ "dodola" ]
         args:
           - "train-qdm"
@@ -464,7 +464,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.9.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.10.0
         command: [ dodola ]
         args:
           - "apply-qdm"

--- a/workflows/templates/qplad.yaml
+++ b/workflows/templates/qplad.yaml
@@ -416,7 +416,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.9.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.10.0
         command: [ dodola ]
         args:
           - "train-qplad"
@@ -459,7 +459,7 @@ spec:
           - name: global-attrs-json
             path: /tmp/global_attrs.json
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.9.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.10.0
         command: [ dodola ]
         args:
           - "apply-qplad"
@@ -502,7 +502,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.9.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.10.0
         command: [ dodola ]
         args:
           - "prime-qplad-output-zarrstore"

--- a/workflows/templates/qualitycontrol-check-cmip6.yaml
+++ b/workflows/templates/qualitycontrol-check-cmip6.yaml
@@ -40,7 +40,7 @@ spec:
           - name: data
           - name: time
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.10.0
         command: [python]
         source: |
           import dask


### PR DESCRIPTION
This PR bumps the dodola version to the latest release (v0.10.0) in QDM, QPLAD, and CMIP6 quality-control workflow templates.

This bump changes the behavior in CMIP6 QC by allowing 0 < DTR < 70. Previous versions failed DTR greater than 40, but this leads to failed runs for otherwise correct CMIP6 GCM runs.

The PR also bumps dodola version in QDM and QPLAD workflowtemplates. This bump isn't for a specific new feature or fix, instead the upstream xclim fork has improved test coverage and we want to exclusively pull this improved testing version.