### PR TITLE
Reflect CMIP6 BY 4.0 license update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ The dataset is made of of three collections, distinguished by data license at th
 
 * `Public domain (CC0-1.0) collection <https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc0>`_
 * `Attribution (CC BY 4.0) collection <https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc-by>`_
-* `Attribution-ShareAlike (CC BY SA 4.0) collection <https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc-by-sa>`_ (note, this is `now available under an attribution/CC BY 4.0 license <https://pcmdi.llnl.gov/CMIP6/TermsOfUse/TermsOfUse6-2.html>`_
+* `Attribution-ShareAlike (CC BY SA 4.0) collection <https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc-by-sa>`_ (note, the terms of use for these models have been updated and this collection is `now available under an attribution/CC BY 4.0 license <https://pcmdi.llnl.gov/CMIP6/TermsOfUse/TermsOfUse6-2.html>`_)
 
 Each modeling center with bias corrected and downscaled data in this collection falls into one of these license categories - see the `table below <#available-institutions-models-and-scenarios-by-license-collection>`_ to see which model is in each collection, and see the section below on `Citing, Licensing, and using data produced by this project <#citing-licensing-and-using-data-produced-by-this-project>`_ for citations and additional information about each license. For examples of how to browse the collections and load the data using python, see the `example use <#example-use>`_ section below.
 

--- a/README.rst
+++ b/README.rst
@@ -42,11 +42,11 @@ Accessing the data
 
 GDPCIR data can be accessed on the Microsoft Planetary Computer: `planetarycomputer.microsoft.com/dataset/group/cil-gdpcir <https://planetarycomputer.microsoft.com/dataset/group/cil-gdpcir>`_
 
-The dataset is made of of three collections, distinguished by data license:
+The dataset is made of of three collections, distinguished by data license at the time of publication:
 
 * `Public domain (CC0-1.0) collection <https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc0>`_
 * `Attribution (CC BY 4.0) collection <https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc-by>`_
-* `Attribution-ShareAlike (CC BY SA 4.0) collection <https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc-by-sa>`_
+* `Attribution-ShareAlike (CC BY SA 4.0) collection <https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc-by-sa>`_ (note, this is `now available under an attribution/CC BY 4.0 license <https://pcmdi.llnl.gov/CMIP6/TermsOfUse/TermsOfUse6-2.html>`_
 
 Each modeling center with bias corrected and downscaled data in this collection falls into one of these license categories - see the `table below <#available-institutions-models-and-scenarios-by-license-collection>`_ to see which model is in each collection, and see the section below on `Citing, Licensing, and using data produced by this project <#citing-licensing-and-using-data-produced-by-this-project>`_ for citations and additional information about each license. For examples of how to browse the collections and load the data using python, see the `example use <#example-use>`_ section below.
 
@@ -89,7 +89,7 @@ EC-Earth-Consortium  EC-Earth3-AerChem ssp370                                   
 EC-Earth-Consortium  EC-Earth3-CC      ssp245 and ssp585                           `CC-BY-4.0`_
 EC-Earth-Consortium  EC-Earth3-Veg     ssp1-2.6, ssp2-4.5, ssp3-7.0, and ssp5-8.5  `CC-BY-4.0`_
 EC-Earth-Consortium  EC-Earth3-Veg-LR  ssp1-2.6, ssp2-4.5, ssp3-7.0, and ssp5-8.5  `CC-BY-4.0`_
-CCCma                CanESM5           ssp1-2.6, ssp2-4.5, ssp3-7.0, ssp5-8.5      `CC-BY-SA-4.0`_
+CCCma                CanESM5           ssp1-2.6, ssp2-4.5, ssp3-7.0, ssp5-8.5      `CC-BY-SA-4.0`_ [*]_
 ==================== ================= ==========================================  =========================
 
 *Notes:*
@@ -97,6 +97,8 @@ CCCma                CanESM5           ssp1-2.6, ssp2-4.5, ssp3-7.0, ssp5-8.5   
 .. [*] At the time of running, no ssp1-2.6 precipitation data was available for the FGOALS-g3 model. Therefore, we provide ``tasmin`` and ``tamax`` for this model and experiment, but not ``pr``. All other model/experiment combinations in the above table include all three variables.
 
 .. [*] The institution which ran MPI-ESM1-2-HR’s historical (CMIP) simulations is `MPI-M`, while the future (ScenarioMIP) simulations were run by `DKRZ`. Therefore, the institution component of `MPI-ESM1-2-HR` filepaths differ between `historical` and `SSP` scenarios.
+
+.. [*] Downscaled data associated with the CanESM5 model is `now available under an attribution/CC BY 4.0 license <https://pcmdi.llnl.gov/CMIP6/TermsOfUse/TermsOfUse6-2.html>`_. However, the model output is still part of the CC-BY-SA collection on Planetary Computer because this is the license the data had at the time of publication.
 
 .. _Example Use:
 
@@ -145,7 +147,7 @@ See also:
 Citing, licensing, and using data produced by this project
 ==========================================================
 
-Projects making use of the data produced as part of the Climate Impact Lab Global Downscaled Projections for Climate Impacts Research (CIL GDPCIR) project are requested to cite both this project and the source datasets from which these results are derived. Additionally, the use of data derived from some GCMs *requires* citations, and some modeling centers impose licensing restrictions & requirements on derived works. See each GCM's license info in the links below for more information.
+Projects making use of the data produced as part of the Climate Impact Lab Global Downscaled Projections for Climate Impacts Research (CIL GDPCIR) project are requested to cite both this project and the source datasets from which these results are derived. Additionally, the use of data derived from some GCMs *requires* citations. See each GCM's license info in the links below for more information.
 
 
 .. _CIL GDPCIR:
@@ -507,7 +509,7 @@ The following bias corrected and downscaled model simulations are licensed under
 CC-BY-SA-4.0
 ~~~~~~~~~~~~
 
-The following bias corrected and downscaled model simulations are licensed under a `Creative Commons Attribution-ShareAlike 4.0 International License <https://creativecommons.org/licenses/by-sa/4.0/>`_. Note that this license requires citation of the source model output (included here) and requires that derived works be shared under the same license. Please see https://creativecommons.org/licenses/by-sa/4.0/ for more information. Access the collection on Planetary Computer at https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc-by-sa.
+The following bias corrected and downscaled model simulations were originally licensed under a `Creative Commons Attribution-ShareAlike 4.0 International License <https://creativecommons.org/licenses/by-sa/4.0/>`_, but this license has since been changed to a `Creative Commons Attribution 4.0 International License <https://creativecommons.org/licenses/by/4.0/>`_. See the `CMIP6 terms of use <https://pcmdi.llnl.gov/CMIP6/TermsOfUse/TermsOfUse6-2.html>`_ for more information. Access the collection on Planetary Computer at https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc-by-sa.
 
 * **CanESM5**
 

--- a/data_licenses/CanESM5.txt
+++ b/data_licenses/CanESM5.txt
@@ -1,18 +1,16 @@
 
-This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License.
-To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/ or see
-the license text at data_licenses/legalcode/cc_by-sa_4.0.txt within this repository. Please
+This work is licensed under the Creative Commons Attribution 4.0 International License.
+To view a copy of this license, visit http://creativecommons.org/licenses/by/4.0/ or see
+the license text at data_licenses/legalcode/cc_by_4.0.txt within this repository. Please
 note that this license only pertains to the downscaled results corresponding to this
 model within the Rhodium Group/Climate Impact Lab Global Downscaled Projections for
 Climate Impacts Research (R/CIL GDPCIR) dataset. Note that different license terms may
 apply to the original GCM output provided by the relevant modeling institution as part
 of the CMIP6 project.
-
+ 
 In using this data, you must provide proper attribution to both the original model and
-the R/CIL GDPCIR dataset. Additionally, if you remix, transform, or build upon the
-material you must distribute your contributions under the same license as the original.
-See the license terms for more information. See the repository README.rst file for
- citation information:
+the R/CIL GDPCIR dataset. See the license terms for more information. See the repository
+README.rst file for citation information:
 https://github.com/ClimateImpactLab/downscaleCMIP6/blob/master/README.rst
  
 See the repository license for information about the license governing the code used to


### PR DESCRIPTION
Changes license for models originally licensed under a CC BY-SA 4.0 license to CC BY 4.0 per CMIP6 updated terms of use. See https://pcmdi.llnl.gov/CMIP6/TermsOfUse/TermsOfUse6-2.html. The models for which we received waivers to release under the less restrictive CC0 license will retain this license based on the waiver.