### PR TITLE
Upgrade argo to v3.2.8 patch

### DIFF
--- a/infrastructure/kubernetes-gcp/argo/kustomization.yaml
+++ b/infrastructure/kubernetes-gcp/argo/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/argoproj/argo-workflows/releases/download/v3.2.7/install.yaml
+  - https://github.com/argoproj/argo-workflows/releases/download/v3.2.8/install.yaml
   - argo-cildc6-org.yaml
   - argo-server-ingress.yaml
   - sso-client-externalsecret.yaml


### PR DESCRIPTION
This is a general patch. We don't need it for a specific feature or bug fix — just rolling with the upstream updates.
