### PR TITLE
Fix failing precipitation regrid in QPLAD downscaling steps

### DIFF
--- a/workflows/templates/qplad.yaml
+++ b/workflows/templates/qplad.yaml
@@ -140,7 +140,7 @@ spec:
                 - name: domain-file
                   value: "{{ inputs.parameters.domain-file }}"
                 - name: add-cyclic-lon
-                  value: "true"
+                  value: "{{=inputs.parameters['regrid-method'] == 'bilinear' ? 'true' : 'false'}}"
                 - name: add-lat-buffer
                   value: "true"
         - - name: move-chunks-to-space
@@ -211,7 +211,7 @@ spec:
                 - name: domain-file
                   value: "{{ inputs.parameters.domainfile0p25x0p25 }}"
                 - name: add-cyclic-lon
-                  value: "true"
+                  value: "{{=inputs.parameters['regrid-method'] == 'bilinear' ? 'true' : 'false'}}"
                 - name: add-lat-buffer
                   value: "true"
         - - name: move-chunks-to-space
@@ -270,7 +270,7 @@ spec:
                 - name: domain-file
                   value: "{{ inputs.parameters.domain-file }}"
                 - name: add-cyclic-lon
-                  value: "true"
+                  value: "{{=inputs.parameters['regrid-method'] == 'bilinear' ? 'true' : 'false'}}"
                 - name: add-lat-buffer
                   value: "true"
 


### PR DESCRIPTION
This changes QPLAD preprocessing templates so that cyclic pixels are
only added when using "bilinear" regridding method.
This change fixes a bug where precipitation "conservative" regridding
method fails due to duplicate values in the "lon" dimension
which were added as wrap-around pixels.

Companion to PR #454

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

[summarize your pull request here]