### PR TITLE
Put target ns in strategic merge patch to ID patch target for argo service account

### DIFF
--- a/infrastructure/kubernetes-gcp/argo/patches/argo-server-serviceaccount.yaml
+++ b/infrastructure/kubernetes-gcp/argo/patches/argo-server-serviceaccount.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: argo-server
+  namespace: argo
   annotations:
     iam.gke.io/gcp-service-account: "argo-server-60f685be@downscalecmip6.iam.gserviceaccount.com"


### PR DESCRIPTION
Extension of fix from PR #617, PR #618, PR #619.

Applies a similar fix to the `patchesStrategicMerge` for argo-workflow's argo-server ServiceAccount. Apparently, kustomize can't find a unique target to apply the patch to after argo-workflows started hard coding the "argo" namespace in their install.yaml in >= v3.3.5.

In case anyone else has the problem, I found this after ArgoCD started reporting errors while syncing:

```
Message:            ComparisonError: rpc error: code = Unknown desc = `kustomize build /tmp/https___github.com_climateimpactlab_downscalecmip6/infrastructure/kubernetes-gcp/argo` failed exit status 1: Error: no matches for Id ~G_v1_ServiceAccount|~X|argo-server; failed to find unique target for patch ~G_v1_ServiceAccount|argo-server
```

This pops up after the upstream change from https://github.com/argoproj/argo-workflows/pull/8280. Had no issues with updates and deployments before this change.
