### PR TITLE
Update cert-manager to 1.6.1

### DIFF
--- a/infrastructure/kubernetes-gcp/cert-manager/kustomization.yaml
+++ b/infrastructure/kubernetes-gcp/cert-manager/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/jetstack/cert-manager/releases/download/v1.5.4/cert-manager.yaml
+  - https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
   - letsencrypt-prod-clusterissuer.yaml
   - letsencrypt-staging-clusterissuer.yaml


### PR DESCRIPTION
General ingress update. This is not required for any particular bug fixes or new features.
