### PR TITLE
Patch Argo Workflows to v3.3.7

### DIFF
--- a/infrastructure/kubernetes-gcp/argo/kustomization.yaml
+++ b/infrastructure/kubernetes-gcp/argo/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/argoproj/argo-workflows/releases/download/v3.3.6/install.yaml
+  - https://github.com/argoproj/argo-workflows/releases/download/v3.3.7/install.yaml
   - argo-cildc6-org.yaml
   - argo-server-ingress.yaml
   - sso-client-externalsecret.yaml


### PR DESCRIPTION
Patch Argo Workflows to v3.3.7 for general bug fixes. We don't require this patch for any specific bug fix.
