### PR TITLE
Crop ssp dataset on from 2015 to 2110 on entrance to cleaning step

### DIFF
--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -188,6 +188,16 @@ spec:
                   value: "1950"
                 - name: to-time
                   value: "2014"
+          - name: crop-ssp-time
+            template: timeslicezarr
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ steps.get-input-raw-ssp-url.outputs.parameters.out-url }}"
+                - name: from-time
+                  value: "2015"
+                - name: to-time
+                  value: "2110"
         - - name: standardize-historical-run
             template: standardize-cmip6
             arguments:
@@ -199,7 +209,7 @@ spec:
             arguments:
               parameters:
                 - name: in-zarr
-                  value: "{{ steps.get-input-raw-ssp-url.outputs.parameters.out-url }}"
+                  value: "{{ steps.crop-ssp-time.outputs.parameters.out-zarr }}"
         - - name: slice-training
             template: timeslicezarr
             arguments:


### PR DESCRIPTION
Crop ssp dataset from 2015 to 2110 on entrance to cmip6 cleaning step.

This is related to #344, but does not resolve the issue.