### PR TITLE
Fix bad Argo Workflow version reference, bad argocd syncs

### DIFF
--- a/infrastructure/kubernetes-gcp/argo/kustomization.yaml
+++ b/infrastructure/kubernetes-gcp/argo/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/argoproj/argo-workflows/releases/download/v3.2.7/install.yaml
+  - https://github.com/argoproj/argo-workflows/releases/download/v3.2.6/install.yaml
   - argo-cildc6-org.yaml
   - argo-server-ingress.yaml
   - sso-client-externalsecret.yaml


### PR DESCRIPTION
Reverts the changes in PR #506 which reference a non-existing version of argo workflows (v3.2.7). This PR corrects this by switching back to argo v3.2.6.