### PR TITLE
Add apply-dtr-minimum-threshold parameter

### DIFF
--- a/workflows/templates/biascorrectdownscale.yaml
+++ b/workflows/templates/biascorrectdownscale.yaml
@@ -47,6 +47,8 @@ spec:
         value: "false"
       - name: qdm-kind
         value: "additive"
+      - name: apply-dtr-minimum-threshold
+        value: "false"
   templates:
 
 
@@ -58,6 +60,7 @@ spec:
           - name: regrid-method
           - name: correct-wetday-frequency  # "true" or "false" STRING!
           - name: qdm-kind  # additive or multiplicative
+          - name: apply-dtr-minimum-threshold
       steps:
         - - name: variable-id-switch
             template: variable-id-switch
@@ -69,6 +72,8 @@ spec:
                   value: "{{ inputs.parameters.regrid-method }}"
                 - name: correct-wetday-frequency
                   value: "{{ inputs.parameters.correct-wetday-frequency }}"
+                - name: apply-dtr-minimum-threshold
+                  value: "{{ inputs.parameters.apply-dtr-minimum-threshold }}"
                 - name: qdm-kind
                   value: "{{ inputs.parameters.qdm-kind }}"
             withParam: "{{ inputs.parameters.jobs }}"
@@ -80,6 +85,7 @@ spec:
           - name: job
           - name: regrid-method
           - name: correct-wetday-frequency
+          - name: apply-dtr-minimum-threshold
           - name: qdm-kind
           - name: variable-id
             value: "{{=jsonpath(inputs.parameters.job, '$.variable_id') }}"
@@ -98,6 +104,8 @@ spec:
                   value: "{{ inputs.parameters.regrid-method }}"
                 - name: correct-wetday-frequency
                   value: "{{ inputs.parameters.correct-wetday-frequency }}"
+                - name: apply-dtr-minimum-threshold
+                  value: "{{ inputs.parameters.apply-dtr-minimum-threshold }}"
                 - name: qdm-kind
                   value: "{{ inputs.parameters.qdm-kind }}"
             when: "{{ inputs.parameters.variable-id }} != 'dtr'"
@@ -145,6 +153,8 @@ spec:
                   value: "{{ inputs.parameters.regrid-method }}"
                 - name: correct-wetday-frequency
                   value: "{{ inputs.parameters.correct-wetday-frequency }}"
+                - name: apply-dtr-minimum-threshold
+                  value: "{{ inputs.parameters.apply-dtr-minimum-threshold }}"
                 - name: qdm-kind
                   value: "{{ inputs.parameters.qdm-kind }}"
             when: "{{ inputs.parameters.variable-id }} == 'dtr'"
@@ -160,6 +170,7 @@ spec:
           - name: regrid-method
           - name: qdm-kind
           - name: correct-wetday-frequency
+          - name: apply-dtr-minimum-threshold
           - name: domainfile1x1
             value: "gs://support-c23ff1a3/domain.1x1.zarr"
           - name: domainfile0p25x0p25
@@ -179,6 +190,8 @@ spec:
                   value: "{{ inputs.parameters.qdm-kind }}"
                 - name: correct-wetday-frequency
                   value: "{{ inputs.parameters.correct-wetday-frequency }}"
+                - name: apply-dtr-minimum-threshold
+                  value: "{{ inputs.parameters.apply-dtr-minimum-threshold }}"
                 - name: first-year
                   value: 1950
                 - name: domainfile1x1
@@ -200,6 +213,8 @@ spec:
                   value: "{{ inputs.parameters.qdm-kind }}"
                 - name: correct-wetday-frequency
                   value: "{{ inputs.parameters.correct-wetday-frequency }}"
+                - name: apply-dtr-minimum-threshold
+                  value: "{{ inputs.parameters.apply-dtr-minimum-threshold }}"                
                 - name: first-year
                   value: 2015
                 - name: domainfile1x1
@@ -217,6 +232,7 @@ spec:
           - name: regrid-method
           - name: qdm-kind
           - name: correct-wetday-frequency
