### PR TITLE
Deploy new e2e-tasmin-jobs.yaml workflowtemplate

### DIFF
--- a/workflows/templates/kustomization.yaml
+++ b/workflows/templates/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - e2e-dtr-jobs.yaml
   - e2e-pr-jobs.yaml
   - e2e-tasmax-jobs.yaml
+  - e2e-tasmin-jobs.yaml
   - qdm.yaml
   - qdm-preprocess.yaml
   - qualitycontrol-check-cmip6.yaml


### PR DESCRIPTION
This fixes a bug in PR #505 and PR #506 where a new workflowtemplate is was created in the repo, but it is never referenced in the kustomization file and thus, never deployed.

The PR fixes things by listing the new workflowTemplate in workflows/templates/kustomization.yaml so the CD system can pick it up and deploy it to the cluster.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

[summarize your pull request here]