### PR TITLE
Add remaining parameter files

### DIFF
--- a/workflows/parameters/CMCC-CM2-SR5-pr.yaml
+++ b/workflows/parameters/CMCC-CM2-SR5-pr.yaml
@@ -1,0 +1,33 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200616" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200622" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200616" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200622" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200616" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200617" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200616" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200717" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200616" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200622" }
+    }
+  ]

--- a/workflows/parameters/CMCC-CM2-SR5-tasmax.yaml
+++ b/workflows/parameters/CMCC-CM2-SR5-tasmax.yaml
@@ -1,0 +1,33 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200616" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200622" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200616" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200622" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200616" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200617" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200616" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200717" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200616" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200622" }
+    }
+  ]

--- a/workflows/parameters/CMCC-CM2-SR5-tasmin.yaml
+++ b/workflows/parameters/CMCC-CM2-SR5-tasmin.yaml
@@ -1,0 +1,33 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200616" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200622" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200616" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200622" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200616" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200617" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200616" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200717" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200616" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-CM2-SR5", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20200622" }
+    }
+  ]

--- a/workflows/parameters/CMCC-ESM2-pr.yaml
+++ b/workflows/parameters/CMCC-ESM2-pr.yaml
@@ -1,0 +1,33 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210114" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210202" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210114" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210202" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210114" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210129" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210114" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210126" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210114" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "pr", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210126" }
+    }
+  ]

--- a/workflows/parameters/CMCC-ESM2-tasmin.yaml
+++ b/workflows/parameters/CMCC-ESM2-tasmin.yaml
@@ -1,0 +1,33 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210114" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210202" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210114" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210202" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210114" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210129" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210114" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210126" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210114" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmin", "source_id": "CMCC-ESM2", "institution_id": "CMCC", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20210126" }
+    }
+  ]

--- a/workflows/parameters/EC-Earth3-AerChem-pr.yaml
+++ b/workflows/parameters/EC-Earth3-AerChem-pr.yaml
@@ -11,6 +11,6 @@ jobs: |
       "variable_id": "pr",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200624" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200827" }
-    },
+    }
   ]
 

--- a/workflows/parameters/EC-Earth3-AerChem-pr.yaml
+++ b/workflows/parameters/EC-Earth3-AerChem-pr.yaml
@@ -1,0 +1,16 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200827" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200827" }
+    },
+  ]
+

--- a/workflows/parameters/EC-Earth3-AerChem-tasmax.yaml
+++ b/workflows/parameters/EC-Earth3-AerChem-tasmax.yaml
@@ -1,0 +1,16 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200827" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200827" }
+    },
+  ]
+

--- a/workflows/parameters/EC-Earth3-AerChem-tasmax.yaml
+++ b/workflows/parameters/EC-Earth3-AerChem-tasmax.yaml
@@ -11,6 +11,6 @@ jobs: |
       "variable_id": "tasmax",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200624" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200827" }
-    },
+    }
   ]
 

--- a/workflows/parameters/EC-Earth3-AerChem-tasmin.yaml
+++ b/workflows/parameters/EC-Earth3-AerChem-tasmin.yaml
@@ -11,6 +11,6 @@ jobs: |
       "variable_id": "tasmin",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200624" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200827" }
-    },
+    }
   ]
 

--- a/workflows/parameters/EC-Earth3-AerChem-tasmin.yaml
+++ b/workflows/parameters/EC-Earth3-AerChem-tasmin.yaml
@@ -1,0 +1,16 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200827" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "EC-Earth3-AerChem", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20200827" }
+    },
+  ]
+

--- a/workflows/parameters/EC-Earth3-CC-pr.yaml
+++ b/workflows/parameters/EC-Earth3-CC-pr.yaml
@@ -1,0 +1,22 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "pr", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" }
+    }
+  ]
+

--- a/workflows/parameters/EC-Earth3-CC-tasmax.yaml
+++ b/workflows/parameters/EC-Earth3-CC-tasmax.yaml
@@ -1,0 +1,22 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" }
+    }
+  ]
+

