### PR TITLE
Remove cruft AKS cluster resource

### DIFF
--- a/infrastructure/terraform/az-core/main.tf
+++ b/infrastructure/terraform/az-core/main.tf
@@ -35,19 +35,6 @@ resource "azurerm_resource_group" "rg" {
   }
 }
 
-module "aks_cluster" {
-  source              = "./modules/aks_cluster"
-  prefix              = var.prefix
-  resource_group_name = azurerm_resource_group.rg.name
-  k8scluster_name     = var.k8scluster_name
-  kubernetes_version  = var.kubernetes_version
-  aks_admin_group     = var.aks_admin_group
-
-  depends_on = [
-    azurerm_resource_group.rg,
-  ]
-}
-
 resource "azurerm_container_registry" "acr" {
   name                = "downscaleCmip6"
   resource_group_name = azurerm_resource_group.rg.name


### PR DESCRIPTION
This removes the actual Kubernetes cluster provisioned on Azure. This is needed for progress on #594.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

[summarize your pull request here]