### PR TITLE
Another fix for failed to find unique target for patch error

### DIFF
--- a/infrastructure/kubernetes-gcp/argo/kustomization.yaml
+++ b/infrastructure/kubernetes-gcp/argo/kustomization.yaml
@@ -17,5 +17,4 @@ patchesJson6902:
       group: apps
       kind: Deployment
       name: argo-server
-      namespace: argo
     path: patches/argo-server-deployment.yaml

--- a/infrastructure/kubernetes-gcp/argo/kustomization.yaml
+++ b/infrastructure/kubernetes-gcp/argo/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: argo
 
 resources:
   - https://github.com/argoproj/argo-workflows/releases/download/v3.3.6/install.yaml


### PR DESCRIPTION
Revert and attempt another refix of PR #617.

Seeing if kustomization is able to find the unique target to apply our argo-workflows configmap patch if we explicitly give the namespace in our base kustomization file.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

[summarize your pull request here]