### PR TITLE
Upgrade ingress-nginx chart to v4.1.4

### DIFF
--- a/infrastructure/kubernetes-gcp/ingress-nginx/Chart.yaml
+++ b/infrastructure/kubernetes-gcp/ingress-nginx/Chart.yaml
@@ -16,5 +16,5 @@ appVersion: "0.0.1"
 
 dependencies:
   - name: ingress-nginx
-    version: "4.0.16"
+    version: "4.1.4"
     repository: 'https://kubernetes.github.io/ingress-nginx'


### PR DESCRIPTION
Minor upgrade to tsukiyomi's ingress-nginx to v4.1.4. We don't require this to address any specific problems — just a general update.