### PR TITLE
Validation check limit for precip raised to 3000 mm

### DIFF
--- a/workflows/templates/qualitycontrol-check-cmip6.yaml
+++ b/workflows/templates/qualitycontrol-check-cmip6.yaml
@@ -40,7 +40,7 @@ spec:
           - name: data
           - name: time
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.14.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.15.0
         command: [python]
         source: |
           # Running this as a script rather than a dodola command as workaround to 


### PR DESCRIPTION
Updates validation template so that precipitation values up to 3000 mm are considered valid. The previous limit was 2000 mm. 

This update comes with bumping the validation/QC template to use the new `dodola:0.15.0` container image.