### PR TITLE
Fixes various format errors and references to non-existing data

### DIFF
--- a/workflows/parameters/ACCESS-ESM1-5-pr.yaml
+++ b/workflows/parameters/ACCESS-ESM1-5-pr.yaml
@@ -23,11 +23,5 @@ jobs: |
       "variable_id": "pr",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "ACCESS-ESM1-5", "institution_id": "CSIRO", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191115" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "pr", "source_id": "ACCESS-ESM1-5", "institution_id": "CSIRO", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191115" }
-    },
-    {
-      "target": "ssp",
-      "variable_id": "pr",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "ACCESS-ESM1-5", "institution_id": "CSIRO", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191115" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "pr", "source_id": "ACCESS-ESM1-5", "institution_id": "CSIRO", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191115" }
     }
   ]

--- a/workflows/parameters/ACCESS-ESM1-5-tasmin.yaml
+++ b/workflows/parameters/ACCESS-ESM1-5-tasmin.yaml
@@ -23,11 +23,5 @@ jobs: |
       "variable_id": "tasmin",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "ACCESS-ESM1-5", "institution_id": "CSIRO", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191115" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "ACCESS-ESM1-5", "institution_id": "CSIRO", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191115" }
-    },
-    {
-      "target": "ssp",
-      "variable_id": "tasmin",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "ACCESS-ESM1-5", "institution_id": "CSIRO", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191115" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmin", "source_id": "ACCESS-ESM1-5", "institution_id": "CSIRO", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191115" }
     }
   ]

--- a/workflows/parameters/GFDL-CM4-tasmax.yaml
+++ b/workflows/parameters/GFDL-CM4-tasmax.yaml
@@ -4,7 +4,7 @@ jobs: |
       "target": "historical",
       "variable_id": "tasmax",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "GFDL-CM4", "institution_id": "NOAA-GFDL", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20180701" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "GFDL-CM4", "institution_id": "NOAA-GFDL", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20180701" }
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "GFDL-CM4", "institution_id": "NOAA-GFDL", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20180701" }
     },
     {
       "target": "ssp",

--- a/workflows/parameters/GFDL-CM4-tasmin.yaml
+++ b/workflows/parameters/GFDL-CM4-tasmin.yaml
@@ -4,7 +4,7 @@ jobs: |
       "target": "historical",
       "variable_id": "tasmin",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "GFDL-CM4", "institution_id": "NOAA-GFDL", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20180701" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "GFDL-CM4", "institution_id": "NOAA-GFDL", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20180701" }
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "GFDL-CM4", "institution_id": "NOAA-GFDL", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20180701" }
     },
     {
       "target": "ssp",

--- a/workflows/parameters/GFDL-ESM4-tasmin.yaml
+++ b/workflows/parameters/GFDL-ESM4-tasmin.yaml
@@ -21,7 +21,7 @@ jobs: |
     {
       "target": "ssp",
       "variable_id": "tasmin",
-      "historical": "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "GFDL-ESM4", "institution_id": "NOAA-GFDL", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190726" },
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "GFDL-ESM4", "institution_id": "NOAA-GFDL", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20190726" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "GFDL-ESM4", "institution_id": "NOAA-GFDL", "member_id": "r1i1p1f1", "grid_label": "gr1", "version": "20180701" }
     }
   ]

--- a/workflows/parameters/MPI-ESM-1-2-HAM-pr.yaml
+++ b/workflows/parameters/MPI-ESM-1-2-HAM-pr.yaml
@@ -11,6 +11,5 @@ jobs: |
       "variable_id": "pr",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM-1-2-HAM", "institution_id": "HAMMOZ-Consortium", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190627" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM-1-2-HAM", "institution_id": "DKRZ", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190628" }
-    },
+    }
   ]
-

--- a/workflows/parameters/MPI-ESM-1-2-HAM-tasmin.yaml
+++ b/workflows/parameters/MPI-ESM-1-2-HAM-tasmin.yaml
@@ -11,5 +11,5 @@ jobs: |
       "variable_id": "tasmin",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM-1-2-HAM", "institution_id": "HAMMOZ-Consortium", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190627" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM-1-2-HAM", "institution_id": "DKRZ", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190628" }
-    },
+    }
   ]

--- a/workflows/parameters/NorESM2-MM-pr.yaml
+++ b/workflows/parameters/NorESM2-MM-pr.yaml
@@ -3,31 +3,31 @@ jobs: |
     {
       "target": "historical",
       "variable_id": "pr",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
     },
     {
       "target": "ssp",
       "variable_id": "pr",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
     },
     {
       "target": "ssp",
       "variable_id": "pr",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
     },
     {
       "target": "ssp",
       "variable_id": "pr",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
     },
     {
       "target": "ssp",
       "variable_id": "pr",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "pr", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
     }
   ]

--- a/workflows/parameters/NorESM2-MM-tasmin.yaml
+++ b/workflows/parameters/NorESM2-MM-tasmin.yaml
@@ -3,31 +3,31 @@ jobs: |
     {
       "target": "historical",
       "variable_id": "tasmin",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
     },
     {
       "target": "ssp",
       "variable_id": "tasmin",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
     },
     {
       "target": "ssp",
       "variable_id": "tasmin",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
     },
     {
       "target": "ssp",
       "variable_id": "tasmin",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
     },
     {
       "target": "ssp",
       "variable_id": "tasmin",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190815" },
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmin", "source_id": "NorESM2-MM", "institution_id": "NCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
     }
   ]


### PR DESCRIPTION
This updates tasmin, tasmax, and pr workflow parameter files, fixing a couple of format errors and references to CMIP6 data that do not exist.

close #406

The only outstanding errors that I could not resolve involve references to a missing historical experiment for UKESM1-0-LL:
```
{ "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "UKESM1-0-LL", "institution_id": "MOHC", "member_id": "r1i1p1f2", "grid_label": "gn", "version": "20191016" }
```
This bad reference likely relates to #361 and #405. One solution is switching version to `20190627`, though this version has a [known issue](https://errata.es-doc.org/static/view.html?uid=76b3f818-d65f-c76b-bfd8-cae5bc27825c) with tasmin and tasmax -- pr looks okay.