### PR TITLE
Remove Github Actions' GCP service account

### DIFF
--- a/infrastructure/terraform/gcp-core/main.tf
+++ b/infrastructure/terraform/gcp-core/main.tf
@@ -202,10 +202,3 @@ resource "google_project_iam_member" "cert_manager-dnsadmin-iammember" {
   member = "serviceAccount:${google_service_account.dns01_solver.email}"
   role   = "roles/dns.admin"
 }
-
-# GCP Service Account for Github Actions.
-resource "google_service_account" "github_actions" {
-  account_id   = "github-actions"
-  description  = "Github Actions service account for Github Repository CI/CD"
-  display_name = "github-actions"
-}

--- a/infrastructure/terraform/gcp-core/main.tf
+++ b/infrastructure/terraform/gcp-core/main.tf
@@ -209,12 +209,3 @@ resource "google_service_account" "github_actions" {
   description  = "Github Actions service account for Github Repository CI/CD"
   display_name = "github-actions"
 }
-# Let Github Actions release to Google Docker Repository.
-resource "google_artifact_registry_repository_iam_member" "github_actions_artifactregistrywriter_iammember" {
-  provider   = google-beta
-  location   = module.artifact_registry.location
-  project    = module.artifact_registry.project
-  repository = module.artifact_registry.private_docker_repository_id
-  role       = "roles/artifactregistry.writer"
-  member     = "serviceAccount:${google_service_account.github_actions.email}"
-}

--- a/infrastructure/terraform/gcp-core/outputs.tf
+++ b/infrastructure/terraform/gcp-core/outputs.tf
@@ -111,13 +111,3 @@ output "argo_cloudsql_password" {
   value       = module.datalake_storage.argo_cloudsql_password
   sensitive   = true
 }
-
-output "github_actions_account_id" {
-  value       = google_service_account.github_actions.account_id
-  description = "cert-manager service account ID."
-}
-
-output "github_actions_email" {
-  value       = google_service_account.github_actions.email
-  description = "Email to created Github Actions service account."
-}


### PR DESCRIPTION
This GCP service account is no longer needed.

Required to progress on #612 