### PR TITLE
Fixes error in bad QPLAD coarse reference regrid method

### DIFF
--- a/workflows/templates/qplad.yaml
+++ b/workflows/templates/qplad.yaml
@@ -236,7 +236,7 @@ spec:
                 - name: in-zarr
                   value: "{{ steps.move-chunks-to-time.outputs.parameters.out-zarr }}"
                 - name: regrid-method
-                  value: "{{ inputs.parameters.regrid-method }}"
+                  value: "nearest_s2d"
                 - name: domain-file
                   value: "{{ inputs.parameters.domainfile0p25x0p25 }}"
                 - name: add-cyclic-lon


### PR DESCRIPTION
The QPLAD coarse reference data should be regridded using methods similar to the main biascorrected/downscaled simulation, when regridding from 1x1 to 0.25x0.25 grids. The main simulation uses "nearest_s2d" to regrid to 0.25x0.25 degrees. The coarse reference used either "conservative" or "bilinear" regridding instead of "nearest_s2d" in its corresponding step. This fixes this error so that the coarse reference is regridded to 0.25x0.25 with "nearest_s2d" -- matching the simulation regrid.

For comparison, the logic for biascorrected regridding to 0.25x0.25 grid currently lives [here](https://github.com/ClimateImpactLab/downscaleCMIP6/blob/02030dc69674eb153c2acf13941d4e0735636d07/workflows/templates/qplad.yaml#L262) lines 262 - 304.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

[summarize your pull request here]