### PR TITLE
Update dodola in standardize-cmip6

### DIFF
--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -408,7 +408,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.16.2
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.17.0
         command: [ "dodola" ]
         args:
           - "cleancmip6"


### PR DESCRIPTION
 This makes use in the `clean-cmip6` workflow of a recent change in `dodola.services.clean_cmip6` and `dodola.core.standardize_gcm`, released in `dodola:0.17.0`. 

This lets in models with large, high resolution data. Closes #574. 