### PR TITLE
Patch argo workflows to v3.3.6

### DIFF
--- a/infrastructure/kubernetes-gcp/argo/kustomization.yaml
+++ b/infrastructure/kubernetes-gcp/argo/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/argoproj/argo-workflows/releases/download/v3.3.5/install.yaml
+  - https://github.com/argoproj/argo-workflows/releases/download/v3.3.6/install.yaml
   - argo-cildc6-org.yaml
   - argo-server-ingress.yaml
   - sso-client-externalsecret.yaml


### PR DESCRIPTION
Argo Workflows patch to v3.3.6 for minor bug fixes.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

[summarize your pull request here]