### PR TITLE
Drop NAN-filled runs from parameter files

### DIFF
--- a/workflows/parameters/ACCESS-CM2-tasmax.yaml
+++ b/workflows/parameters/ACCESS-CM2-tasmax.yaml
@@ -17,17 +17,5 @@ jobs: |
       "variable_id": "tasmax",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
-    },
-    {
-      "target": "ssp",
-      "variable_id": "tasmax",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210317" }
-    },
-    {
-      "target": "ssp",
-      "variable_id": "tasmax",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210317" }
     }
   ]

--- a/workflows/parameters/ACCESS-ESM1-5-tasmax.yaml
+++ b/workflows/parameters/ACCESS-ESM1-5-tasmax.yaml
@@ -23,11 +23,5 @@ jobs: |
       "variable_id": "tasmax",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-ESM1-5", "institution_id": "CSIRO", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191115" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-ESM1-5", "institution_id": "CSIRO", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191115" }
-    },
-    {
-      "target": "ssp",
-      "variable_id": "tasmax",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-ESM1-5", "institution_id": "CSIRO", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191115" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "ACCESS-ESM1-5", "institution_id": "CSIRO", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210318" }
     }
   ]

--- a/workflows/parameters/MRI-ESM2-0-tasmax.yaml
+++ b/workflows/parameters/MRI-ESM2-0-tasmax.yaml
@@ -17,17 +17,5 @@ jobs: |
       "variable_id": "tasmax",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" }
-    },
-    {
-      "target": "ssp",
-      "variable_id": "tasmax",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
-    },
-    {
-      "target": "ssp",
-      "variable_id": "tasmax",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
     }
   ]


### PR DESCRIPTION
This removes runs from tasmax parameter files as these runs appear to contain only NANs.

Specifically, this drops:
- ssp126 and ssp585 from ACCESS-CM2 tasmax
- ssp585 from ACCESS-ESM1-5
- ssp126 and ssp585 from MRI-ESM2-0

close #374
close #375
close #372 