### PR TITLE
Test fix for bad precip wetday correction and precip max validation

### DIFF
--- a/workflows/templates/qdm-preprocess.yaml
+++ b/workflows/templates/qdm-preprocess.yaml
@@ -154,7 +154,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.12.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
         command: [ python ]
         source: |
           import logging
@@ -165,7 +165,6 @@ spec:
 
           input_zarr = "{{ inputs.parameters.in-zarr }}"
 
-          wdf_corrected_zarr = "/workspace/wdf_corrected.zarr"
           dodola.services.correct_wet_day_frequency(
               "{{ inputs.parameters.in-zarr }}",
               process="pre",

--- a/workflows/templates/qualitycontrol-check-cmip6.yaml
+++ b/workflows/templates/qualitycontrol-check-cmip6.yaml
@@ -40,7 +40,7 @@ spec:
           - name: data
           - name: time
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.13.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
         command: [python]
         source: |
           # Running this as a script rather than a dodola command as workaround to 


### PR DESCRIPTION
This PR sets the wetday-frequency correction and cmip6 validation steps to use the latest `dodola:dev` to test fixes in https://github.com/ClimateImpactLab/dodola/pull/158.

Note we're switching these template steps over to a floating `dodola:dev` release. They should be pinned to a proper release in a later PR if this works.

Close #458