+          - name: apply-dtr-minimum-threshold
           - name: first-year
           - name: domainfile1x1
           - name: domainfile0p25x0p25
@@ -363,6 +379,8 @@ spec:
                   value: "{{ inputs.parameters.domainfile1x1 }}"
                 - name: correct-wetday-frequency
                   value: "{{ inputs.parameters.correct-wetday-frequency }}"
+                - name: apply-dtr-minimum-threshold
+                  value: "{{ inputs.parameters.apply-dtr-minimum-threshold }}"                
                 - name: qdm-kind
                   value: "{{ inputs.parameters.qdm-kind }}"
                 - name: first-year

--- a/workflows/templates/e2e-dtr-jobs.yaml
+++ b/workflows/templates/e2e-dtr-jobs.yaml
@@ -83,3 +83,5 @@ spec:
                   value: "false"
                 - name: qdm-kind
                   value: "multiplicative"
+                - name: apply-dtr-minimum-threshold
+                  value: "true"

--- a/workflows/templates/e2e-pr-jobs.yaml
+++ b/workflows/templates/e2e-pr-jobs.yaml
@@ -61,3 +61,5 @@ spec:
                   value: "true"
                 - name: qdm-kind
                   value: "multiplicative"
+                - name: apply-dtr-minimum-threshold
+                  value: "false"

--- a/workflows/templates/e2e-tasmax-jobs.yaml
+++ b/workflows/templates/e2e-tasmax-jobs.yaml
@@ -79,4 +79,5 @@ spec:
                   value: "false"
                 - name: qdm-kind
                   value: "additive"
-
+                - name: apply-dtr-minimum-threshold
+                  value: "false"

--- a/workflows/templates/qdm.yaml
+++ b/workflows/templates/qdm.yaml
@@ -148,7 +148,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.12.0
         command: [ python ]
         source: |
           import logging

--- a/workflows/templates/qdm.yaml
+++ b/workflows/templates/qdm.yaml
@@ -31,6 +31,8 @@ spec:
         value: "gs://support-c23ff1a3/domain.1x1.zarr"
       - name: correct-wetday-frequency
         value: "false"
+      - name: apply-dtr-minimum-threshold
+        value: "false"
       - name: first-year
         value: 2015
       - name: last-year
@@ -48,6 +50,7 @@ spec:
           - name: regrid-method
           - name: domainfile1x1
           - name: correct-wetday-frequency
+          - name: apply-dtr-minimum-threshold
           - name: qdm-kind
           - name: first-year
           - name: last-year
@@ -72,6 +75,8 @@ spec:
                   value: "false"
                 - name: add-cyclic
                   value: "false"
+                - name: apply-dtr-minimum-threshold
+                  value: "false"
           - name: preprocess-training
             template: preprocess
             arguments:
@@ -84,6 +89,8 @@ spec:
                   value: "{{ inputs.parameters.domainfile1x1 }}"
                 - name: correct-wetday-frequency
                   value: "{{ inputs.parameters.correct-wetday-frequency }}"
+                - name: apply-dtr-minimum-threshold
+                  value: "{{ inputs.parameters.apply-dtr-minimum-threshold }}"
           - name: preprocess-simulation
             template: preprocess
             arguments:
@@ -96,6 +103,8 @@ spec:
                   value: "{{ inputs.parameters.domainfile1x1 }}"
                 - name: correct-wetday-frequency
                   value: "{{ inputs.parameters.correct-wetday-frequency }}"
+                - name: apply-dtr-minimum-threshold
+                  value: "{{ inputs.parameters.apply-dtr-minimum-threshold }}"
           - name: qdm
             depends: >-
               preprocess-reference
@@ -131,6 +140,7 @@ spec:
           - name: regrid-method
           - name: domain-file
           - name: correct-wetday-frequency
+          - name: apply-dtr-minimum-threshold
           - name: add-cyclic
             value: "lon"
       outputs:
