### PR TITLE
Allow 0s in clean CMIP6 DTR validation check

### DIFF
--- a/workflows/templates/qualitycontrol-check-cmip6.yaml
+++ b/workflows/templates/qualitycontrol-check-cmip6.yaml
@@ -40,7 +40,7 @@ spec:
           - name: data
           - name: time
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.13.0
         command: [python]
         source: |
           import dask
@@ -73,7 +73,7 @@ spec:
               if v == "tasmin" or v == "tasmax":
                   _test_temp_range(d, v)
               if v == "dtr":
-                  _test_dtr_range(d, v)
+                  _test_dtr_range(d, v, data_type)
               if v == "dtr" or v == "pr":
                  _test_negative_values(d, v)
               if v == "pr":

--- a/workflows/templates/qualitycontrol-check-cmip6.yaml
+++ b/workflows/templates/qualitycontrol-check-cmip6.yaml
@@ -43,6 +43,9 @@ spec:
         image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.13.0
         command: [python]
         source: |
+          # Running this as a script rather than a dodola command as workaround to 
+          # https://github.com/ClimateImpactLab/dodola/issues/126
+          
           import dask
           import numpy as np
           from dodola.core import (_test_for_nans, _test_variable_names, _test_timesteps, _test_temp_range, _test_dtr_range, _test_negative_values, _test_maximum_precip)


### PR DESCRIPTION
This pins the dodola image in the QC control workflow to the recent dodola:0.13.0 release.

close #452

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

[summarize your pull request here]