### PR TITLE
Fix bad parameter file formatting

### DIFF
--- a/workflows/parameters/MPI-ESM1-2-HAM-tasmax.yaml
+++ b/workflows/parameters/MPI-ESM1-2-HAM-tasmax.yaml
@@ -11,6 +11,5 @@ jobs: |
       "variable_id": "tasmax",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-HAM", "institution_id": "HAMMOZ-Consortium", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190627" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-HAM", "institution_id": "DKRZ", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190628" }
-    },
+    }
   ]
-


### PR DESCRIPTION
Fix bad file format in workflows/parameters/MPI-ESM1-2-HAM-tasmax.yaml. This was killing workflows right out of the gate.

close #349
