### PR TITLE
Add GKE metrics scraper for argo wrk controller

### DIFF
--- a/infrastructure/kubernetes-gcp/argo/kustomization.yaml
+++ b/infrastructure/kubernetes-gcp/argo/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - argo-cildc6-org.yaml
   - argo-server-ingress.yaml
   - sso-client-externalsecret.yaml
+  - workflow-controller-monitor.yaml
 
 patchesStrategicMerge:
   - patches/workflow-controller-configmap.yaml

--- a/infrastructure/kubernetes-gcp/argo/workflow-controller-monitor.yaml
+++ b/infrastructure/kubernetes-gcp/argo/workflow-controller-monitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.gke.io/v1alpha1
+kind: PodMonitor
+metadata:
+  name: workflow-controller-monitor
+  namespace: argo
+spec:
+  selector:
+    matchLabels:
+      app: workflow-controller
+      app.kubernetes.io/instance: argo
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics


### PR DESCRIPTION
Adds argo workflow controller metrics monitor to test monitor addition.

Take this addition as a prototype. LIkely to break, change in the near future.