### PR TITLE
Fix precip workflows killed before finishing

### DIFF
--- a/workflows/templates/e2e-pr-jobs.yaml
+++ b/workflows/templates/e2e-pr-jobs.yaml
@@ -11,6 +11,8 @@ metadata:
     component: e2e
 spec:
   entrypoint: e2e-pr-jobs
+  # Workflows must finish in 12 hours. Precip runs a bit long right now:
+  activeDeadlineSeconds: 43200
   arguments:
     parameters:
       - name: jobs


### PR DESCRIPTION
Extends workflow deadline from 8 hours (default) to 12 hours. 

The addition of "ceiling threshold" steps to biascorrection and downscaling parts of the precipitation workflow are new and still inefficient. This PR extends the workflows deadline so that workflows will not need to be manually retried or restarted. This was a problem in our last couple precip runs.

Ideally, we can polish up these new ceiling steps so they run faster. This deadline extension will do in the meantime.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

[summarize your pull request here]