### PR TITLE
fix parameter files

### DIFF
--- a/workflows/parameters/MPI-ESM1-2-HR-pr.yaml
+++ b/workflows/parameters/MPI-ESM1-2-HR-pr.yaml
@@ -4,19 +4,7 @@ jobs: |
       "target": "historical",
       "variable_id": "pr",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM1-2-HR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM1-2-HR", "institution_id": "DKRZ", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
-    },
-    {
-      "target": "ssp",
-      "variable_id": "pr",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM1-2-HR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM1-2-HR", "institution_id": "DKRZ", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
-    },
-    {
-      "target": "ssp",
-      "variable_id": "pr",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM1-2-HR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM1-2-HR", "institution_id": "DKRZ", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "pr", "source_id": "MPI-ESM1-2-HR", "institution_id": "DKRZ", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
     },
     {
       "target": "ssp",

--- a/workflows/parameters/MPI-ESM1-2-HR-tasmax.yaml
+++ b/workflows/parameters/MPI-ESM1-2-HR-tasmax.yaml
@@ -4,19 +4,7 @@ jobs: |
       "target": "historical",
       "variable_id": "tasmax",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-HR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-HR", "institution_id": "DKRZ", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
-    },
-    {
-      "target": "ssp",
-      "variable_id": "tasmax",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-HR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-HR", "institution_id": "DKRZ", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
-    },
-    {
-      "target": "ssp",
-      "variable_id": "tasmax",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-HR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-HR", "institution_id": "DKRZ", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmax", "source_id": "MPI-ESM1-2-HR", "institution_id": "DKRZ", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
     },
     {
       "target": "ssp",

--- a/workflows/parameters/MPI-ESM1-2-HR-tasmin.yaml
+++ b/workflows/parameters/MPI-ESM1-2-HR-tasmin.yaml
@@ -4,19 +4,7 @@ jobs: |
       "target": "historical",
       "variable_id": "tasmin",
       "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM1-2-HR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM1-2-HR", "institution_id": "DKRZ", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
-    },
-    {
-      "target": "ssp",
-      "variable_id": "tasmin",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM1-2-HR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp370", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM1-2-HR", "institution_id": "DKRZ", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
-    },
-    {
-      "target": "ssp",
-      "variable_id": "tasmin",
-      "historical": { "activity_id": "CMIP", "experiment_id": "historical", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM1-2-HR", "institution_id": "MPI-M", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" },
-      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp245", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM1-2-HR", "institution_id": "DKRZ", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
+      "ssp": { "activity_id": "ScenarioMIP", "experiment_id": "ssp126", "table_id": "day", "variable_id": "tasmin", "source_id": "MPI-ESM1-2-HR", "institution_id": "DKRZ", "member_id": "r1i1p1f1", "grid_label": "gn", "version": "20190710" }
     },
     {
       "target": "ssp",


### PR DESCRIPTION
 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

I wanted to push `MPI-ESM1-2-HR` through a second round of runs, but I think the parameter files are out of date. According to Diana's dropbox table here : https://www.dropbox.com/scl/fi/lhxglqclb1xekg2kug6al/downscaling_project_status.xlsx?dl=0&rlkey=exts0qyu0loxr29eubi12f5p8, it only has ssp126 and ssp585.

So I filtered the parameter files for that model.

Note I swapped the ssp in `historical`. I wanted to check with you that this is not a problem with respect to our methods. 

Thanks !