### PR TITLE
Update dodola image version to latest release in standardize cmip6

### DIFF
--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -408,7 +408,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.16.1
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.16.2
         command: [ "dodola" ]
         args:
           - "cleancmip6"


### PR DESCRIPTION
 - [ ] closes #439 
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

This updates the `dodola` image version to use the latest release in the `standardize-cmip6` container template.

This was fully 'tested' in https://argo.cildc6.org/workflows/default/biascorrectdownscale-dev-tt9gd?tab=workflow. Apologies -- I forgot to subset the parameter file and it actually ran the full end to end workflow with all scenarios as a test. 