### PR TITLE
fix xclim installation bug in global validation notebook 

### DIFF
--- a/notebooks/downscaling_pipeline/global_validation_manual.ipynb
+++ b/notebooks/downscaling_pipeline/global_validation_manual.ipynb
@@ -38,7 +38,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! pip install xclim # we don't have this package on compute.impactlab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,24 +89,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a65b5d67aa0a424d93c23c7f81033db6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(HTML(value='<h2>GatewayCluster</h2>'), HBox(children=(HTML(value='\\n<div>\\n<style scoped>\\n    …"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "cluster.scale(40)\n",
     "cluster"

--- a/notebooks/downscaling_pipeline/science_validation_manual.py
+++ b/notebooks/downscaling_pipeline/science_validation_manual.py
@@ -9,7 +9,6 @@ from matplotlib import cm
 import gcsfs
 import re
 import requests
-! pip install xclim 
 import xclim as xc
 
 def xr_conditional_count(ds, threshold=95, convert=lambda x : (x - 32) * 5 / 9 + 273.15):


### PR DESCRIPTION
move xclim installation from within .py file to xclim installation from within jupyter notebook. 

I had myself created this bug in https://github.com/ClimateImpactLab/downscaleCMIP6/pull/353.