### PR TITLE
Dirty fix to ERA-5 precipitation data being "tp"

### DIFF
--- a/workflows/templates/clean-era5.yaml
+++ b/workflows/templates/clean-era5.yaml
@@ -119,6 +119,8 @@ spec:
             ds = ds.rename({"tmin": "tasmin"})
         if "precip" in ds.variables:
             ds = ds.rename({"precip": "pr"})
+        if "tp" in ds.variables:
+            ds = ds.rename({"tp": "pr"})
         ds = ds.rename({"latitude": "lat", "longitude": "lon"})
 
         ds = ds.drop_vars("dayofyear", errors="ignore")


### PR DESCRIPTION
Precipitation should be "pr" in cleaned data. We're seeing precipitation as a "tp" variable in raw reanalysis data. This PR is a quick and dirty fix so it gets properly renamed instead of ignored in the cleaning step.