### PR TITLE
Another fix for failed to find unique target for patch error

### DIFF
--- a/infrastructure/kubernetes-gcp/argo/kustomization.yaml
+++ b/infrastructure/kubernetes-gcp/argo/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: argo
 
 resources:
   - https://github.com/argoproj/argo-workflows/releases/download/v3.3.6/install.yaml

--- a/infrastructure/kubernetes-gcp/argo/patches/workflow-controller-configmap.yaml
+++ b/infrastructure/kubernetes-gcp/argo/patches/workflow-controller-configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: workflow-controller-configmap
+  namespace: argo
 data:
 
   # Limit the maximum number of incomplete workflows in a namespace.


### PR DESCRIPTION
Looks like PR #618 didn't do the trick either.

This is another fix to see if we can get the argo-workflows kustomization to identify a unique patch target with argo-workflows > v3.3.4.

This also reverts the fix from #618.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

[summarize your pull request here]