### PR TITLE
Simplify QC workflow replacing script with dodola v0.18.0 command

### DIFF
--- a/workflows/templates/qualitycontrol-check-cmip6.yaml
+++ b/workflows/templates/qualitycontrol-check-cmip6.yaml
@@ -39,65 +39,21 @@ spec:
           - name: variable
           - name: data
           - name: time
-      script:
-        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.17.0
-        command: [python]
-        source: |
-          # Running this as a script rather than a dodola command as workaround to 
-          # https://github.com/ClimateImpactLab/dodola/issues/126
-          
-          import dask
-          import numpy as np
-          from dodola.core import (_test_for_nans, _test_variable_names, _test_timesteps, _test_temp_range, _test_dtr_range, _test_negative_values, _test_maximum_precip)
-          from dodola.repository import read
-          import xarray as xr
-
-          in_zarr = "{{ inputs.parameters.in-zarr }}"
-          variable = "{{ inputs.parameters.variable }}"
-          data_type = "{{ inputs.parameters.data }}"
-          time_period = "{{ inputs.parameters.time }}"
-
-          print(f"Validating {in_zarr}")
-
-          ds = read(in_zarr)
-
-          # These only read in Zarr Store metadata -- not memory intensive.
-          _test_variable_names(ds, variable)
-          _test_timesteps(ds, data_type, time_period)
-
-          # Other test are done on annual selections with dask.delayed to
-          # avoid large memory errors.
-          @dask.delayed
-          def clear_memory_intensive_tests(f, v, t):
-              d = read(f).sel(time=str(t))
-
-              _test_for_nans(d, v)
-
-              if v == "tasmin" or v == "tasmax":
-                  _test_temp_range(d, v)
-              if v == "dtr":
-                  _test_dtr_range(d, v, data_type)
-              if v == "dtr" or v == "pr":
-                 _test_negative_values(d, v)
-              if v == "pr":
-                 _test_maximum_precip(d, v)
-
-              # Assumes error thrown if had problem before this.
-              return True
-
-          tasks = []
-          for t in np.unique(ds["time"].dt.year.data):
-              test_results = clear_memory_intensive_tests(in_zarr, variable, t)
-              tasks.append(test_results)
-          tasks = dask.compute(*tasks)
-          assert all(tasks)  # Likely don't need this
-          print(f"Validated")
+      container:
+        image: us-central1-docker.pkg.dev/downscalecmip6/private/dodola:0.18.0
+        command: [ "dodola" ]
+        args:
+          - "validate-dataset"
+          - "{{ inputs.parameters.in-zarr }}"
+          - "--variable={{ inputs.parameters.variable }}"
+          - "--data-type={{ inputs.parameters.data }}"
+          - "--time-period={{ inputs.parameters.time }}"
         resources:
           requests:
-            memory: 8Gi
+            memory: 12Gi
             cpu: "2000m"
           limits:
-            memory: 8Gi
+            memory: 12Gi
             cpu: "2000m"
       activeDeadlineSeconds: 3600
       retryStrategy:


### PR DESCRIPTION
This simply swaps an argo-nested script for the simpler dodola command.

We couldn't do this in dodola releases before v0.18.0 because of memory issues resolved in this release.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

[summarize your pull request here]