### PR TITLE
Fix failing precipitation regridding in QDM bias-correction

### DIFF
--- a/workflows/templates/qdm-preprocess.yaml
+++ b/workflows/templates/qdm-preprocess.yaml
@@ -41,7 +41,7 @@ spec:
           - name: apply-dtr-minimum-threshold
             value: "false"
           - name: add-cyclic
-            value: "lon"
+            value: "{{=inputs.parameters['regrid-method'] == 'bilinear' ? 'lon' : 'false'}}"
       outputs:
         parameters:
           - name: out-zarr


### PR DESCRIPTION
This changes QDM-preprocessing so that cyclic or wrap-around pixels are
only added to 'lon' dimension when using "bilinear" regridding method.
This change fixes a bug were precipitation "conservative" regridding
method fails due to duplicate values in the "lon" dimension
which were added as wrap-around pixels.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

[summarize your pull request here]