### PR TITLE
Fix no --wetday-post-correction error

### DIFF
--- a/workflows/templates/qplad.yaml
+++ b/workflows/templates/qplad.yaml
@@ -451,7 +451,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.10.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.15.0
         command: [ dodola ]
         args:
           - "train-qplad"
@@ -495,7 +495,7 @@ spec:
           - name: global-attrs-json
             path: /tmp/global_attrs.json
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.10.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.15.0
         command: [ dodola ]
         args:
           - "apply-qplad"
@@ -539,7 +539,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.13.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.15.0
         command: [ dodola ]
         args:
           - "prime-qplad-output-zarrstore"


### PR DESCRIPTION
Bumps all QPLAD template images to dodola:0.15.0 to support wetday-post-correction option. An error is thrown without this update.
