### PR TITLE
Bump all workflow images to dodola:0.19.0 release

### DIFF
--- a/workflows/templates/biascorrectdownscale-dtr.yaml
+++ b/workflows/templates/biascorrectdownscale-dtr.yaml
@@ -547,7 +547,7 @@ spec:
             valueFrom:
               path: "/tmp/lastyear.txt"
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.10.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ python ]
         source: |
           import dodola.repository
@@ -599,7 +599,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: ghcr.io/climateimpactlab/dodola:0.15.1
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ dodola ]
         args:
           - "apply-non-polar-dtr-ceiling"

--- a/workflows/templates/biascorrectdownscale-precipitation.yaml
+++ b/workflows/templates/biascorrectdownscale-precipitation.yaml
@@ -395,7 +395,7 @@ spec:
             valueFrom:
               path: "/tmp/lastyear.txt"
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.10.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ python ]
         source: |
           import dodola.repository
@@ -448,7 +448,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: ghcr.io/climateimpactlab/dodola:0.15.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ dodola ]
         args:
           - "adjust-maximum-precipitation"

--- a/workflows/templates/biascorrectdownscale.yaml
+++ b/workflows/templates/biascorrectdownscale.yaml
@@ -516,7 +516,7 @@ spec:
             valueFrom:
               path: "/tmp/lastyear.txt"
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.10.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ python ]
         source: |
           import dodola.repository

--- a/workflows/templates/catalog.yaml
+++ b/workflows/templates/catalog.yaml
@@ -24,7 +24,7 @@ spec:
             valueFrom:
               path: "/tmp/url.txt"
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.8.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ python ]
         source: |
           import dodola.repository as storage
@@ -84,7 +84,7 @@ spec:
             valueFrom:
               path: "/tmp/url.txt"
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.8.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ python ]
         source: |
           base_url = "{{ inputs.parameters.base-url }}"

--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -408,7 +408,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: ghcr.io/climateimpactlab/dodola:0.17.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ "dodola" ]
         args:
           - "cleancmip6"
@@ -443,7 +443,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.16.1
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -510,7 +510,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.16.1
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         env:
           - name: IN1_ZARR
             value: "{{ inputs.parameters.in1-zarr }}"

--- a/workflows/templates/clean-era5.yaml
+++ b/workflows/templates/clean-era5.yaml
@@ -43,7 +43,7 @@ spec:
       - name: out-zarr
         value: "{{ inputs.parameters.out-zarr }}"
     container:
-      image: ghcr.io/climateimpactlab/dodola:0.8.0
+      image: ghcr.io/climateimpactlab/dodola:0.19.0
       env:
       - name: IN_ZARR
         value: "{{  inputs.parameters.in-zarr }}"
@@ -89,7 +89,7 @@ spec:
       - name: out-zarr
         value: "{{ inputs.parameters.out-zarr }}"
     script:
-      image: ghcr.io/climateimpactlab/dodola:0.8.0
+      image: ghcr.io/climateimpactlab/dodola:0.19.0
       env:
       - name: IN_ZARR
         value: "{{  inputs.parameters.in-zarr }}"

--- a/workflows/templates/compute-dtr.yaml
+++ b/workflows/templates/compute-dtr.yaml
@@ -351,7 +351,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.9.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ python ]
         source: |
           import dodola.repository

--- a/workflows/templates/create-output-metadata-json.yaml
+++ b/workflows/templates/create-output-metadata-json.yaml
@@ -32,7 +32,7 @@ spec:
           - name: global-attrs-json
             path: /tmp/global_attrs.json
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.8.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ python ]
         source: |
           import json

--- a/workflows/templates/create-pr-references.yaml
+++ b/workflows/templates/create-pr-references.yaml
@@ -221,7 +221,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.16.1
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ python ]
         source: |
           import numpy as np
@@ -295,7 +295,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.16.1
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ python ]
         source: |
           from copy import deepcopy
@@ -365,7 +365,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: ghcr.io/climateimpactlab/dodola:0.16.1
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ dodola ]
         args:
           - "correct-wetday-frequency"

