### PR TITLE
extend minimum temperature tolerance from 150 K to 130 K

### DIFF
--- a/workflows/templates/qualitycontrol-check-cmip6.yaml
+++ b/workflows/templates/qualitycontrol-check-cmip6.yaml
@@ -40,7 +40,7 @@ spec:
           - name: data
           - name: time
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.15.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.16.0
         command: [python]
         source: |
           # Running this as a script rather than a dodola command as workaround to 


### PR DESCRIPTION
This upgrades the container in `qualitycontrol-cmip6` template to the recently released dodola 0.16.0 version, in order to use a wider temperature validation range with a lower bound at 130 K instead of 150 K, from this PR : https://github.com/ClimateImpactLab/dodola/pull/170. 