### PR TITLE
Add remaining tasmin pr parameter files

### DIFF
--- a/workflows/parameters/ACCESS-CM2-pr.yaml
+++ b/workflows/parameters/ACCESS-CM2-pr.yaml
@@ -1,0 +1,21 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    }
+  ]

--- a/workflows/parameters/ACCESS-CM2-tasmin.yaml
+++ b/workflows/parameters/ACCESS-CM2-tasmin.yaml
@@ -1,0 +1,21 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "ACCESS-CM2", "institution_id": "CSIRO-ARCCSS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+    }
+  ]

--- a/workflows/parameters/AWI-CM-1-1-MR-tasmin.yaml
+++ b/workflows/parameters/AWI-CM-1-1-MR-tasmin.yaml
@@ -1,0 +1,33 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "AWI-CM-1-1-MR", "institution_id": "AWI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20181218" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "AWI-CM-1-1-MR", "institution_id": "AWI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190529" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "AWI-CM-1-1-MR", "institution_id": "AWI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20181218" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "AWI-CM-1-1-MR", "institution_id": "AWI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190529" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "AWI-CM-1-1-MR", "institution_id": "AWI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20181218" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "AWI-CM-1-1-MR", "institution_id": "AWI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190529" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "AWI-CM-1-1-MR", "institution_id": "AWI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20181218" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "AWI-CM-1-1-MR", "institution_id": "AWI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190529" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "AWI-CM-1-1-MR", "institution_id": "AWI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20181218" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmin", "source_id": "AWI-CM-1-1-MR", "institution_id": "AWI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190529" }
+    }
+  ]

--- a/workflows/parameters/FGOALS-g3-pr.yaml
+++ b/workflows/parameters/FGOALS-g3-pr.yaml
@@ -1,0 +1,28 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190826" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190820" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190826" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190820" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190826" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190818" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190826" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "pr", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190818" }
+    }
+  ]
+

--- a/workflows/parameters/FGOALS-g3-tasmin.yaml
+++ b/workflows/parameters/FGOALS-g3-tasmin.yaml
@@ -1,0 +1,34 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190826" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190820" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190826" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190820" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190826" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190818" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190826" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190818" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190826" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmin", "source_id": "FGOALS-g3", "institution_id": "CAS", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190819" }
+    }
+  ]
+


### PR DESCRIPTION
 This PR adds missing parameter files for tasmin and pr for `AWI-CM-1-1-MR`, `FGOALS-g3`, and `ACCESS-CM2`. Note the following: 

- historical pr is missing from the Pangeo archive for any ensemble members for AWI-CM-1-1-MR, hence no parameter file 
- no ssp126 present in the archive for FGOALS-g3 pr 
- other ssps available for ACCESS-CM2, but we eliminated 126 and 585 for tasmax/tasmin due to NaNs so doing the same for pr 