### PR TITLE
Update ERA-5 to ERA5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,10 +25,10 @@ R/CIL GDPCIR
 
 Users are requested to cite this project in derived works. This project does not yet have a public DOI or citation - check back for details.
 
-ERA-5
------
+ERA5
+----
 
-Additionally, we request you cite the historical dataset used in bias correction and downscaling, ERA-5. See the `ECMWF guide to citing a dataset on the Climate Data Store <https://confluence.ecmwf.int/display/CKB/How+to+acknowledge+and+cite+a+Climate+Data+Store+%28CDS%29+catalogue+entry+and+the+data+published+as+part+of+it>`_:
+Additionally, we request you cite the historical dataset used in bias correction and downscaling, ERA5. See the `ECMWF guide to citing a dataset on the Climate Data Store <https://confluence.ecmwf.int/display/CKB/How+to+acknowledge+and+cite+a+Climate+Data+Store+%28CDS%29+catalogue+entry+and+the+data+published+as+part+of+it>`_:
 
     Hersbach, H, et al. The ERA5 global reanalysis. Q J R Meteorol Soc.2020; 146: 1999–2049. https://doi.org/10.1002/qj.3803
 

--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -218,7 +218,7 @@ spec:
                   value: "{{ steps.standardize-historical-run.outputs.parameters.out-zarr }}"
                 - name: out-zarr
                   value: "{{ steps.get-output-clean-training-url.outputs.parameters.out-url }}"
-                  # Matches window of "reference" ERA-5 data +/- 15 days.
+                  # Matches window of "reference" ERA5 data +/- 15 days.
                 - name: from-time
                   value: "1994-12-17"
                 - name: to-time

--- a/workflows/templates/qdm-preprocess.yaml
+++ b/workflows/templates/qdm-preprocess.yaml
@@ -7,7 +7,7 @@ metadata:
       Preprocessing steps before Quantile Delta Mapping bias correction for reanalysis and CMIP6 GCM Zarr Stores.
 
       This workflow applies wet-day-frequency correction, a minimum threshold for small variable values, and regrids
-      cleaned CMIP6 and ERA-5 renalsysis data to a standard grid. The output also chunked to be contiguous across the
+      cleaned CMIP6 and ERA5 renalsysis data to a standard grid. The output also chunked to be contiguous across the
       "time" dimension in preparation for bias-correction via Quantile Delta Mapping (QDM).
     workflows.argoproj.io/tags: zarr,biascorrect,cmip6,qdm,dc6,preprocess,regrid,rechunk
     workflows.argoproj.io/version: '>= 3.1.0'


### PR DESCRIPTION
The ECMWF Reanalysis v5 (ERA5) does not have a hyphen or dash in the name. This PR corrects this in the README and some documentation.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

[summarize your pull request here]