--- a/workflows/parameters/EC-Earth3-CC-tasmin.yaml
+++ b/workflows/parameters/EC-Earth3-CC-tasmin.yaml
@@ -1,0 +1,22 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmin", "source_id": "EC-Earth3-CC", "institution_id": "EC-Earth-Consortium", "member_id": "r1i1p1f1", "grid_label": "gr", "version": "20210113" }
+    }
+  ]
+

--- a/workflows/parameters/HadGEM3-GC31-LL-pr.yaml
+++ b/workflows/parameters/HadGEM3-GC31-LL-pr.yaml
@@ -1,0 +1,27 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190908" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190908" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "pr", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20200114" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "pr",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "pr", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20200114" }
+    }
+  ]

--- a/workflows/parameters/HadGEM3-GC31-LL-tasmax.yaml
+++ b/workflows/parameters/HadGEM3-GC31-LL-tasmax.yaml
@@ -1,0 +1,27 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190908" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190908" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20200114" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20200114" }
+    }
+  ]

--- a/workflows/parameters/HadGEM3-GC31-LL-tasmin.yaml
+++ b/workflows/parameters/HadGEM3-GC31-LL-tasmin.yaml
@@ -1,0 +1,27 @@
+jobs: |
+  [
+    {
+      "target": "historical",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190908" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190908" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20200114" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmin",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20190624" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmin", "source_id": "HadGEM3-GC31-LL", "institution_id": "MOHC", "member_id": "r1i1p1f3", "grid_label": "gn", "version": "20200114" }
+    }
+  ]

--- a/workflows/parameters/UKESM1-0-LL-pr.yaml
+++ b/workflows/parameters/UKESM1-0-LL-pr.yaml
@@ -27,7 +27,7 @@ jobs: |
     {
       "target": "ssp",
       "variable_id": "pr",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "UKESM1-0-LL", "institution_id": "MOHC", "member_id": "r1i1p1f2", "grid_label": "gn", "version": "20191016" },
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "UKESM1-0-LL", "institution_id": "MOHC", "member_id": "r1i1p1f2", "grid_label": "gn", "version": "20190627" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "pr", "source_id": "UKESM1-0-LL", "institution_id": "MOHC", "member_id": "r1i1p1f2", "grid_label": "gn", "version": "20190726" }
     }
   ]

--- a/workflows/parameters/UKESM1-0-LL-tasmax.yaml
+++ b/workflows/parameters/UKESM1-0-LL-tasmax.yaml
@@ -27,7 +27,7 @@ jobs: |
     {
       "target": "ssp",
       "variable_id": "tasmax",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "UKESM1-0-LL", "institution_id": "MOHC", "member_id": "r1i1p1f2", "grid_label": "gn", "version": "20191016" },
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "UKESM1-0-LL", "institution_id": "MOHC", "member_id": "r1i1p1f2", "grid_label": "gn", "version": "20190627" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "UKESM1-0-LL", "institution_id": "MOHC", "member_id": "r1i1p1f2", "grid_label": "gn", "version": "20190726" }
     }
   ]

--- a/workflows/parameters/UKESM1-0-LL-tasmin.yaml
+++ b/workflows/parameters/UKESM1-0-LL-tasmin.yaml
@@ -27,7 +27,7 @@ jobs: |
     {
       "target": "ssp",
       "variable_id": "tasmin",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "UKESM1-0-LL", "institution_id": "MOHC", "member_id": "r1i1p1f2", "grid_label": "gn", "version": "20191016" },
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "UKESM1-0-LL", "institution_id": "MOHC", "member_id": "r1i1p1f2", "grid_label": "gn", "version": "20190627" },
       "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmin", "source_id": "UKESM1-0-LL", "institution_id": "MOHC", "member_id": "r1i1p1f2", "grid_label": "gn", "version": "20190726" }
     }
   ]


### PR DESCRIPTION
 Adds parameter files for the following models:

- CMCC-CM2-SR5
- CMCC-ESM2
- EC-Earth3-AerChem
- EC-Earth3-CC
- HadGEM3-GC31-LL

And fixes version numbers for `UKESM1-0-LL` parameter files. 