### PR TITLE
Fix to failed to find unique target for patch

### DIFF
--- a/infrastructure/kubernetes-gcp/argo/kustomization.yaml
+++ b/infrastructure/kubernetes-gcp/argo/kustomization.yaml
@@ -17,4 +17,5 @@ patchesJson6902:
       group: apps
       kind: Deployment
       name: argo-server
+      namespace: argo
     path: patches/argo-server-deployment.yaml


### PR DESCRIPTION
Versions of Argo workflows after v3.3.4 appear to have a namespace added to their install.yaml resources (see https://github.com/argoproj/argo-workflows/pull/8280 and https://github.com/argoproj/argo-workflows/issues/8250#issuecomment-1084046919), with causes an error when kustomization tries to apply updates:

```
ComparisonError  rpc error: code = Unknown desc = Manifest generation error (cached): `kustomize build /tmp/https___github.com_climateimpactlab_downscalecmip6/infrastructure/kubernetes-gcp/argo` failed exit status 1: Error: no matches for Id ~G_v1_ConfigMap|~X|workflow-controller-configmap; failed to find unique target for patch ~G_v1_ConfigMap|workflow-controller-configmap  2022-06-02 18:16:15 -0700 PDT
```
This *might* relate to a bug in customization (see https://github.com/kubernetes-sigs/kustomize/issues/1332).

So we're specifying the namespace in the install.yaml resource when defining the patch for the customization with the hopes that it will be able to find its target.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

[summarize your pull request here]