### PR TITLE
manually correct NorESM2 LM raw historical longitude bounds

### DIFF
--- a/notebooks/downscaling_pipeline/correct-NorESM2-LM-raw-historical-lon-bounds.ipynb
+++ b/notebooks/downscaling_pipeline/correct-NorESM2-LM-raw-historical-lon-bounds.ipynb
@@ -10,20 +10,21 @@
     "#### Date of last run : February 11th 2022\n",
     "#### Author : Emile Tenezakis\n",
     "### Purpose : \n",
-    "This notebook was written and run to solve the following issue : https://github.com/ClimateImpactLab/downscaleCMIP6/issues/529 in the CMIP6 downscaling project. The issue was that the precipitation `NorESM2-LM` historical data grid does not exactly match that of the projection grids (future ssp projections), specifically the longitudinal bounds. It was decided, as a workaround, to manually modify the raw downloaded data rather than the workflow code in order to avoid introducing special cases. Therefore, In this notebook, we read the historical and ssp \n",
-    "precipitation `NorESM2-LM` data from the raw data bucket (these files were downloaded saved by the 'download' part of the project pipeline), we replace the `lon_bnds` variable in the historical data by that of any other ssp dataset, and we overwrite the historical zarr store with that new dataset."
+    "This notebook was written and run to solve the following issue : https://github.com/ClimateImpactLab/downscaleCMIP6/issues/529 in the CMIP6 downscaling project. The issue was that the precipitation `NorESM2-LM` historical data grid does not exactly match that of the projection grids (future ssp projections), specifically the longitudinal bounds. It was decided, as a workaround, to manually modify the raw downloaded data rather than the workflow code in order to avoid introducing special cases. Therefore, In this notebook, we download the historical and ssp \n",
+    "precipitation `NorESM2-LM` data from CMIP6-in-the-cloud, we replace the `lon_bnds` variable in the historical data by that of any other ssp dataset, and we overwrite the historical zarr store with that new dataset in our GCS raw data bucket."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 51,
    "id": "c0eb24a9-dde5-4548-a178-dd7f7eb9e05a",
    "metadata": {},
    "outputs": [],
    "source": [
     "import xarray as xr\n",
     "import numpy as np\n",
-    "import gcsfs"
+    "import gcsfs\n",
+    "import intake"
    ]
   },
   {
@@ -31,12 +32,44 @@
    "id": "77409abe-c563-49c4-8246-0ce4fd772a33",
    "metadata": {},
    "source": [
-    "Helper for gcs I/O authentication"
+    "Helper for gcs I/O"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 52,
+   "id": "3796fff8-49f8-45ba-a17c-5ae2c129438b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fetch_pangeo(experiment_id):\n",
+    "    if 'ssp' in experiment_id:\n",
+    "        version = '20191108'\n",
+    "        activity_ID = 'ScenarioMIP'\n",
+    "    elif 'historical' in experiment_id:\n",
+    "        version = '20190815'\n",
+    "        activity_ID = 'CMIP'\n",
+    "    else: \n",
+    "        raise ValueError('invalid experiment id')\n",
+    "    col = intake.open_esm_datastore(\"https://storage.googleapis.com/cmip6/pangeo-cmip6-noQC.json\")\n",
+    "    cat = col.search(\n",
+    "        activity_id=activity_ID,\n",
+    "        experiment_id=experiment_id,\n",
+    "        table_id='day',\n",
+    "        variable_id='pr',\n",
+    "        source_id='NorESM2-LM',\n",
+    "        member_id='r1i1p1f1',\n",
+    "        grid_label='gn',\n",
+    "        version=int(version),\n",
+    "    )\n",
+    "    d = cat.to_dataset_dict(progressbar=False)\n",
+    "    assert len(d) == 1\n",
+    "    return d[list(d.keys())[0]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
    "id": "48aba947-7641-4af2-b5c9-9a06127a64d0",
    "metadata": {},
    "outputs": [],
@@ -54,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 54,
    "id": "32dcf7a1-f1f8-4ceb-86cc-804e559a0e7e",
    "metadata": {},
    "outputs": [],
@@ -70,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 55,
    "id": "5ba6b882-ad62-4a15-81a5-03eb689eedbc",
    "metadata": {},
    "outputs": [],
@@ -81,25 +114,49 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7f5961b-76be-4114-beb8-bb6a40f706df",
+   "id": "b29d5ef7-c706-413d-a9f8-c4b6d2140f3b",
    "metadata": {},
    "source": [
-    "Read each `NorESM2-LM` precipitation dataset"
+    "Download datasets directly from CMIP6-in-the-cloud"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 56,
+   "id": "c038d9f8-0662-45f6-b014-a2d066699a40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "IDs = ['historical',\n",
+    "           'ssp126',\n",
+    "           'ssp245',\n",
+    "           'ssp370',\n",
+    "           'ssp585']\n",
+    "dataset_dict = {}\n",
+    "for i in IDs:\n",
+    "    dataset_dict[i] = fetch_pangeo(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dead58d5-6e96-4160-9b84-85b885e4b4da",
+   "metadata": {},
+   "source": [
+    "For convenience"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
    "id": "3fa3228d-0c04-4800-a9c2-56175f576fe8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "hist_url = 'gs://raw-305d04da/cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/gn/v20190815.zarr'\n",
-    "hist = read_gcs_zarr(hist_url)\n",
-    "ssp126 = read_gcs_zarr('gs://raw-305d04da/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/gn/v20191108.zarr')\n",
-    "ssp245 = read_gcs_zarr('gs://raw-305d04da/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/gn/v20191108.zarr')\n",
-    "ssp370 = read_gcs_zarr('gs://raw-305d04da/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/gn/v20191108.zarr')\n",
-    "ssp585 = read_gcs_zarr('gs://raw-305d04da/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/gn/v20191108.zarr')"
+    "hist = dataset_dict['historical']\n",
+    "ssp126 = dataset_dict['ssp126']\n",
+    "ssp245 = dataset_dict['ssp245']\n",
+    "ssp370 = dataset_dict['ssp370']\n",
+    "ssp585 = dataset_dict['ssp585']"
    ]
   },
   {
@@ -130,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 58,
    "id": "7d357868-79bf-4e92-839e-da790352ca9e",
    "metadata": {},
    "outputs": [],
@@ -148,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 59,
    "id": "8ce5f0f0-0da5-4e9e-b023-e542a7369900",
    "metadata": {},
    "outputs": [],
@@ -158,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 60,
    "id": "2119d53d-bc30-46e3-af4b-629a6d3edaad",
    "metadata": {},
    "outputs": [
@@ -169,7 +226,7 @@
        "       [356.25, 360.  ]])"
       ]
      },
-     "execution_count": 92,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -180,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 61,
    "id": "ef40ba59-32a9-4c3c-bf4b-a5ab668728ba",
    "metadata": {},
    "outputs": [
@@ -191,7 +248,7 @@
        "       [356.25, 358.75]])"
       ]
      },
-     "execution_count": 93,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -210,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 62,
    "id": "8a033bfa-af19-41e3-a1e7-34417570dc2b",
    "metadata": {},
    "outputs": [],
@@ -228,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 63,
    "id": "e20b975f-cec3-4452-bf2d-008ff89e69cf",
    "metadata": {},
    "outputs": [],
@@ -246,12 +303,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 64,
    "id": "5d86cfe3-9d44-43d4-8ef3-d607dff3076d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "record = 'date : 2022-02-11, author : Emile Tenezakis, description : modified the first and last entries of the longitudinal bounds array (lon_bnds). These entries change from array([[0., 1.25], [356.25, 360.]]) to array([[-1.25, 1.25], [356.25, 358.75]]). This change was made so that this dataset spatial bounds match with the SSP projection dataset bounds'\n",
+    "record = 'date : 2022-02-11, author : Emile Tenezakis, description : in the raw downloaded CMIP6-in-the-cloud data, modified the first and last entries of the longitudinal bounds array (lon_bnds). These entries change from array([[0., 1.25], [356.25, 360.]]) to array([[-1.25, 1.25], [356.25, 358.75]]). This change was made so that this dataset spatial bounds match with the SSP projection dataset bounds'\n",
     "hist.attrs['modifications'] = record"
    ]
   },