--- a/workflows/templates/distributed-regrid.yaml
+++ b/workflows/templates/distributed-regrid.yaml
@@ -94,7 +94,7 @@ spec:
             valueFrom:
               path: "/tmp/lastyear.txt"
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.8.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"
@@ -193,7 +193,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.8.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         env:
           - name: IN_ZARR
             value: "{{ inputs.parameters.in-zarr }}"

--- a/workflows/templates/download-cmip6.yaml
+++ b/workflows/templates/download-cmip6.yaml
@@ -230,7 +230,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-url }}"
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.8.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         env:
           - name: ACTIVITY_ID
             value: "{{inputs.parameters.activity-id}}"

--- a/workflows/templates/qdm-preprocess.yaml
+++ b/workflows/templates/qdm-preprocess.yaml
@@ -154,7 +154,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: ghcr.io/climateimpactlab/dodola:0.16.1
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ dodola ]
         args:
           - "correct-wetday-frequency"
@@ -216,7 +216,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.12.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ python ]
         source: |
           import logging
@@ -262,7 +262,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.12.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ python ]
         source: |
           import logging

--- a/workflows/templates/qdm.yaml
+++ b/workflows/templates/qdm.yaml
@@ -303,7 +303,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: ghcr.io/climateimpactlab/dodola:0.10.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ dodola ]
         args:
           - "prime-qdm-output-zarrstore"
@@ -346,7 +346,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: ghcr.io/climateimpactlab/dodola:0.15.1
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ "dodola" ]
         args:
           - "train-qdm"
@@ -394,7 +394,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: ghcr.io/climateimpactlab/dodola:0.10.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ dodola ]
         args:
           - "apply-qdm"

--- a/workflows/templates/qplad.yaml
+++ b/workflows/templates/qplad.yaml
@@ -455,7 +455,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: ghcr.io/climateimpactlab/dodola:0.15.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ dodola ]
         args:
           - "train-qplad"
@@ -499,7 +499,7 @@ spec:
           - name: global-attrs-json
             path: /tmp/global_attrs.json
       container:
-        image: ghcr.io/climateimpactlab/dodola:0.15.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ dodola ]
         args:
           - "apply-qplad"
@@ -543,7 +543,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: ghcr.io/climateimpactlab/dodola:0.15.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ dodola ]
         args:
           - "prime-qplad-output-zarrstore"
@@ -599,7 +599,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.15.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ python ]
         source: |
           import logging

--- a/workflows/templates/qualitycontrol-check-cmip6.yaml
+++ b/workflows/templates/qualitycontrol-check-cmip6.yaml
@@ -40,7 +40,7 @@ spec:
           - name: data
           - name: time
       container:
-        image: ghcr.io/climateimpactlab/dodola:0.18.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ "dodola" ]
         args:
           - "validate-dataset"

--- a/workflows/templates/rechunk.yaml
+++ b/workflows/templates/rechunk.yaml
@@ -31,7 +31,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: ghcr.io/climateimpactlab/dodola:0.8.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ dodola ]
         args:
           - "rechunk"

--- a/workflows/templates/regrid.yaml
+++ b/workflows/templates/regrid.yaml
@@ -25,7 +25,7 @@ spec:
           - name: out-zarr
             value: "{{ inputs.parameters.out-zarr }}"
       container:
-        image: ghcr.io/climateimpactlab/dodola:0.8.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ "dodola" ]
         args:
           - "regrid"

--- a/workflows/templates/zarr-transfer.yaml
+++ b/workflows/templates/zarr-transfer.yaml
@@ -27,7 +27,7 @@ spec:
           - name: from-zarr
           - name: to-zarr
       script:
-        image: ghcr.io/climateimpactlab/dodola:0.8.0
+        image: ghcr.io/climateimpactlab/dodola:0.19.0
         command: [ python ]
         source: |
           import dodola.repository


### PR DESCRIPTION
Updates all workflow images to ghcr.io/climateimpactlab/dodola:0.19.0.

This comes with significant package and environment update for `dodola`. It's also one of the newer version released with a DOI.