@@ -138,19 +148,28 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.10.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
         command: [ python ]
         source: |
           import logging
           import dodola.services
 
-          logger = logging.getLogger(__name__)
           logging.basicConfig(level=logging.INFO)
+          logger = logging.getLogger(__name__)
 
           input_zarr = "{{ inputs.parameters.in-zarr }}"
 
+          # This is only applied to CMIP6 DTR.
+          apply_minimum_threshold = "{{ inputs.parameters.apply-dtr-minimum-threshold }}".lower() == "true"
+          if apply_minimum_threshold:
+              logger.info("Applying DTR minimum threshold")
+              min_thresholded_zarr = "/workspace/min_thresholded.zarr"
+              dodola.services.correct_small_dtr(input_zarr, min_thresholded_zarr)
+              input_zarr = min_thresholded_zarr
+
           correct_wetday_frequency = "{{ inputs.parameters.correct-wetday-frequency }}".lower() == "true"
           if correct_wetday_frequency:
+              logger.info("Applying wet-day frequency correction")
               wdf_corrected_zarr = "/workspace/wdf_corrected.zarr"
               dodola.services.correct_wet_day_frequency(
                   input_zarr,
@@ -162,6 +181,8 @@ spec:
           # Prevents regridding artifacts along international dateline.
           add_cyclic = "{{ inputs.parameters.add-cyclic }}".lower()
           if add_cyclic != "false":
+              logger.info("Adding cyclic wraparound pixels")
+
               import dodola.repository as storage
               from dodola.core import _add_cyclic
 

--- a/workflows/templates/qdm.yaml
+++ b/workflows/templates/qdm.yaml
@@ -158,15 +158,7 @@ spec:
           logger = logging.getLogger(__name__)
 
           input_zarr = "{{ inputs.parameters.in-zarr }}"
-
-          # This is only applied to CMIP6 DTR.
           apply_minimum_threshold = "{{ inputs.parameters.apply-dtr-minimum-threshold }}".lower() == "true"
-          if apply_minimum_threshold:
-              logger.info("Applying DTR minimum threshold")
-              min_thresholded_zarr = "/workspace/min_thresholded.zarr"
-              dodola.services.correct_small_dtr(input_zarr, min_thresholded_zarr)
-              input_zarr = min_thresholded_zarr
-
           correct_wetday_frequency = "{{ inputs.parameters.correct-wetday-frequency }}".lower() == "true"
           if correct_wetday_frequency:
               logger.info("Applying wet-day frequency correction")
@@ -208,12 +200,27 @@ spec:
               out="/workspace/regridded.zarr"
           )
 
+          # If we're ending with minimum_threshold we need to be sure
+          # the next rechunk step outputs to local disk rather than
+          # the final output zarr URL.
+          if apply_minimum_threshold:
+            rechunked_zarr = "/workspace/timeseries_chunks.zarr"
+          else:
+            rechunked_zarr = "{{ inputs.parameters.out-zarr }}"
+
           # QDM steps require time to be contiguous in memory.
           dodola.services.rechunk(
               "/workspace/regridded.zarr",
               target_chunks = {"time": -1, "lat": 10, "lon": 10},
-              out="{{ inputs.parameters.out-zarr }}"
+              out=rechunked_zarr
           )
+
+          # This minimum threshold is only applied to CMIP6 DTR.
+          if apply_minimum_threshold:
+              dodola.services.correct_small_dtr(
+                  rechunked_zarr, 
+                  "{{ inputs.parameters.out-zarr }}"
+              )
         resources:
           requests:
             memory: 16Gi


### PR DESCRIPTION
Adds the ability to apply a minimum threshold to DTR -- raising all values lower than a threshold up to the threshold.

We're changing more than QDM's "preprocess" step because we pass a parameter saying whether the minimum threshold should be applied starting from the "e2e" workflowtemplates through the biascorrectdownscale workflowtemplate all the way to the QDM template. My thinking here was that the e2e workflowtemplates should make it clear about the differences between each of the variable runs.

close #380