### PR TITLE
Fix QDM bias correction of historical getting bad last-year parameter

### DIFF
--- a/workflows/templates/biascorrectdownscale.yaml
+++ b/workflows/templates/biascorrectdownscale.yaml
@@ -181,8 +181,6 @@ spec:
                   value: "{{ inputs.parameters.correct-wetday-frequency }}"
                 - name: first-year
                   value: 1950
-                - name: last-year
-                  value: 2014
                 - name: domainfile1x1
                   value: "{{ inputs.parameters.domainfile1x1 }}"
                 - name: domainfile0p25x0p25
@@ -204,8 +202,6 @@ spec:
                   value: "{{ inputs.parameters.correct-wetday-frequency }}"
                 - name: first-year
                   value: 2015
-                - name: last-year
-                  value: 2100
                 - name: domainfile1x1
                   value: "{{ inputs.parameters.domainfile1x1 }}"
                 - name: domainfile0p25x0p25
@@ -222,7 +218,6 @@ spec:
           - name: qdm-kind
           - name: correct-wetday-frequency
           - name: first-year
-          - name: last-year
           - name: domainfile1x1
           - name: domainfile0p25x0p25
           - name: reference-zarr
@@ -335,11 +330,21 @@ spec:
                   value: "{{workflow.creationTimestamp.Y}}{{workflow.creationTimestamp.m}}{{workflow.creationTimestamp.d}}{{workflow.creationTimestamp.H}}{{workflow.creationTimestamp.M}}{{workflow.creationTimestamp.S}}"
                 - name: base-url
                   value: "gs://downscaled-288ec5ac/stage"
+          - name: get-biascorrected-last-year
+            template: get-biascorrected-last-year
+            depends: get-input-clean-simulation-url
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ tasks.get-input-clean-simulation-url.outputs.parameters.out-url }}"
           - name: biascorrect
             templateRef:
               name: qdm
               template: main
-            depends: "get-input-clean-simulation-url && get-input-clean-training-url"
+            depends: >-
+              get-input-clean-simulation-url
+              && get-input-clean-training-url
+              && get-biascorrected-last-year
             arguments:
               parameters:
                 - name: variable-id
@@ -363,7 +368,7 @@ spec:
                 - name: first-year
                   value: "{{ inputs.parameters.first-year }}"
                 - name: last-year
-                  value: "{{ inputs.parameters.last-year }}"
+                  value: "{{ tasks.get-biascorrected-last-year.outputs.parameters.last-year }}"
           - name: rechunk-biascorrected
             depends: "get-output-biascorrected-url && biascorrect"
             templateRef:
@@ -473,3 +478,61 @@ spec:
                 - name: time
                   value: >-
                     {{=jsonpath(inputs.parameters.simulation, '$.experiment_id') == 'historical' ? 'historical' : 'future'}}
+
+
+      # This template helps to dynamically find the last year for bias-corrected 
+      # output based on the years available in the input simulation.
+      # Different experiments have different end dates and we don't want to
+      # make up data where it didn't already exist.
+    - name: get-biascorrected-last-year
+      inputs:
+        parameters:
+          - name: in-zarr
+          - name: time-variable-name
+            value: "time"
+      outputs:
+        parameters:
+          - name: last-year
+            valueFrom:
+              path: "/tmp/lastyear.txt"
+      script:
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.10.0
+        command: [ python ]
+        source: |
+          import dodola.repository
+
+          input_zarr = "{{ inputs.parameters.in-zarr }}"
+          time_variable = "{{ inputs.parameters.time-variable-name }}"
+
+          print(f"Reading {input_zarr}")
+          ds = dodola.repository.read(input_zarr)
+
+          # Getting the full date is useful for debugging.
+          max_date = ds[time_variable].max().item()
+          print(f"Found {max_date=}")
+
+          max_year = max_date.year
+          out_lastyear = 2014   # For historical simulations.
+          # For ssp* experiment simulations:
+          if max_year == 2099:
+              out_lastyear = 2099
+          elif max_year >= 2100:
+              out_lastyear = 2100
+
+          print(f"Using {out_lastyear=}")
+          with open("/tmp/lastyear.txt", mode="w") as fl:
+              fl.write(str(out_lastyear))
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: "100m"
+          limits:
+            memory: 2Gi
+            cpu: "1000m"
+      activeDeadlineSeconds: 900
+      retryStrategy:
+        limit: 4
+        retryPolicy: "Always"
+        backoff:
+          duration: 30s
+          factor: 2

