### PR TITLE
Scale-down core nodes to standard memory

### DIFF
--- a/infrastructure/terraform/gcp-core/modules/gke_argo_cluster/main.tf
+++ b/infrastructure/terraform/gcp-core/modules/gke_argo_cluster/main.tf
@@ -82,7 +82,7 @@ resource "google_container_node_pool" "core" {
   }
 
   node_config {
-    machine_type    = "e2-highmem-4"
+    machine_type    = "e2-standard-4"
     image_type      = "COS_CONTAINERD"
     service_account = var.node_service_account_email
     oauth_scopes = [


### PR DESCRIPTION
This will be more efficient and cost-effective. We didn't use all available memory with larger workflows, parallelized to run 10 at a time, per Namespace. We can get away with "standard" types.