@@ -265,22 +322,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
-   "id": "e8a19f65-3aba-44f0-a483-048ac09deade",
+   "execution_count": 65,
+   "id": "b44596ae-02e5-43bc-b1b2-4b55afc868e6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "out_url = hist_url"
+    "out_url = 'gs://raw-305d04da/cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/gn/v20190815.zarr' # overwrite at this location"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 66,
    "id": "2867ff00-4be3-4d2d-8651-2e0c86633596",
    "metadata": {},
    "outputs": [],
    "source": [
-    "write_gcs_zarr(hist, out_url, mode=\"a\")"
+    "write_gcs_zarr(hist, out_url, mode=\"w\")"
    ]
   },
   {
@@ -295,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 67,
    "id": "305e2396-323e-46fe-a2c0-f75b4cfc95ef",
    "metadata": {},
    "outputs": [],
@@ -305,7 +362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 68,
    "id": "b4458230-3c93-44f9-baf2-abbed90e9923",
    "metadata": {},
    "outputs": [],

--- a/notebooks/downscaling_pipeline/correct-NorESM2-LM-raw-historical-lon-bounds.ipynb
+++ b/notebooks/downscaling_pipeline/correct-NorESM2-LM-raw-historical-lon-bounds.ipynb
@@ -1,0 +1,345 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ea5b32d7-c2ff-4ed8-9002-5846228dab4f",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "#### Date of last run : February 11th 2022\n",
+    "#### Author : Emile Tenezakis\n",
+    "### Purpose : \n",
+    "This notebook was written and run to solve the following issue : https://github.com/ClimateImpactLab/downscaleCMIP6/issues/529 in the CMIP6 downscaling project. The issue was that the precipitation `NorESM2-LM` historical data grid does not exactly match that of the projection grids (future ssp projections), specifically the longitudinal bounds. It was decided, as a workaround, to manually modify the raw downloaded data rather than the workflow code in order to avoid introducing special cases. Therefore, In this notebook, we read the historical and ssp \n",
+    "precipitation `NorESM2-LM` data from the raw data bucket (these files were downloaded saved by the 'download' part of the project pipeline), we replace the `lon_bnds` variable in the historical data by that of any other ssp dataset, and we overwrite the historical zarr store with that new dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "id": "c0eb24a9-dde5-4548-a178-dd7f7eb9e05a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import numpy as np\n",
+    "import gcsfs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77409abe-c563-49c4-8246-0ce4fd772a33",
+   "metadata": {},
+   "source": [
+    "Helper for gcs I/O authentication"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "id": "48aba947-7641-4af2-b5c9-9a06127a64d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def read_gcs_zarr(zarr_url, token='/opt/gcsfuse_tokens/impactlab-data.json', check=False, consolidated=True):\n",
+    "    \"\"\"\n",
+    "    takes in a GCSFS zarr url, bucket token, and returns a dataset, given authentication.\n",
+    "    \"\"\"\n",
+    "    fs = gcsfs.GCSFileSystem(token=token)\n",
+    "    store_path = fs.get_mapper(zarr_url, check=check)\n",
+    "    ds = xr.open_zarr(store_path, consolidated=consolidated)\n",
+    "    ds.close()\n",
+    "    return ds "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "id": "32dcf7a1-f1f8-4ceb-86cc-804e559a0e7e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def write_gcs_zarr(ds, zarr_url, token='/opt/gcsfuse_tokens/impactlab-data.json', check=False, mode='w-'):\n",
+    "    \"\"\"\n",
+    "    takes in a GCSFS zarr url, bucket token, dataset, and writes the dataset to URL.\n",
+    "    \"\"\"\n",
+    "    fs = gcsfs.GCSFileSystem(token=token)\n",
+    "    store_path = fs.get_mapper(zarr_url, check=check)\n",
+    "    ds.to_zarr(store_path, mode=mode, compute=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "id": "5ba6b882-ad62-4a15-81a5-03eb689eedbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def return_fs(token='/opt/gcsfuse_tokens/impactlab-data.json'):\n",
+    "    return gcsfs.GCSFileSystem(token=token)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7f5961b-76be-4114-beb8-bb6a40f706df",
+   "metadata": {},
+   "source": [
+    "Read each `NorESM2-LM` precipitation dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "id": "3fa3228d-0c04-4800-a9c2-56175f576fe8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hist_url = 'gs://raw-305d04da/cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/gn/v20190815.zarr'\n",
+    "hist = read_gcs_zarr(hist_url)\n",
+    "ssp126 = read_gcs_zarr('gs://raw-305d04da/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/gn/v20191108.zarr')\n",
+    "ssp245 = read_gcs_zarr('gs://raw-305d04da/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/gn/v20191108.zarr')\n",
+    "ssp370 = read_gcs_zarr('gs://raw-305d04da/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/gn/v20191108.zarr')\n",
+    "ssp585 = read_gcs_zarr('gs://raw-305d04da/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/gn/v20191108.zarr')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d903798-3659-4b3e-8e0b-e1eb2f9e4a5c",
+   "metadata": {},
+   "source": [
+    "Compare longitudinal bounds between ssps : all identical."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19e9b76d-9919-4e83-ac71-5e46b18ef223",
+   "metadata": {},
+   "source": [
+    "np.testing.assert_equal(ssp126.lon_bnds.values, ssp245.lon_bnds.values)\n",
+    "np.testing.assert_equal(ssp126.lon_bnds.values, ssp370.lon_bnds.values)\n",
+    "np.testing.assert_equal(ssp126.lon_bnds.values, ssp585.lon_bnds.values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd165306-e588-4698-8ae7-af2c6a918269",
+   "metadata": {},
+   "source": [
+    "Compare longitudinal bounds between historical and ssp : not identical ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "id": "7d357868-79bf-4e92-839e-da790352ca9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.testing.assert_raises(AssertionError, np.testing.assert_equal, hist.lon_bnds.values, ssp126.lon_bnds.values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6865b3a1-4f9f-4ac0-a8c9-d199d93f72ae",
+   "metadata": {},
+   "source": [
+    "... everything is identical except the first and last around the prime meridian."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "id": "8ce5f0f0-0da5-4e9e-b023-e542a7369900",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.testing.assert_equal(hist.lon_bnds.values[1:142,:], ssp126.lon_bnds.values[1:142, :])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "id": "2119d53d-bc30-46e3-af4b-629a6d3edaad",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[  0.  ,   1.25],\n",
+       "       [356.25, 360.  ]])"
+      ]
+     },
+     "execution_count": 92,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hist.lon_bnds.values[(0, 143),:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "id": "ef40ba59-32a9-4c3c-bf4b-a5ab668728ba",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ -1.25,   1.25],\n",
+       "       [356.25, 358.75]])"
+      ]
+     },
+     "execution_count": 93,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ssp126.lon_bnds.values[(0, 143),:]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62989ccc-87d6-40b0-ad56-cb5e76755ab9",
+   "metadata": {},
+   "source": [
+    "In the historical dataset, one band (on the left of the meridian) is wider than the other. We replace the longitudinal bounds in the historical dataset by the longitudinal bounds in any of the ssp datasets, in order to remove this discrepancy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "id": "8a033bfa-af19-41e3-a1e7-34417570dc2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hist['lon_bnds'] = ssp126['lon_bnds']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1764c0ec-3b67-445f-9727-621dc4fccbd6",
+   "metadata": {},
+   "source": [
+    "Here we verify that the operation worked : the longitudinal bounds are now equal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "id": "e20b975f-cec3-4452-bf2d-008ff89e69cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.testing.assert_equal(hist.lon_bnds.values, ssp126.lon_bnds.values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ffd2dae-1965-404f-9a70-74c1a57d719d",
+   "metadata": {},
+   "source": [
+    "We add an attribute to document this change in the dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 100,
+   "id": "5d86cfe3-9d44-43d4-8ef3-d607dff3076d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "record = 'date : 2022-02-11, author : Emile Tenezakis, description : modified the first and last entries of the longitudinal bounds array (lon_bnds). These entries change from array([[0., 1.25], [356.25, 360.]]) to array([[-1.25, 1.25], [356.25, 358.75]]). This change was made so that this dataset spatial bounds match with the SSP projection dataset bounds'\n",
+    "hist.attrs['modifications'] = record"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "544c6560-0d8c-4de3-991d-16d4f1694018",
+   "metadata": {},
+   "source": [
+    "Finally, we overwrite the zarr store with the modified data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "id": "e8a19f65-3aba-44f0-a483-048ac09deade",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out_url = hist_url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "id": "2867ff00-4be3-4d2d-8651-2e0c86633596",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "write_gcs_zarr(hist, out_url, mode=\"a\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8bfe459e-6396-4348-83d8-87fa67b69aaf",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Verifying the changes persisted"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 101,
+   "id": "305e2396-323e-46fe-a2c0-f75b4cfc95ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.testing.assert_equal(read_gcs_zarr(out_url).lon_bnds.values, ssp126.lon_bnds.values)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 102,
+   "id": "b4458230-3c93-44f9-baf2-abbed90e9923",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert read_gcs_zarr(out_url).attrs['modifications'] == record"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
 - [x] closes #529 
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

This PR adds a notebook that I ran to solve https://github.com/ClimateImpactLab/downscaleCMIP6/issues/529. The cause of the issue is that the precipitation `NorESM2-LM` historical data grid does not exactly match that of the projection grids (future ssp projections), specifically the longitudinal bound values. 

It was decided, as a workaround, to manually modify the raw downloaded data rather than the workflow code in order to avoid introducing special cases. Therefore, In this notebook, I read the historical and ssp precipitation `NorESM2-LM` data from the raw data GCS bucket, replaced the `lon_bnds` variable in the historical data by that of an ssp dataset, documented that change in `attrs` with a new 'modification' entry, and overwrote the historical zarr store with the changes.

I experienced errrors while overwriting the data using the `'w'` mode in `xarray.to_zarr()`, which accidentially deleted the entire historical raw dataset from storage. I moved from `w` to `a`, which solved the problem, but it means I had to re-download, and overwrite, the data in GCS, from pangeo, with this workflow : https://argo.cildc6.org/workflows/default/download-gcm-gdd27?tab=workflow. Of course, I used the parameters as they appear in the master branch parameter file for this model. 

If someone disagrees with the location of this notebook, please let me know. 

A workflow is running with this new data at https://argo.cildc6.org/workflows/default/e2e-noresm2-lm-pr-7sq6c?tab=workflow. 