### PR TITLE
explore and modify cmip6 dtr if negative values are present

### DIFF
--- a/notebooks/downscaling_pipeline/cmip6_dtr.ipynb
+++ b/notebooks/downscaling_pipeline/cmip6_dtr.ipynb
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install intake==0.6.2\n",
+    "# ! pip install intake-esm==2021.1.15"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],
@@ -25,12 +35,27 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 2,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "from science_validation_manual import read_gcs_zarr"
+    "### Note that `intake` and `intake-esm` versions must be `0.6.2` and `2021.1.15` respectively for `bnds`, `lat_bnds`, and `lon_bnds` to be preserved in the CMIP6 data. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.6.2\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(intake.__version__)"
    ]
   },
   {
@@ -39,42 +64,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fs = gcsfs.GCSFileSystem(token='/opt/gcsfuse_tokens/impactlab-data.json')"
+    "from science_validation_manual import read_gcs_zarr"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'client, cluster = rhgk.get_standard_cluster()\\ncluster'"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "'''client, cluster = rhgk.get_standard_cluster()\n",
-    "cluster'''"
+    "fs = gcsfs.GCSFileSystem(token='/opt/gcsfuse_tokens/impactlab-data.json')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "col = intake.open_esm_datastore(\"https://storage.googleapis.com/cmip6/pangeo-cmip6.json\")"
+    "# col = intake.open_esm_datastore(\"https://storage.googleapis.com/cmip6/pangeo-cmip6.json\")\n",
+    "col = intake.open_esm_datastore(\"https://storage.googleapis.com/cmip6/pangeo-cmip6-noQC.json\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,14 +192,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'ScenarioMIP.NOAA-GFDL.GFDL-CM4.ssp245.day.gr1': <xarray.Dataset>\n",
+       " Dimensions:    (lat: 180, bnds: 2, lon: 288, member_id: 1, time: 31390)\n",
+       " Coordinates:\n",
+       "     height     float64 ...\n",
+       "   * lat        (lat) float64 -89.5 -88.5 -87.5 -86.5 ... 86.5 87.5 88.5 89.5\n",
+       "     lat_bnds   (lat, bnds) float64 dask.array<chunksize=(180, 2), meta=np.ndarray>\n",
+       "   * lon        (lon) float64 0.625 1.875 3.125 4.375 ... 355.6 356.9 358.1 359.4\n",
+       "     lon_bnds   (lon, bnds) float64 dask.array<chunksize=(288, 2), meta=np.ndarray>\n",
+       "   * time       (time) object 2015-01-01 12:00:00 ... 2100-12-31 12:00:00\n",
+       "     time_bnds  (time, bnds) object dask.array<chunksize=(15695, 2), meta=np.ndarray>\n",
+       "   * member_id  (member_id) <U8 'r1i1p1f1'\n",
+       " Dimensions without coordinates: bnds\n",
+       " Data variables:\n",
+       "     tasmax     (member_id, time, lat, lon) float32 dask.array<chunksize=(1, 840, 180, 288), meta=np.ndarray>\n",
+       " Attributes: (12/51)\n",
+       "     Conventions:             CF-1.7 CMIP-6.0 UGRID-1.0\n",
+       "     activity_id:             ScenarioMIP\n",
+       "     branch_method:           standard\n",
+       "     branch_time_in_child:    0.0\n",
+       "     branch_time_in_parent:   60225.0\n",
+       "     comment:                 <null ref>\n",
+       "     ...                      ...\n",
+       "     variant_label:           r1i1p1f1\n",
+       "     status:                  2019-09-25;created;by nhn2@columbia.edu\n",
+       "     netcdf_tracking_ids:     hdl:21.14100/8ba7eed9-91b4-4933-a0d5-d230190ea72...\n",
+       "     version_id:              v20180701\n",
+       "     intake_esm_varname:      ['tasmax']\n",
+       "     intake_esm_dataset_key:  ScenarioMIP.NOAA-GFDL.GFDL-CM4.ssp245.day.gr1}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "model = 'NorESM2-MM'\n",
-    "# _get_cmip6_dataset(model, variable, tuple_id, period='ssp')\n",
-    "dtr = compute_dtr(model, tuple_id=0)\n",
-    "check_dtr(dtr, model)"
+    "model = 'GFDL-CM4'\n",
+    "'''dtr = compute_dtr(model, tuple_id=0)\n",
+    "check_dtr(dtr, model)'''\n",
+    "tasmax = _get_cmip6_dataset(model, 'tasmax', 1, period='ssp')\n",
+    "tasmax"
    ]
   },
   {
@@ -201,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,16 +274,31 @@
     "        \n",
     "    # compute max or min \n",
     "    if variable == 'tasmax':\n",
-    "        return (maximum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin']), tasmax[k_tasmax[0]].attrs)\n",
+    "        tmax = maximum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+    "        ds_temp = tmax.to_dataset(name='tasmax')\n",
+    "        ds_temp.attrs = tasmax[k_tasmax[0]].attrs\n",
+    "        '''ds_temp = ds_temp.expand_dims({\"bnds\": ds_bnds['bnds']})\n",
+    "        ds_temp = ds_temp.assign_coords({\"lat_bnds\": ds_bnds['lat_bnds'],\n",
+    "                                         \"lon_bnds\": ds_bnds['lon_bnds']})'''\n",
+    "        return ds_temp\n",
+    "    \n",
     "    elif variable == 'tasmin':\n",
-    "        return (minimum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin']), tasmin[k_tasmin[0]].attrs)\n",
+    "        tmin = minimum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+    "        ds_temp = tmin.to_dataset(name='tasmin')\n",
+    "        ds_temp.attrs = tasmin[k_tasmin[0]].attrs\n",
+    "        '''ds_temp = ds_temp.expand_dims({\"bnds\": ds_bnds['bnds']})\n",
+    "        ds_temp = ds_temp.assign_coords({\"lat_bnds\": ds_bnds['lat_bnds'],\n",
+    "                                         \"lon_bnds\": ds_bnds['lon_bnds']})'''\n",
+    "        \n",
+    "        return ds_temp\n",
     "\n",
     "def swap_cmip6_tasmax_or_tasmin(model, tuple_id, variable, ssp='ssp245', target_run='ssp'):\n",
     "    \"\"\"\n",
     "    for select GCMs with negative DTR, this swaps tasmax and tasmin so that tasmax > tasmin \n",
     "    \"\"\"\n",
-    "    temp_var, attribs = _compute_max_or_min_temperature(model, tuple_id=tuple_id, variable=variable, ssp_or_historical=target_run)\n",
-    "    temp_var_computed = temp_var.persist()\n",
+    "    temp_var = _compute_max_or_min_temperature(model, tuple_id=tuple_id, \n",
+    "                                                          variable=variable, ssp_or_historical=target_run)\n",
+    "    ds_temp = temp_var.persist()\n",
     "    \n",
     "    if target_run == 'historical':\n",
     "        activity_id = 'CMIP'\n",
@@ -243,12 +311,9 @@
     "            version = '20180701'\n",
     "        else:\n",
     "            version = '20190726'\n",
-    "    # store_filename = 'gs://impactlab-data/climate/source_data/CMIP6/{}-{}-{}.zarr'.format(model, variable, ssp)\n",
+    "\n",
     "    store_filename = ('gs://raw-305d04da/cmip6/{}/NOAA-GFDL/{}/{}/r1i1p1f1/day/{}/gr1/v{}.zarr'.format(activity_id, model, ssp, variable, version))\n",
     "    store = fs.get_mapper(store_filename, check=False)\n",
-    "    \n",
-    "    ds_temp = temp_var_computed.to_dataset(name=variable)\n",
-    "    ds_temp.attrs = attribs\n",
     "    \n",
     "    ds_temp.chunk({'member_id': 1, 'time': 830, 'lat': len(ds_temp.lat), 'lon': len(ds_temp.lon)}).to_zarr(store, consolidated=True, mode=\"w\")\n",
     "    \n",
@@ -257,35 +322,214 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 145,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# historical: _get_cmip6_dataset('GFDL-CM4', 'tasmin', 0, period='historical')\n",
-    "# ssp245: _get_cmip6_dataset('GFDL-CM4', 'tasmin', 1, period='ssp')\n",
-    "# _get_cmip6_dataset('GFDL-ESM4', 'tasmin', 0, period='historical')"
+    "swap_cmip6_tasmax_or_tasmin('GFDL-ESM4', 1, 'tasmin', 'ssp245', target_run='ssp')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 144,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "\"# variables: tasmin and tasmax\\n# models: GFDL-ESM4 (all ssps included in downscaling) and GFDL-CM4 (ssps 245 and 585)\\nmodel = 'GFDL-ESM4'\\ngfdlcm4_scens = ['historical', 'ssp245', 'ssp585']\\ngfdlesm4_scens = ['historical', 'ssp370', 'ssp245', 'ssp126', 'ssp585']\\nfor variable in ['tasmin', 'tasmax']:\\n    for i, tuple_id in enumerate([0, 1, 2, 3, 4]):\\n        if tuple_id != 0:\\n            target_run = 'ssp'\\n        else:\\n            target_run = 'historical'\\n        swap_cmip6_tasmax_or_tasmin(model, tuple_id, variable, gfdlesm4_scens[i], target_run=target_run)\""
-      ]
-     },
-     "execution_count": 144,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-10-08d03974d51f>:26: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmin = minimum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self.variable, other_variable)\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self_data, other_data) if not reflexive else f(other_data, self_data)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "zarr store for GFDL-ESM4 historical saved to gs://raw-305d04da/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/gr1/v20190726.zarr\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-10-08d03974d51f>:26: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmin = minimum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self.variable, other_variable)\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self_data, other_data) if not reflexive else f(other_data, self_data)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "zarr store for GFDL-ESM4 ssp370 saved to gs://raw-305d04da/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/gr1/v20180701.zarr\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-10-08d03974d51f>:26: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmin = minimum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self.variable, other_variable)\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self_data, other_data) if not reflexive else f(other_data, self_data)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "zarr store for GFDL-ESM4 ssp245 saved to gs://raw-305d04da/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20180701.zarr\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-10-08d03974d51f>:26: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmin = minimum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self.variable, other_variable)\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self_data, other_data) if not reflexive else f(other_data, self_data)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "zarr store for GFDL-ESM4 ssp126 saved to gs://raw-305d04da/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/gr1/v20180701.zarr\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-10-08d03974d51f>:26: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmin = minimum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self.variable, other_variable)\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self_data, other_data) if not reflexive else f(other_data, self_data)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "zarr store for GFDL-ESM4 ssp585 saved to gs://raw-305d04da/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20180701.zarr\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-10-08d03974d51f>:17: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmax = maximum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self.variable, other_variable)\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self_data, other_data) if not reflexive else f(other_data, self_data)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "zarr store for GFDL-ESM4 historical saved to gs://raw-305d04da/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20190726.zarr\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-10-08d03974d51f>:17: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmax = maximum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self.variable, other_variable)\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self_data, other_data) if not reflexive else f(other_data, self_data)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "zarr store for GFDL-ESM4 ssp370 saved to gs://raw-305d04da/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20180701.zarr\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-10-08d03974d51f>:17: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmax = maximum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self.variable, other_variable)\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self_data, other_data) if not reflexive else f(other_data, self_data)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "zarr store for GFDL-ESM4 ssp245 saved to gs://raw-305d04da/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20180701.zarr\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-10-08d03974d51f>:17: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmax = maximum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self.variable, other_variable)\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self_data, other_data) if not reflexive else f(other_data, self_data)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "zarr store for GFDL-ESM4 ssp126 saved to gs://raw-305d04da/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/gr1/v20180701.zarr\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-10-08d03974d51f>:17: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmax = maximum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self.variable, other_variable)\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self_data, other_data) if not reflexive else f(other_data, self_data)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "zarr store for GFDL-ESM4 ssp585 saved to gs://raw-305d04da/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20180701.zarr\n"
+     ]
     }
    ],
    "source": [
     "# variables: tasmin and tasmax\n",
     "# models: GFDL-ESM4 (all ssps included in downscaling) and GFDL-CM4 (ssps 245 and 585)\n",
     "model = 'GFDL-ESM4'\n",
+    "\n",
     "gfdlcm4_scens = ['historical', 'ssp245', 'ssp585']\n",
     "gfdlesm4_scens = ['historical', 'ssp370', 'ssp245', 'ssp126', 'ssp585']\n",
     "for variable in ['tasmin', 'tasmax']:\n",
@@ -298,15 +542,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 142,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ds = read_gcs_zarr('gs://raw-305d04da/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20190726.zarr')"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -315,25 +550,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "original raw CMIP6 data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<ipython-input-33-3735fe96e8b7>:49: UserWarning: DTR has 9670 negative values for GFDL-CM4, GFDL-CM4 needs tasmin/tasmax swapping\n",
-      "  warnings.warn(\"DTR has {} negative values for {}, {} needs tasmin/tasmax swapping\".format(neg_count, model, model))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"original raw CMIP6 data\")\n",
     "model = 'GFDL-CM4'\n",
@@ -344,25 +563,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "pre-processed CMIP6 data\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<ipython-input-33-3735fe96e8b7>:51: UserWarning: DTR has 83 zero values for GFDL-CM4\n",
-      "  warnings.warn(\"DTR has {} zero values for {}\".format(zero_count, model))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"pre-processed CMIP6 data\")\n",
     "model = 'GFDL-CM4'\n",
@@ -372,7 +575,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/downscaling_pipeline/cmip6_dtr.ipynb
+++ b/notebooks/downscaling_pipeline/cmip6_dtr.ipynb
@@ -1,0 +1,414 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import intake\n",
+    "import xarray as xr\n",
+    "import os \n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import zarr \n",
+    "import gcsfs\n",
+    "from xarray.ufuncs import maximum, minimum\n",
+    "import rhg_compute_tools.kubernetes as rhgk\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import re\n",
+    "import yaml\n",
+    "import ast\n",
+    "import warnings "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from science_validation_manual import read_gcs_zarr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs = gcsfs.GCSFileSystem(token='/opt/gcsfuse_tokens/impactlab-data.json')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'client, cluster = rhgk.get_standard_cluster()\\ncluster'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "'''client, cluster = rhgk.get_standard_cluster()\n",
+    "cluster'''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "col = intake.open_esm_datastore(\"https://storage.googleapis.com/cmip6/pangeo-cmip6.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _paramfile_to_tuple(model, variable):\n",
+    "    \"\"\"\n",
+    "    takes in a model and variable, returns tuple from parameter file. \n",
+    "    \"\"\"\n",
+    "    param_file = '/home/jovyan/downscaling/downscale/workflows/parameters/{}-{}.yaml'.format(model, variable)\n",
+    "    with open(param_file, 'r') as f:\n",
+    "        var_dict = yaml.full_load(f)\n",
+    "    # some string parsing \n",
+    "    line = var_dict['jobs']\n",
+    "    line1 = re.sub(r\"\\n\", \"\", line)\n",
+    "    line2 = re.sub(r\"[\\[\\]]\", \"\", line1)\n",
+    "    return ast.literal_eval(line2.strip())\n",
+    "\n",
+    "def _get_cmip6_dataset(model, variable, tuple_id, period='ssp'):\n",
+    "    d_ssp = _paramfile_to_tuple(model, variable)[tuple_id][period]\n",
+    "    cat = col.search(\n",
+    "              activity_id=d_ssp['activity_id'],\n",
+    "              experiment_id=d_ssp['experiment_id'],\n",
+    "              table_id=d_ssp['table_id'],\n",
+    "              variable_id=d_ssp['variable_id'],\n",
+    "              source_id=d_ssp['source_id'],\n",
+    "              member_id=d_ssp['member_id'],\n",
+    "              grid_label=d_ssp['grid_label'],\n",
+    "              version=int(d_ssp['version']),\n",
+    "          )\n",
+    "    return cat.to_dataset_dict(progressbar=False)\n",
+    "\n",
+    "def compute_dtr(model, tuple_id=1):\n",
+    "    \"\"\"\n",
+    "    takes in tasmax and tasmin Datasets, computes DTR (returns it lazily)\n",
+    "    \"\"\"\n",
+    "    tasmax = _get_cmip6_dataset(model, 'tasmax', tuple_id)\n",
+    "    k_tasmax = list(tasmax.keys())\n",
+    "    if len(k_tasmax) != 1:\n",
+    "        raise ValueError(\"there is likely an issue with {} tasmax\".format(model))\n",
+    "    tasmin = _get_cmip6_dataset(model, 'tasmin', tuple_id)\n",
+    "    k_tasmin = list(tasmin.keys())\n",
+    "    if len(k_tasmin) != 1:\n",
+    "        raise ValueError(\"there is likely an issue with {} tasmin\".format(model))\n",
+    "    return tasmax[k_tasmax[0]]['tasmax'] - tasmin[k_tasmin[0]]['tasmin'] \n",
+    "\n",
+    "def check_dtr(dtr, model):\n",
+    "    \"\"\"\n",
+    "    \"\"\"\n",
+    "    min_dtr = dtr.min('time')\n",
+    "    neg_count = min_dtr.where(min_dtr < 0).count().values\n",
+    "    zero_count = min_dtr.where(min_dtr == 0).count().values\n",
+    "    if neg_count > 0:\n",
+    "        warnings.warn(\"DTR has {} negative values for {}, {} needs tasmin/tasmax swapping\".format(neg_count, model, model))\n",
+    "    if zero_count > 0:\n",
+    "        warnings.warn(\"DTR has {} zero values for {}\".format(zero_count, model))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "checking models "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "DTR negative: \n",
+    "- GFDL-ESM4\n",
+    "- GFDL-CM4\n",
+    "\n",
+    "DTR positive: \n",
+    "- CanESM5\n",
+    "- INM-CM4-8\n",
+    "- INM-CM5-0\n",
+    "- NorESM2-MM\n",
+    "- NorESM2-LM\n",
+    "- MIROC6\n",
+    "- EC-Earth3-Veg-LR\n",
+    "- EC-Earth3-Veg\n",
+    "- EC-Earth3\n",
+    "- KIOST-ESM\n",
+    "- MIROC-ES2L\n",
+    "- MPI-ESM1-2-LR\n",
+    "- MPI-ESM1-2-HR\n",
+    "- NESM3\n",
+    "- MRI-ESM2-0\n",
+    "- FGOALS-g3\n",
+    "- CMCC-ESM2\n",
+    "- BCC-CSM2-MR\n",
+    "- AWI-CM-1-1-MR\n",
+    "- ACCESS-CM2\n",
+    "\n",
+    "Parameter files to add or fix (could not check DTR): \n",
+    "- UKESM1-0-LL\n",
+    "- ACCESS-ESM1-5\n",
+    "\n",
+    "Tasmin parameter files to add (could not check DTR): \n",
+    "- CAMS-CSM1-0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = 'NorESM2-MM'\n",
+    "# _get_cmip6_dataset(model, variable, tuple_id, period='ssp')\n",
+    "dtr = compute_dtr(model, tuple_id=0)\n",
+    "check_dtr(dtr, model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### For models with negative DTR, swap tasmax and tasmin ### \n",
+    "\n",
+    "GFDL-CM4: historical, ssp245, ssp585\n",
+    "\n",
+    "GFDL-ESM4: historical, ssp126, ssp245, ssp370, ssp585"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _compute_max_or_min_temperature(model, tuple_id=1, variable='tasmax', ssp_or_historical='ssp'):\n",
+    "    \"\"\"\n",
+    "    takes in a model source_id, pulls in the required parameter file info, \n",
+    "    gets the tasmax and tasmin Datasets from the CMIP6 archive, computes tasmax or tasmin (returns it lazily)\n",
+    "    \"\"\"\n",
+    "    tasmax = _get_cmip6_dataset(model, 'tasmax', tuple_id, period=ssp_or_historical)\n",
+    "    k_tasmax = list(tasmax.keys())\n",
+    "    if len(k_tasmax) != 1:\n",
+    "        raise ValueError(\"there is likely an issue with {} tasmax\".format(model))\n",
+    "    tasmin = _get_cmip6_dataset(model, 'tasmin', tuple_id, period=ssp_or_historical)\n",
+    "    k_tasmin = list(tasmin.keys())\n",
+    "    if len(k_tasmin) != 1:\n",
+    "        raise ValueError(\"there is likely an issue with {} tasmin\".format(model))\n",
+    "        \n",
+    "    # compute max or min \n",
+    "    if variable == 'tasmax':\n",
+    "        return (maximum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin']), tasmax[k_tasmax[0]].attrs)\n",
+    "    elif variable == 'tasmin':\n",
+    "        return (minimum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin']), tasmin[k_tasmin[0]].attrs)\n",
+    "\n",
+    "def swap_cmip6_tasmax_or_tasmin(model, tuple_id, variable, ssp='ssp245', target_run='ssp'):\n",
+    "    \"\"\"\n",
+    "    for select GCMs with negative DTR, this swaps tasmax and tasmin so that tasmax > tasmin \n",
+    "    \"\"\"\n",
+    "    temp_var, attribs = _compute_max_or_min_temperature(model, tuple_id=tuple_id, variable=variable, ssp_or_historical=target_run)\n",
+    "    temp_var_computed = temp_var.persist()\n",
+    "    \n",
+    "    if target_run == 'historical':\n",
+    "        activity_id = 'CMIP'\n",
+    "    else:\n",
+    "        activity_id = 'ScenarioMIP'\n",
+    "    if model == 'GFDL-CM4':\n",
+    "        version = '20180701'\n",
+    "    elif model == 'GFDL-ESM4':\n",
+    "        if target_run == 'ssp':\n",
+    "            version = '20180701'\n",
+    "        else:\n",
+    "            version = '20190726'\n",
+    "    # store_filename = 'gs://impactlab-data/climate/source_data/CMIP6/{}-{}-{}.zarr'.format(model, variable, ssp)\n",
+    "    store_filename = ('gs://raw-305d04da/cmip6/{}/NOAA-GFDL/{}/{}/r1i1p1f1/day/{}/gr1/v{}.zarr'.format(activity_id, model, ssp, variable, version))\n",
+    "    store = fs.get_mapper(store_filename, check=False)\n",
+    "    \n",
+    "    ds_temp = temp_var_computed.to_dataset(name=variable)\n",
+    "    ds_temp.attrs = attribs\n",
+    "    \n",
+    "    ds_temp.chunk({'member_id': 1, 'time': 830, 'lat': len(ds_temp.lat), 'lon': len(ds_temp.lon)}).to_zarr(store, consolidated=True, mode=\"w\")\n",
+    "    \n",
+    "    print(\"zarr store for {} {} saved to {}\".format(model, ssp, store_filename))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 145,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# historical: _get_cmip6_dataset('GFDL-CM4', 'tasmin', 0, period='historical')\n",
+    "# ssp245: _get_cmip6_dataset('GFDL-CM4', 'tasmin', 1, period='ssp')\n",
+    "# _get_cmip6_dataset('GFDL-ESM4', 'tasmin', 0, period='historical')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 144,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"# variables: tasmin and tasmax\\n# models: GFDL-ESM4 (all ssps included in downscaling) and GFDL-CM4 (ssps 245 and 585)\\nmodel = 'GFDL-ESM4'\\ngfdlcm4_scens = ['historical', 'ssp245', 'ssp585']\\ngfdlesm4_scens = ['historical', 'ssp370', 'ssp245', 'ssp126', 'ssp585']\\nfor variable in ['tasmin', 'tasmax']:\\n    for i, tuple_id in enumerate([0, 1, 2, 3, 4]):\\n        if tuple_id != 0:\\n            target_run = 'ssp'\\n        else:\\n            target_run = 'historical'\\n        swap_cmip6_tasmax_or_tasmin(model, tuple_id, variable, gfdlesm4_scens[i], target_run=target_run)\""
+      ]
+     },
+     "execution_count": 144,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# variables: tasmin and tasmax\n",
+    "# models: GFDL-ESM4 (all ssps included in downscaling) and GFDL-CM4 (ssps 245 and 585)\n",
+    "model = 'GFDL-ESM4'\n",
+    "gfdlcm4_scens = ['historical', 'ssp245', 'ssp585']\n",
+    "gfdlesm4_scens = ['historical', 'ssp370', 'ssp245', 'ssp126', 'ssp585']\n",
+    "for variable in ['tasmin', 'tasmax']:\n",
+    "    for i, tuple_id in enumerate([0, 1, 2, 3, 4]):\n",
+    "        if tuple_id != 0:\n",
+    "            target_run = 'ssp'\n",
+    "        else:\n",
+    "            target_run = 'historical'\n",
+    "        swap_cmip6_tasmax_or_tasmin(model, tuple_id, variable, gfdlesm4_scens[i], target_run=target_run)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 142,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = read_gcs_zarr('gs://raw-305d04da/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20190726.zarr')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "check original raw DTR for `GFDL-CM4` ssp245 and then \"updated\" DTR for the same model/ssp "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "original raw CMIP6 data\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-33-3735fe96e8b7>:49: UserWarning: DTR has 9670 negative values for GFDL-CM4, GFDL-CM4 needs tasmin/tasmax swapping\n",
+      "  warnings.warn(\"DTR has {} negative values for {}, {} needs tasmin/tasmax swapping\".format(neg_count, model, model))\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"original raw CMIP6 data\")\n",
+    "model = 'GFDL-CM4'\n",
+    "# _get_cmip6_dataset(model, variable, tuple_id, period='ssp')\n",
+    "dtr = compute_dtr(model, tuple_id=1)\n",
+    "check_dtr(dtr, model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pre-processed CMIP6 data\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-33-3735fe96e8b7>:51: UserWarning: DTR has 83 zero values for GFDL-CM4\n",
+      "  warnings.warn(\"DTR has {} zero values for {}\".format(zero_count, model))\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"pre-processed CMIP6 data\")\n",
+    "model = 'GFDL-CM4'\n",
+    "\n",
+    "check_dtr(dtr_gfdlcm4_ssp245, model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "min_dtr = dtr_gfdlcm4_ssp245.min('time')\n",
+    "neg_count = min_dtr.where(min_dtr < 0).count().values\n",
+    "if neg_count > 0:\n",
+    "    warnings.warn(\"DTR has negative values for {} STILL\".format('GFDL-CM4 ssp245'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/downscaling_pipeline/cmip6_dtr.ipynb
+++ b/notebooks/downscaling_pipeline/cmip6_dtr.ipynb
@@ -60,6 +60,27 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-66-a4ebb10b4b70>:3: UserWarning: Double check that you have installed intake-esm (the 2021.1.15 version specified above), otherwise the bnds, lat_bnds, and lon_bdns will not be loaded               in any Pangeo CMIP6 datasets in the cat.to_dataset_dict step\n",
+      "  warnings.warn(\"Double check that you have installed intake-esm (the 2021.1.15 version specified above), otherwise the bnds, lat_bnds, and lon_bdns will not be loaded \\\n"
+     ]
+    }
+   ],
+   "source": [
+    "if intake.__version__ != '0.6.2':\n",
+    "    raise AssertionError(\"this workflow requires version 0.6.2 of intake\")\n",
+    "warnings.warn(\"Double check that you have installed intake-esm (the 2021.1.15 version specified above), otherwise the bnds, lat_bnds, and lon_bdns will not be loaded \\\n",
+    "              in any Pangeo CMIP6 datasets in the cat.to_dataset_dict step\")"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
    "outputs": [],
@@ -192,43 +213,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'ScenarioMIP.NOAA-GFDL.GFDL-CM4.ssp245.day.gr1': <xarray.Dataset>\n",
-       " Dimensions:    (lat: 180, bnds: 2, lon: 288, member_id: 1, time: 31390)\n",
-       " Coordinates:\n",
-       "     height     float64 ...\n",
-       "   * lat        (lat) float64 -89.5 -88.5 -87.5 -86.5 ... 86.5 87.5 88.5 89.5\n",
-       "     lat_bnds   (lat, bnds) float64 dask.array<chunksize=(180, 2), meta=np.ndarray>\n",
-       "   * lon        (lon) float64 0.625 1.875 3.125 4.375 ... 355.6 356.9 358.1 359.4\n",
-       "     lon_bnds   (lon, bnds) float64 dask.array<chunksize=(288, 2), meta=np.ndarray>\n",
-       "   * time       (time) object 2015-01-01 12:00:00 ... 2100-12-31 12:00:00\n",
-       "     time_bnds  (time, bnds) object dask.array<chunksize=(15695, 2), meta=np.ndarray>\n",
-       "   * member_id  (member_id) <U8 'r1i1p1f1'\n",
-       " Dimensions without coordinates: bnds\n",
-       " Data variables:\n",
-       "     tasmax     (member_id, time, lat, lon) float32 dask.array<chunksize=(1, 840, 180, 288), meta=np.ndarray>\n",
-       " Attributes: (12/51)\n",
-       "     Conventions:             CF-1.7 CMIP-6.0 UGRID-1.0\n",
-       "     activity_id:             ScenarioMIP\n",
-       "     branch_method:           standard\n",
-       "     branch_time_in_child:    0.0\n",
-       "     branch_time_in_parent:   60225.0\n",
-       "     comment:                 <null ref>\n",
-       "     ...                      ...\n",
-       "     variant_label:           r1i1p1f1\n",
-       "     status:                  2019-09-25;created;by nhn2@columbia.edu\n",
-       "     netcdf_tracking_ids:     hdl:21.14100/8ba7eed9-91b4-4933-a0d5-d230190ea72...\n",
-       "     version_id:              v20180701\n",
-       "     intake_esm_varname:      ['tasmax']\n",
-       "     intake_esm_dataset_key:  ScenarioMIP.NOAA-GFDL.GFDL-CM4.ssp245.day.gr1}"
+       "{'cell_measures': 'area: areacella',\n",
+       " 'cell_methods': 'area: mean time: maximum',\n",
+       " 'interp_method': 'conserve_order2',\n",
+       " 'long_name': 'Daily Maximum Near-Surface Air Temperature',\n",
+       " 'original_name': 'tasmax',\n",
+       " 'standard_name': 'air_temperature',\n",
+       " 'units': 'K'}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -238,7 +238,7 @@
     "'''dtr = compute_dtr(model, tuple_id=0)\n",
     "check_dtr(dtr, model)'''\n",
     "tasmax = _get_cmip6_dataset(model, 'tasmax', 1, period='ssp')\n",
-    "tasmax"
+    "k_tasmax = list(tasmax.keys())"
    ]
   },
   {
@@ -254,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,26 +271,22 @@
     "    k_tasmin = list(tasmin.keys())\n",
     "    if len(k_tasmin) != 1:\n",
     "        raise ValueError(\"there is likely an issue with {} tasmin\".format(model))\n",
+    "    ds_tmax = tasmax[k_tasmax[0]].copy()\n",
+    "    ds_tmin = tasmin[k_tasmin[0]].copy()\n",
     "        \n",
     "    # compute max or min \n",
     "    if variable == 'tasmax':\n",
-    "        tmax = maximum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
-    "        ds_temp = tmax.to_dataset(name='tasmax')\n",
-    "        ds_temp.attrs = tasmax[k_tasmax[0]].attrs\n",
-    "        '''ds_temp = ds_temp.expand_dims({\"bnds\": ds_bnds['bnds']})\n",
-    "        ds_temp = ds_temp.assign_coords({\"lat_bnds\": ds_bnds['lat_bnds'],\n",
-    "                                         \"lon_bnds\": ds_bnds['lon_bnds']})'''\n",
-    "        return ds_temp\n",
+    "        tmax = maximum(ds_tmax['tasmax'], ds_tmin['tasmin'])\n",
+    "        tmax.attrs = tasmax[k_tasmax[0]]['tasmax'].attrs\n",
+    "        ds_tmax['tasmax'] = tmax\n",
+    "        return ds_tmax\n",
     "    \n",
     "    elif variable == 'tasmin':\n",
-    "        tmin = minimum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
-    "        ds_temp = tmin.to_dataset(name='tasmin')\n",
-    "        ds_temp.attrs = tasmin[k_tasmin[0]].attrs\n",
-    "        '''ds_temp = ds_temp.expand_dims({\"bnds\": ds_bnds['bnds']})\n",
-    "        ds_temp = ds_temp.assign_coords({\"lat_bnds\": ds_bnds['lat_bnds'],\n",
-    "                                         \"lon_bnds\": ds_bnds['lon_bnds']})'''\n",
+    "        tmin = minimum(ds_tmax['tasmax'], ds_tmin['tasmin'])\n",
+    "        tmin.attrs = tasmin[k_tasmin[0]]['tasmin'].attrs\n",
+    "        ds_tmin['tasmin'].values = tmin \n",
     "        \n",
-    "        return ds_temp\n",
+    "        return ds_tmin\n",
     "\n",
     "def swap_cmip6_tasmax_or_tasmin(model, tuple_id, variable, ssp='ssp245', target_run='ssp'):\n",
     "    \"\"\"\n",
@@ -322,24 +318,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "swap_cmip6_tasmax_or_tasmin('GFDL-ESM4', 1, 'tasmin', 'ssp245', target_run='ssp')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-10-08d03974d51f>:26: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
-      "  tmin = minimum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "<ipython-input-53-0429f515085c>:19: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmax = maximum(ds_tmax['tasmax'], ds_tmin['tasmin'])\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self.variable, other_variable)\n",
+      "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  f(self_data, other_data) if not reflexive else f(other_data, self_data)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "zarr store for GFDL-CM4 ssp245 saved to gs://raw-305d04da/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20180701.zarr\n"
+     ]
+    }
+   ],
+   "source": [
+    "swap_cmip6_tasmax_or_tasmin('GFDL-CM4', 1, 'tasmax', 'ssp245', target_run='ssp')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-53-0429f515085c>:26: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmin = minimum(ds_tmax['tasmax'], ds_tmin['tasmin'])\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
       "  f(self.variable, other_variable)\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
@@ -357,8 +373,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-10-08d03974d51f>:26: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
-      "  tmin = minimum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "<ipython-input-53-0429f515085c>:26: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmin = minimum(ds_tmax['tasmax'], ds_tmin['tasmin'])\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
       "  f(self.variable, other_variable)\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
@@ -376,8 +392,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-10-08d03974d51f>:26: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
-      "  tmin = minimum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "<ipython-input-53-0429f515085c>:26: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmin = minimum(ds_tmax['tasmax'], ds_tmin['tasmin'])\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
       "  f(self.variable, other_variable)\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
@@ -395,8 +411,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-10-08d03974d51f>:26: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
-      "  tmin = minimum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "<ipython-input-53-0429f515085c>:26: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmin = minimum(ds_tmax['tasmax'], ds_tmin['tasmin'])\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
       "  f(self.variable, other_variable)\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
@@ -414,8 +430,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-10-08d03974d51f>:26: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
-      "  tmin = minimum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "<ipython-input-53-0429f515085c>:26: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmin = minimum(ds_tmax['tasmax'], ds_tmin['tasmin'])\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
       "  f(self.variable, other_variable)\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
@@ -433,8 +449,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-10-08d03974d51f>:17: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
-      "  tmax = maximum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "<ipython-input-53-0429f515085c>:19: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmax = maximum(ds_tmax['tasmax'], ds_tmin['tasmin'])\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
       "  f(self.variable, other_variable)\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
@@ -452,8 +468,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-10-08d03974d51f>:17: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
-      "  tmax = maximum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "<ipython-input-53-0429f515085c>:19: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmax = maximum(ds_tmax['tasmax'], ds_tmin['tasmin'])\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
       "  f(self.variable, other_variable)\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
@@ -471,8 +487,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-10-08d03974d51f>:17: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
-      "  tmax = maximum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "<ipython-input-53-0429f515085c>:19: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmax = maximum(ds_tmax['tasmax'], ds_tmin['tasmin'])\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
       "  f(self.variable, other_variable)\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
@@ -490,8 +506,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-10-08d03974d51f>:17: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
-      "  tmax = maximum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "<ipython-input-53-0429f515085c>:19: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmax = maximum(ds_tmax['tasmax'], ds_tmin['tasmin'])\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
       "  f(self.variable, other_variable)\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
@@ -509,8 +525,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-10-08d03974d51f>:17: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
-      "  tmax = maximum(tasmax[k_tasmax[0]]['tasmax'], tasmin[k_tasmin[0]]['tasmin'])\n",
+      "<ipython-input-53-0429f515085c>:19: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
+      "  tmax = maximum(ds_tmax['tasmax'], ds_tmin['tasmin'])\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/dataarray.py:3081: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
       "  f(self.variable, other_variable)\n",
       "/srv/conda/envs/notebook/lib/python3.8/site-packages/xarray/core/variable.py:2409: FutureWarning: xarray.ufuncs is deprecated. Instead, use numpy ufuncs directly.\n",
@@ -542,6 +558,34 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'cell_measures': 'area: areacella',\n",
+       " 'cell_methods': 'area: mean time: maximum',\n",
+       " 'interp_method': 'conserve_order2',\n",
+       " 'long_name': 'Daily Maximum Near-Surface Air Temperature',\n",
+       " 'original_name': 'tasmax',\n",
+       " 'standard_name': 'air_temperature',\n",
+       " 'units': 'K'}"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# ds = read_gcs_zarr('gs://raw-305d04da/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20180701.zarr')\n",
+    "ds = read_gcs_zarr('gs://raw-305d04da/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20180701.zarr')\n",
+    "ds['tasmax'].attrs"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -550,39 +594,72 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "ds_tmax = read_gcs_zarr('gs://raw-305d04da/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20180701.zarr')\n",
+    "ds_tmin = read_gcs_zarr('gs://raw-305d04da/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20180701.zarr')\n",
+    "dtr_gfdlcm4_ssp585 = ds_tmax['tasmax'] - ds_tmin['tasmin']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "original raw CMIP6 data\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-7-3735fe96e8b7>:49: UserWarning: DTR has 9661 negative values for GFDL-CM4, GFDL-CM4 needs tasmin/tasmax swapping\n",
+      "  warnings.warn(\"DTR has {} negative values for {}, {} needs tasmin/tasmax swapping\".format(neg_count, model, model))\n",
+      "<ipython-input-7-3735fe96e8b7>:51: UserWarning: DTR has 1 zero values for GFDL-CM4\n",
+      "  warnings.warn(\"DTR has {} zero values for {}\".format(zero_count, model))\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"original raw CMIP6 data\")\n",
     "model = 'GFDL-CM4'\n",
     "# _get_cmip6_dataset(model, variable, tuple_id, period='ssp')\n",
-    "dtr = compute_dtr(model, tuple_id=1)\n",
+    "dtr = compute_dtr(model, tuple_id=2)\n",
     "check_dtr(dtr, model)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 62,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pre-processed CMIP6 data\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<ipython-input-7-3735fe96e8b7>:51: UserWarning: DTR has 95 zero values for GFDL-CM4\n",
+      "  warnings.warn(\"DTR has {} zero values for {}\".format(zero_count, model))\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"pre-processed CMIP6 data\")\n",
     "model = 'GFDL-CM4'\n",
     "\n",
-    "check_dtr(dtr_gfdlcm4_ssp245, model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "min_dtr = dtr_gfdlcm4_ssp245.min('time')\n",
-    "neg_count = min_dtr.where(min_dtr < 0).count().values\n",
-    "if neg_count > 0:\n",
-    "    warnings.warn(\"DTR has negative values for {} STILL\".format('GFDL-CM4 ssp245'))"
+    "check_dtr(dtr_gfdlcm4_ssp585, model)"
    ]
   },
   {


### PR DESCRIPTION
This notebook explores and computes DTR for CMIP6 models. If DTR is negative (which only occurs for the GFDL models), tasmax/tasmin are swapped and saved to the "raw" CMIP6 bucket in our downscaling pipeline. 

closes #403 and #426 