### PR TITLE
Add wet-day frequency correction to QPLAD fine, coarse reference creation

### DIFF
--- a/workflows/templates/biascorrectdownscale-precipitation.yaml
+++ b/workflows/templates/biascorrectdownscale-precipitation.yaml
@@ -338,6 +338,8 @@ spec:
                   value: "{{ inputs.parameters.regrid-method }}"
                 - name: domain-file
                   value: "{{ inputs.parameters.domainfile0p25x0p25 }}"
+                - name: correct-wetday-frequency
+                  value: "{{ inputs.parameters.correct-wetday-frequency }}"
           - name: create-coarse-reference
             templateRef:
               name: qplad
@@ -352,6 +354,8 @@ spec:
                   value: "{{ inputs.parameters.domainfile0p25x0p25 }}"
                 - name: domainfile1x1
                   value: "{{ inputs.parameters.domainfile1x1 }}"
+                - name: correct-wetday-frequency
+                  value: "{{ inputs.parameters.correct-wetday-frequency }}"
           - name: preprocess-biascorrected
             templateRef:
               name: qplad

--- a/workflows/templates/qplad.yaml
+++ b/workflows/templates/qplad.yaml
@@ -62,6 +62,8 @@ spec:
                   value: "{{ inputs.parameters.regrid-method }}"
                 - name: domain-file
                   value: "{{ inputs.parameters.domainfile0p25x0p25 }}"
+                - name: correct-wetday-frequency
+                  value: "{{ inputs.parameters.correct-wetday-frequency }}"
           - name: create-coarse-reference
             template: create-coarse-reference
             arguments:
@@ -74,6 +76,8 @@ spec:
                   value: "{{ inputs.parameters.domainfile0p25x0p25 }}"
                 - name: domainfile1x1
                   value: "{{ inputs.parameters.domainfile1x1 }}"
+                - name: correct-wetday-frequency
+                  value: "{{ inputs.parameters.correct-wetday-frequency }}"
           - name: preprocess-biascorrected
             template: preprocess-biascorrected
             arguments:
@@ -112,6 +116,8 @@ spec:
           - name: in-zarr
           - name: regrid-method
           - name: domain-file
+          - name: correct-wetday-frequency
+            value: "false"
       outputs:
         parameters:
           - name: out-zarr
@@ -148,6 +154,14 @@ spec:
                   value: "{{=inputs.parameters['regrid-method'] == 'bilinear' ? 'true' : 'false'}}"
                 - name: add-lat-buffer
                   value: "true"
+        - - name: check-to-correct-wetday-frequency
+            template: check-to-correct-wetday-frequency
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ steps.regrid.outputs.parameters.out-zarr }}"
+                - name: correct-wetday-frequency
+                  value: "{{ inputs.parameters.correct-wetday-frequency }}"
         - - name: move-chunks-to-space
             templateRef:
               name: rechunk
@@ -155,7 +169,7 @@ spec:
             arguments:
               parameters:
                 - name: in-zarr
-                  value: "{{ steps.regrid.outputs.parameters.out-zarr }}"
+                  value: "{{ steps.check-to-correct-wetday-frequency.outputs.parameters.out-zarr }}"
                 - name: time-chunk
                   value: 365
                 - name: lat-chunk
@@ -171,6 +185,8 @@ spec:
           - name: regrid-method
           - name: domainfile0p25x0p25
           - name: domainfile1x1
+          - name: correct-wetday-frequency
+            value: "false"
       outputs:
         parameters:
           - name: out-zarr
@@ -189,6 +205,14 @@ spec:
                   value: "{{ inputs.parameters.regrid-method }}"
                 - name: domain-file
                   value: "{{ inputs.parameters.domainfile1x1 }}"
+        - - name: check-to-correct-wetday-frequency
+            template: check-to-correct-wetday-frequency
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ steps.coarse-regrid.outputs.parameters.out-zarr }}"
+                - name: correct-wetday-frequency
+                  value: "{{ inputs.parameters.correct-wetday-frequency }}"
         - - name: move-chunks-to-time
             templateRef:
               name: rechunk
@@ -196,7 +220,7 @@ spec:
             arguments:
               parameters:
                 - name: in-zarr
-                  value: "{{ steps.coarse-regrid.outputs.parameters.out-zarr }}"
+                  value: "{{ steps.check-to-correct-wetday-frequency.outputs.parameters.out-zarr }}"
                 - name: time-chunk
                   value: "73"
                 - name: lat-chunk
@@ -535,3 +559,69 @@ spec:
       retryStrategy:
         limit: 2
         retryPolicy: "Always"
+
+
+    - name: check-to-correct-wetday-frequency
+      inputs:
+        parameters:
+          - name: in-zarr
+          - name: correct-wetday-frequency
+            value: "false"
+      dag:
+        tasks:
+          - name: correct-wetday-frequency
+            template: correct-wetday-frequency
+            arguments:
+              parameters:
+                - name: in-zarr
+                  value: "{{ inputs.parameters.in-zarr }}"
+            when: "{{inputs.parameters.correct-wetday-frequency}} == true"
+      outputs:
+        parameters:
+          - name: out-zarr
+            valueFrom:
+              expression: "inputs.parameters['correct-wetday-frequency'] == 'true' ? tasks['correct-wetday-frequency'].outputs.parameters['out-zarr'] : inputs.parameters['in-zarr']"
+
+
+      # Wet-day freqency correction for downscaling precipitation
+    - name: correct-wetday-frequency
+      inputs:
+        parameters:
+          - name: in-zarr
+          - name: out-zarr
+            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/wdf-corrected.zarr"
+      outputs:
+        parameters:
+          - name: out-zarr
+            value: "{{ inputs.parameters.out-zarr }}"
+      script:
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.15.0
+        command: [ python ]
+        source: |
+          import logging
+          import dodola.services
+
+          logging.basicConfig(level=logging.INFO)
+          logger = logging.getLogger(__name__)
+
+          input_zarr = "{{ inputs.parameters.in-zarr }}"
+
+          dodola.services.correct_wet_day_frequency(
+              "{{ inputs.parameters.in-zarr }}",
+              process="pre",
+              out="{{ inputs.parameters.out-zarr }}"
+          )
+        resources:
+          requests:
+            memory: 16Gi
+            cpu: "1000m"
+          limits:
+            memory: 18Gi
+            cpu: "2000m"
+      activeDeadlineSeconds: 1200
+      retryStrategy:
+        limit: 4
+        retryPolicy: "Always"
+        backoff:
+          duration: 30s
+          factor: 2


### PR DESCRIPTION
Adds optional wet-day frequency correction to the fine and coarse reference creation templates in the QPLAD WorkflowTemplate. By default wet-day correction is not applied.

This fixes an issue where precipitation data had wet-day correction to references in bias-correction but later downscaling reference data did not have wet-day correction. Exploding values ensued.

Includes changes to e2e-precipitation workflowtemplate so that wet-day correct parameter is correctly passed to reference creation.

Wet-day correction is applied to the QPLAD reference after the first regrid from native to 1x1 degree grids.