### PR TITLE
Fix dtr polar validation in dodola dev release

### DIFF
--- a/workflows/templates/qualitycontrol-check-cmip6.yaml
+++ b/workflows/templates/qualitycontrol-check-cmip6.yaml
@@ -40,7 +40,7 @@ spec:
           - name: data
           - name: time
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.11.1
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
         command: [python]
         source: |
           import dask


### PR DESCRIPTION
Bumping the dodola image for a validation step to test https://github.com/ClimateImpactLab/dodola/pull/153.

Related to #450. Note we're switching to a floating dodola:dev image.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

[summarize your pull request here]