### PR TITLE
Fix bad random draws in QDM wet-day correction

### DIFF
--- a/workflows/templates/qdm-preprocess.yaml
+++ b/workflows/templates/qdm-preprocess.yaml
@@ -154,7 +154,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.16.1
         command: [ dodola ]
         args:
           - "correct-wetday-frequency"

--- a/workflows/templates/qdm-preprocess.yaml
+++ b/workflows/templates/qdm-preprocess.yaml
@@ -163,10 +163,10 @@ spec:
           - "--out={{ inputs.parameters.out-zarr }}"
         resources:
           requests:
-            memory: 20Gi
+            memory: 30Gi
             cpu: "1000m"
           limits:
-            memory: 20Gi
+            memory: 30Gi
             cpu: "2000m"
       activeDeadlineSeconds: 1800
       retryStrategy:

--- a/workflows/templates/qdm-preprocess.yaml
+++ b/workflows/templates/qdm-preprocess.yaml
@@ -153,31 +153,22 @@ spec:
         parameters:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
-      script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.15.0
-        command: [ python ]
-        source: |
-          import logging
-          import dodola.services
-
-          logging.basicConfig(level=logging.INFO)
-          logger = logging.getLogger(__name__)
-
-          input_zarr = "{{ inputs.parameters.in-zarr }}"
-
-          dodola.services.correct_wet_day_frequency(
-              "{{ inputs.parameters.in-zarr }}",
-              process="pre",
-              out="{{ inputs.parameters.out-zarr }}"
-          )
+      container:
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:dev
+        command: [ dodola ]
+        args:
+          - "correct-wetday-frequency"
+          - "{{ inputs.parameters.in-zarr}}"
+          - "--process=pre"
+          - "--out={{ inputs.parameters.out-zarr }}"
         resources:
           requests:
-            memory: 16Gi
+            memory: 20Gi
             cpu: "1000m"
           limits:
-            memory: 18Gi
+            memory: 20Gi
             cpu: "2000m"
-      activeDeadlineSeconds: 1200
+      activeDeadlineSeconds: 1800
       retryStrategy:
         limit: 4
         retryPolicy: "Always"


### PR DESCRIPTION
Updates QDM wet-day step to new dodola release. This patch fixes a bug where wet-day correction only drew a single random value rather than an array (see https://github.com/ClimateImpactLab/dodola/issues/173).

The PR also changes the wet-day step to use the dodola command rather than a custom python script from scratch. It's more compact and easier to test this way.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

[summarize your pull request here]