### PR TITLE
Increase tasmax, timesteps allowed by QC checks

### DIFF
--- a/workflows/templates/qualitycontrol-check-cmip6.yaml
+++ b/workflows/templates/qualitycontrol-check-cmip6.yaml
@@ -40,7 +40,7 @@ spec:
           - name: data
           - name: time
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.11.0
         command: [python]
         source: |
           import dask


### PR DESCRIPTION
This PR upgrade dodola to v0.11.0 in the quality-control workflowtemplate. 

This upgrade to QC checks means that:
* tasmax is allowed over a wider range.
* Loosen restrictions on the expected number of timesteps (especially for CMIP6 future simulations) with cleaner errors indicating whether timesteps are larger or smaller than expected.