### PR TITLE
Upgrade cert-manager to v1.8.2

### DIFF
--- a/infrastructure/kubernetes-gcp/cert-manager/kustomization.yaml
+++ b/infrastructure/kubernetes-gcp/cert-manager/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
+  - https://github.com/cert-manager/cert-manager/releases/download/v1.8.2/cert-manager.yaml
   - letsencrypt-prod-clusterissuer.yaml
   - letsencrypt-staging-clusterissuer.yaml


### PR DESCRIPTION
This is a major cert-manager upgrade from v1.6 to v1.8.2.

This upgrade is not to address any specific issue but because we need to roll with general updates.
