### PR TITLE
Fix MRI-ESM2-0 model nans

### DIFF
--- a/workflows/parameters/MRI-ESM2-0-pr.yaml
+++ b/workflows/parameters/MRI-ESM2-0-pr.yaml
@@ -3,31 +3,31 @@ jobs: |
     {
       "target": "historical",
       "variable_id": "pr",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" }
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190927" }
     },
     {
       "target": "ssp",
       "variable_id": "pr",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" }
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190927" }
     },
     {
       "target": "ssp",
       "variable_id": "pr",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" }
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20210830" }
     },
     {
       "target": "ssp",
       "variable_id": "pr",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20210907" }
     },
     {
       "target": "ssp",
       "variable_id": "pr",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "pr", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20210907" }
     }
   ]

--- a/workflows/parameters/MRI-ESM2-0-tasmax.yaml
+++ b/workflows/parameters/MRI-ESM2-0-tasmax.yaml
@@ -3,19 +3,31 @@ jobs: |
     {
       "target": "historical",
       "variable_id": "tasmax",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" }
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190927" }
     },
     {
       "target": "ssp",
       "variable_id": "tasmax",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" }
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190927" }
     },
     {
       "target": "ssp",
       "variable_id": "tasmax",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" }
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20210830" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20210907" }
+    },
+    {
+      "target": "ssp",
+      "variable_id": "tasmax",
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmax", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20210907" }
     }
   ]

--- a/workflows/parameters/MRI-ESM2-0-tasmin.yaml
+++ b/workflows/parameters/MRI-ESM2-0-tasmin.yaml
@@ -3,31 +3,31 @@ jobs: |
     {
       "target": "historical",
       "variable_id": "tasmin",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" }
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190927" }
     },
     {
       "target": "ssp",
       "variable_id": "tasmin",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" }
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190927" }
     },
     {
       "target": "ssp",
       "variable_id": "tasmin",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" }
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20210830" }
     },
     {
       "target": "ssp",
       "variable_id": "tasmin",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20210907" }
     },
     {
       "target": "ssp",
       "variable_id": "tasmin",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190603" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20191108" }
+      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20190603" },
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp585", "table_id": "day", "variable_id": "tasmin", "source_id": "MRI-ESM2-0", "institution_id": "MRI", "member_id": "r2i1p1f1", "grid_label": "gn", "version": "20210907" }
     }
   ]


### PR DESCRIPTION
 This PR updates the parameter files for the MRI-ESM2-0 model to use the `r2i1p1f1` ensemble member instead of the `r1i1p1f1` member because that one had NaNs for some variables and ssps. 

closes #442 and #376 