### PR TITLE
Bump argo to patch bad emissary default mounting

### DIFF
--- a/infrastructure/kubernetes-gcp/argo/kustomization.yaml
+++ b/infrastructure/kubernetes-gcp/argo/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/argoproj/argo-workflows/releases/download/v3.2.5/install.yaml
+  - https://github.com/argoproj/argo-workflows/releases/download/v3.2.6/install.yaml
   - argo-cildc6-org.yaml
   - argo-server-ingress.yaml
   - sso-client-externalsecret.yaml


### PR DESCRIPTION
Bumps argo workflows to v3.2.6. Fixes some relevant, but not critical bugs related to mounting empty directories in the `wait` container.