### PR TITLE
Add 360 day calendar support to clean-cmip6

### DIFF
--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -408,7 +408,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.16.1
         command: [ "dodola" ]
         args:
           - "cleancmip6"
@@ -443,7 +443,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.16.1
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -510,7 +510,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.8.0
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.16.1
         env:
           - name: IN1_ZARR
             value: "{{ inputs.parameters.in1-zarr }}"


### PR DESCRIPTION
 - [x] closes #181
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

Update the clean-cmip6 WorkflowTemplate dodola containers from v0.8.0 to v0.16.1 so they have basic support for 360-day calendars.
