### PR TITLE
Bump ingress-nginx to 4.0.16

### DIFF
--- a/infrastructure/kubernetes-gcp/ingress-nginx/Chart.yaml
+++ b/infrastructure/kubernetes-gcp/ingress-nginx/Chart.yaml
@@ -16,5 +16,5 @@ appVersion: "0.0.1"
 
 dependencies:
   - name: ingress-nginx
-    version: "4.0.6"
+    version: "4.0.16"
     repository: 'https://kubernetes.github.io/ingress-nginx'


### PR DESCRIPTION
General ingress update. This is not required for any particular bug fixes or new features.