--- a/workflows/templates/qdm.yaml
+++ b/workflows/templates/qdm.yaml
@@ -33,6 +33,8 @@ spec:
         value: "false"
       - name: first-year
         value: 2015
+      - name: last-year
+        value: 2100
   templates:
 
     - name: main
@@ -48,6 +50,7 @@ spec:
           - name: correct-wetday-frequency
           - name: qdm-kind
           - name: first-year
+          - name: last-year
       outputs:
         parameters:
           - name: out-zarr
@@ -93,19 +96,11 @@ spec:
                   value: "{{ inputs.parameters.domainfile1x1 }}"
                 - name: correct-wetday-frequency
                   value: "{{ inputs.parameters.correct-wetday-frequency }}"
-          - name: calc-qdm-last-year
-            depends: preprocess-simulation
-            template: calc-qdm-last-year
-            arguments:
-              parameters:
-                - name: in-zarr
-                  value: "{{ tasks.preprocess-simulation.outputs.parameters.out-zarr }}"
           - name: qdm
             depends: >-
               preprocess-reference
               && preprocess-training
               && preprocess-simulation
-              && calc-qdm-last-year
             template: qdm
             arguments:
               parameters:
@@ -124,7 +119,7 @@ spec:
                 - name: first-year
                   value: "{{ inputs.parameters.first-year }}"
                 - name: last-year
-                  value: "{{ tasks.calc-qdm-last-year.outputs.parameters.last-year }}"
+                  value: "{{ inputs.parameters.last-year }}"
 
 
     - name: preprocess
@@ -213,56 +208,6 @@ spec:
           emptyDir:
             sizeLimit: 40Gi
       activeDeadlineSeconds: 1200
-      retryStrategy:
-        limit: 4
-        retryPolicy: "Always"
-        backoff:
-          duration: 30s
-          factor: 2
-
-
-    - name: calc-qdm-last-year
-      inputs:
-        parameters:
-          - name: in-zarr
-          - name: time-variable-name
-            value: "time"
-      outputs:
-        parameters:
-          - name: last-year
-            valueFrom:
-              path: "/tmp/lastyear.txt"
-      script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.10.0
-        command: [ python ]
-        source: |
-          import dodola.services
-          import dodola.repository
-
-          input_zarr = "{{ inputs.parameters.in-zarr }}"
-          time_variable = "{{ inputs.parameters.time-variable-name }}"
-
-          print(f"Reading {input_zarr}")
-          ds = dodola.repository.read(input_zarr)
-
-          max_year = ds[time_variable].max().item().year
-          print(f"Found {max_year=}")  # DEBUG
-
-          out_lastyear = 2099
-          if max_year >= 2100:
-              out_lastyear = 2100
-
-          print(f"Using {out_lastyear=}")
-          with open("/tmp/lastyear.txt", mode="w") as fl:
-              fl.write(str(out_lastyear))
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: "500m"
-          limits:
-            memory: 2Gi
-            cpu: "1000m"
-      activeDeadlineSeconds: 900
       retryStrategy:
         limit: 4
         retryPolicy: "Always"


### PR DESCRIPTION
Fixes QDM bias correction of historical simulations getting passed bad (i.e. future) "last-year" parameter.
This PR also moves the 'dynamically find last year of output' logic out of the QDM workflowtemplate, because it's not really a key part of the QDM method.

close #371 
close #368 