### PR TITLE
Move workflows from midwest to west coast storage

### DIFF
--- a/workflows/regrid-cmip6.yaml
+++ b/workflows/regrid-cmip6.yaml
@@ -80,7 +80,7 @@ spec:
           - name: historical
           - name: regrid-method
           - name: domainfile1x1
-            value: "gs://support-c23ff1a3/domain.1x1.zarr"
+            value: "gs://support-f8a48a9e/domain.1x1.zarr"
       steps:
         - - name: historical
             template: regrid-cmip6
@@ -139,7 +139,7 @@ spec:
                 - name: version
                   value: "{{=jsonpath(inputs.parameters.simulation, '$.version')}}"
                 - name: base-url
-                  value: "gs://clean-b1dbca25/cmip6"
+                  value: "gs://clean-f1e04ef5/cmip6"
           - name: get-output-regridded-url
             templateRef:
               name: catalog
@@ -165,7 +165,7 @@ spec:
                 - name: version
                   value: "{{workflow.creationTimestamp.Y}}{{workflow.creationTimestamp.m}}{{workflow.creationTimestamp.d}}{{workflow.creationTimestamp.H}}{{workflow.creationTimestamp.M}}{{workflow.creationTimestamp.S}}"
                 - name: base-url
-                  value: "gs://support-c23ff1a3/regrid-cmip6"
+                  value: "gs://support-f8a48a9e/regrid-cmip6"
           - name: check-to-add-cyclic-pixels
             templateRef:
               name: qdm-preprocess

--- a/workflows/regrid-era5.yaml
+++ b/workflows/regrid-era5.yaml
@@ -28,9 +28,9 @@ spec:
           - name: version
             value: "{{workflow.creationTimestamp.Y}}{{workflow.creationTimestamp.m}}{{workflow.creationTimestamp.d}}{{workflow.creationTimestamp.H}}{{workflow.creationTimestamp.M}}{{workflow.creationTimestamp.S}}"
           - name: domainfile1x1
-            value: "gs://support-c23ff1a3/domain.1x1.zarr"
+            value: "gs://support-f8a48a9e/domain.1x1.zarr"
           - name: domainfile0p25x0p25
-            value: "gs://support-c23ff1a3/domain.0p25x0p25.zarr"
+            value: "gs://support-f8a48a9e/domain.0p25x0p25.zarr"
       dag:
         tasks:
           - name: rechunk-for-regrid
@@ -40,7 +40,7 @@ spec:
             arguments:
               parameters:
                 - name: in-zarr
-                  value: "gs://clean-b1dbca25/reanalysis/ERA-5/F320/{{ inputs.parameters.variable-id }}.1995-2015.F320.zarr"
+                  value: "gs://clean-f1e04ef5/reanalysis/ERA-5/F320/{{ inputs.parameters.variable-id }}.1995-2015.F320.zarr"
                 - name: time-chunk
                   value: "365"
                 - name: lat-chunk
@@ -57,7 +57,7 @@ spec:
                 - name: in-zarr
                   value: "{{ tasks.rechunk-for-regrid.outputs.parameters.out-zarr }}"
                 - name: out-zarr
-                  value: "gs://support-c23ff1a3/regrid-reference/regrid1x1/{{ inputs.parameters.variable-id }}/v{{ inputs.parameters.version }}.zarr"
+                  value: "gs://support-f8a48a9e/regrid-reference/regrid1x1/{{ inputs.parameters.variable-id }}/v{{ inputs.parameters.version }}.zarr"
                 - name: regrid-method
                   value: "{{ inputs.parameters.regrid-method }}"
                 - name: domain-file
@@ -72,7 +72,7 @@ spec:
                 - name: in-zarr
                   value: "{{ tasks.rechunk-for-regrid.outputs.parameters.out-zarr }}"
                 - name: out-zarr
-                  value: "gs://support-c23ff1a3/regrid-reference/regrid0p25x0p25/{{inputs.parameters.variable-id}}/v{{inputs.parameters.version}}.zarr"
+                  value: "gs://support-f8a48a9e/regrid-reference/regrid0p25x0p25/{{inputs.parameters.variable-id}}/v{{inputs.parameters.version}}.zarr"
                 - name: regrid-method
                   value: "{{ inputs.parameters.regrid-method }}"
                 - name: domain-file

--- a/workflows/templates/biascorrectdownscale-precipitation.yaml
+++ b/workflows/templates/biascorrectdownscale-precipitation.yaml
@@ -92,9 +92,9 @@ spec:
             value: "conservative"
           - name: first-year
           - name: domainfile1x1
-            value: "gs://support-c23ff1a3/domain.1x1.zarr"
+            value: "gs://support-f8a48a9e/domain.1x1.zarr"
           - name: domainfile0p25x0p25
-            value: "gs://support-c23ff1a3/domain.0p25x0p25.zarr"
+            value: "gs://support-f8a48a9e/domain.0p25x0p25.zarr"
           - name: qdm-kind
             value: "multiplicative"
           - name: correct-wetday-frequency
@@ -102,11 +102,11 @@ spec:
           - name: apply-dtr-minimum-threshold
             value: "false"
           - name: qdm-reference-zarr
-            value: "gs://support-c23ff1a3/qdm-reference/pr/v20220201000555.zarr"
+            value: "gs://support-f8a48a9e/qdm-reference/pr/v20220201000555.zarr"
           - name: qplad-fine-reference-zarr
-            value: "gs://support-c23ff1a3/qplad-fine-reference/pr/v20220201000555.zarr"
+            value: "gs://support-f8a48a9e/qplad-fine-reference/pr/v20220201000555.zarr"
           - name: qplad-coarse-reference-zarr
-            value: "gs://support-c23ff1a3/qplad-coarse-reference/pr/v20220201000555.zarr"
+            value: "gs://support-f8a48a9e/qplad-coarse-reference/pr/v20220201000555.zarr"
       dag:
         tasks:
           - name: get-input-clean-training-url
@@ -134,7 +134,7 @@ spec:
                 - name: version
                   value: "{{=jsonpath(inputs.parameters.historical, '$.version')}}"
                 - name: base-url
-                  value: "gs://clean-b1dbca25/cmip6"
+                  value: "gs://clean-f1e04ef5/cmip6"
           - name: get-input-clean-simulation-url
             templateRef:
               name: catalog
@@ -160,7 +160,7 @@ spec:
                 - name: version
                   value: "{{=jsonpath(inputs.parameters.simulation, '$.version')}}"
                 - name: base-url
-                  value: "gs://clean-b1dbca25/cmip6"
+                  value: "gs://clean-f1e04ef5/cmip6"
           - name: get-output-biascorrected-url
             templateRef:
               name: catalog
@@ -186,7 +186,7 @@ spec:
                 - name: version
                   value: "{{workflow.creationTimestamp.Y}}{{workflow.creationTimestamp.m}}{{workflow.creationTimestamp.d}}{{workflow.creationTimestamp.H}}{{workflow.creationTimestamp.M}}{{workflow.creationTimestamp.S}}"
                 - name: base-url
-                  value: "gs://biascorrected-492e989a/stage"
+                  value: "gs://biascorrected-4a21ed18/stage"
           - name: get-output-downscaled-url
             templateRef:
               name: catalog
@@ -212,7 +212,7 @@ spec:
                 - name: version
                   value: "{{workflow.creationTimestamp.Y}}{{workflow.creationTimestamp.m}}{{workflow.creationTimestamp.d}}{{workflow.creationTimestamp.H}}{{workflow.creationTimestamp.M}}{{workflow.creationTimestamp.S}}"
                 - name: base-url
-                  value: "gs://downscaled-288ec5ac/stage"
+                  value: "gs://downscaled-48ec31ab/stage"
           - name: get-biascorrected-last-year
             template: get-biascorrected-last-year
             depends: get-input-clean-simulation-url
@@ -273,7 +273,7 @@ spec:
                 - name: simulation-zarr
                   value: "{{ tasks.preprocess-simulation.outputs.parameters.out-zarr }}"
                 - name: out-zarr
-                  value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/qdm-adjusted.zarr"
+                  value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/qdm-adjusted.zarr"
                 - name: kind
                   value: "{{ inputs.parameters.qdm-kind }}"
                 - name: first-year
@@ -349,7 +349,7 @@ spec:
                 - name: qdm-kind
                   value: "{{ inputs.parameters.qdm-kind }}"
                 - name: out-zarr
-                  value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/qplad-adjusted.zarr"
+                  value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/qplad-adjusted.zarr"
                 - name: correct-wetday-frequency
                   value: "{{ inputs.parameters.correct-wetday-frequency }}"
           - name: cap-max-downscaled-precip
@@ -442,7 +442,7 @@ spec:
         parameters:
           - name: in-zarr
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/capped-precip.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/capped-precip.zarr"
       outputs:
         parameters:
           - name: out-zarr

--- a/workflows/templates/biascorrectdownscale.yaml
+++ b/workflows/templates/biascorrectdownscale.yaml
@@ -172,9 +172,9 @@ spec:
           - name: correct-wetday-frequency
           - name: apply-dtr-minimum-threshold
           - name: domainfile1x1
-            value: "gs://support-c23ff1a3/domain.1x1.zarr"
+            value: "gs://support-f8a48a9e/domain.1x1.zarr"
           - name: domainfile0p25x0p25
-            value: "gs://support-c23ff1a3/domain.0p25x0p25.zarr"
+            value: "gs://support-f8a48a9e/domain.0p25x0p25.zarr"
       steps:
         - - name: historical
             template: biascorrectdownscale
@@ -239,7 +239,7 @@ spec:
           - name: reference-zarr
             # Use simulation variable_id to get reference URL.
             value: >-
-              gs://clean-b1dbca25/reanalysis/ERA-5/F320/{{=jsonpath(inputs.parameters.simulation, '$.variable_id')}}.1995-2015.F320.zarr
+              gs://clean-f1e04ef5/reanalysis/ERA-5/F320/{{=jsonpath(inputs.parameters.simulation, '$.variable_id')}}.1995-2015.F320.zarr
       dag:
         tasks:
           - name: get-input-clean-training-url
@@ -267,7 +267,7 @@ spec:
                 - name: version
                   value: "{{=jsonpath(inputs.parameters.historical, '$.version')}}"
                 - name: base-url
-                  value: "gs://clean-b1dbca25/cmip6"
+                  value: "gs://clean-f1e04ef5/cmip6"
           - name: get-input-clean-simulation-url
             templateRef:
               name: catalog
@@ -293,7 +293,7 @@ spec:
                 - name: version
                   value: "{{=jsonpath(inputs.parameters.simulation, '$.version')}}"
                 - name: base-url
-                  value: "gs://clean-b1dbca25/cmip6"
+                  value: "gs://clean-f1e04ef5/cmip6"
           - name: get-output-biascorrected-url
             templateRef:
               name: catalog
@@ -319,7 +319,7 @@ spec:
                 - name: version
                   value: "{{workflow.creationTimestamp.Y}}{{workflow.creationTimestamp.m}}{{workflow.creationTimestamp.d}}{{workflow.creationTimestamp.H}}{{workflow.creationTimestamp.M}}{{workflow.creationTimestamp.S}}"
                 - name: base-url
-                  value: "gs://biascorrected-492e989a/stage"
+                  value: "gs://biascorrected-4a21ed18/stage"
           - name: get-output-downscaled-url
             templateRef:
               name: catalog
@@ -345,7 +345,7 @@ spec:
                 - name: version
                   value: "{{workflow.creationTimestamp.Y}}{{workflow.creationTimestamp.m}}{{workflow.creationTimestamp.d}}{{workflow.creationTimestamp.H}}{{workflow.creationTimestamp.M}}{{workflow.creationTimestamp.S}}"
                 - name: base-url
-                  value: "gs://downscaled-288ec5ac/stage"
+                  value: "gs://downscaled-48ec31ab/stage"
           - name: get-biascorrected-last-year
             template: get-biascorrected-last-year
             depends: get-input-clean-simulation-url
@@ -372,7 +372,7 @@ spec:
                 - name: simulation-zarr
                   value: "{{ tasks.get-input-clean-simulation-url.outputs.parameters.out-url }}"
                 - name: out-zarr
-                  value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/qdm-adjusted.zarr"
+                  value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/qdm-adjusted.zarr"
                 - name: regrid-method
                   value: "{{ inputs.parameters.regrid-method }}"
                 - name: domainfile1x1

--- a/workflows/templates/clean-cmip6.yaml
+++ b/workflows/templates/clean-cmip6.yaml
@@ -124,7 +124,7 @@ spec:
                 - name: version
                   value: "{{=jsonpath(inputs.parameters.historical, '$.version')}}"
                 - name: base-url
-                  value: "gs://raw-305d04da/cmip6"
+                  value: "gs://raw-957d115e/cmip6"
           - name: get-input-raw-ssp-url
             templateRef:
               name: catalog
@@ -150,7 +150,7 @@ spec:
                 - name: version
                   value: "{{=jsonpath(inputs.parameters.ssp, '$.version')}}"
                 - name: base-url
-                  value: "gs://raw-305d04da/cmip6"
+                  value: "gs://raw-957d115e/cmip6"
           - name: get-output-clean-training-url
             templateRef:
               name: catalog
@@ -176,7 +176,7 @@ spec:
                 - name: version
                   value: "{{=jsonpath(inputs.parameters.historical, '$.version')}}"
                 - name: base-url
-                  value: "gs://clean-b1dbca25/cmip6"
+                  value: "gs://clean-f1e04ef5/cmip6"
             # We're slicing historical to time period of interest to reduce memory in later steps.
         - - name: crop-historical-time
             template: timeslicezarr
@@ -284,7 +284,7 @@ spec:
                 - name: version
                   value: "{{=jsonpath(inputs.parameters['target-json'], '$.version')}}"
                 - name: base-url
-                  value: "gs://clean-b1dbca25/cmip6"
+                  value: "gs://clean-f1e04ef5/cmip6"
           - name: remove-late-ssp
             template: timeslicezarr
             arguments:
@@ -359,7 +359,7 @@ spec:
                 - name: version
                   value: "{{=jsonpath(inputs.parameters['target-json'], '$.version')}}"
                 - name: base-url
-                  value: "gs://clean-b1dbca25/cmip6"
+                  value: "gs://clean-f1e04ef5/cmip6"
           - name: remove-early-historical
             template: timeslicezarr
             arguments:
@@ -402,7 +402,7 @@ spec:
         parameters:
           - name: in-zarr
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/standardized.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/standardized.zarr"
       outputs:
         parameters:
           - name: out-zarr
@@ -437,7 +437,7 @@ spec:
           - name: from-time
           - name: to-time
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/timesliced.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/timesliced.zarr"
       outputs:
         parameters:
           - name: out-zarr
@@ -504,7 +504,7 @@ spec:
           - name: in1-zarr
           - name: in2-zarr
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/concatenated.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/concatenated.zarr"
       outputs:
         parameters:
           - name: out-zarr

--- a/workflows/templates/clean-era5.yaml
+++ b/workflows/templates/clean-era5.yaml
@@ -12,9 +12,9 @@ spec:
   arguments:
     parameters:
     - name: in-zarr
-      value: "gs://raw-305d04da/reanalysis/ERA-5/F320/tasmax.1995-2015.F320.v2.zarr"
+      value: "gs://raw-957d115e/reanalysis/ERA-5/F320/tasmax.1995-2015.F320.v2.zarr"
     - name: out-zarr
-      value: "gs://clean-b1dbca25/reanalysis/ERA-5/F320/tasmax.1995-2015.F320.zarr"
+      value: "gs://clean-f1e04ef5/reanalysis/ERA-5/F320/tasmax.1995-2015.F320.zarr"
   templates:
 
   - name: main

--- a/workflows/templates/create-output-metadata-json.yaml
+++ b/workflows/templates/create-output-metadata-json.yaml
@@ -17,7 +17,7 @@ spec:
   arguments:
     parameters:
       - name: in-zarr
-        value: "gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20180701.zarr"
+        value: "gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20180701.zarr"
       - name: workflowstep
         value: downscale
   templates:

--- a/workflows/templates/create-pr-references.yaml
+++ b/workflows/templates/create-pr-references.yaml
@@ -20,7 +20,7 @@ spec:
   arguments:
     parameters:
       - name: in-zarr
-        value: "gs://clean-b1dbca25/reanalysis/ERA-5/F320/pr.1995-2015.F320.zarr"
+        value: "gs://clean-f1e04ef5/reanalysis/ERA-5/F320/pr.1995-2015.F320.zarr"
   templates:
 
     - name: create-pr-references
@@ -28,17 +28,17 @@ spec:
         parameters:
           - name: in-zarr
           - name: out-qdm-reference
-            value: "gs://support-c23ff1a3/qdm-reference/pr/v{{ inputs.parameters.version }}.zarr"
+            value: "gs://support-f8a48a9e/qdm-reference/pr/v{{ inputs.parameters.version }}.zarr"
           - name: out-qplad-fine-reference
-            value: "gs://support-c23ff1a3/qplad-fine-reference/pr/v{{ inputs.parameters.version }}.zarr"
+            value: "gs://support-f8a48a9e/qplad-fine-reference/pr/v{{ inputs.parameters.version }}.zarr"
           - name: out-qplad-coarse-reference
-            value: "gs://support-c23ff1a3/qplad-coarse-reference/pr/v{{ inputs.parameters.version }}.zarr"
+            value: "gs://support-f8a48a9e/qplad-coarse-reference/pr/v{{ inputs.parameters.version }}.zarr"
           - name: regrid-method
             value: "conservative"
           - name: domainfile1x1
-            value: "gs://support-c23ff1a3/domain.1x1.zarr"
+            value: "gs://support-f8a48a9e/domain.1x1.zarr"
           - name: domainfile0p25x0p25
-            value: "gs://support-c23ff1a3/domain.0p25x0p25.zarr"
+            value: "gs://support-f8a48a9e/domain.0p25x0p25.zarr"
           - name: version
             value: "{{workflow.creationTimestamp.Y}}{{workflow.creationTimestamp.m}}{{workflow.creationTimestamp.d}}{{workflow.creationTimestamp.H}}{{workflow.creationTimestamp.M}}{{workflow.creationTimestamp.S}}"
       dag:
@@ -213,7 +213,7 @@ spec:
         parameters:
           - name: fineref-zarr
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/wdf_precorrection.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/wdf_precorrection.zarr"
           - name: variable
             value: "pr"
       outputs:
@@ -287,7 +287,7 @@ spec:
           - name: ref-zarr
           - name: wdf-correction-zarr
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/wdf_precorrected.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/wdf_precorrected.zarr"
           - name: variable
             value: "pr"
       outputs:
@@ -359,7 +359,7 @@ spec:
         parameters:
           - name: in-zarr
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/wdf-corrected.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/wdf-corrected.zarr"
       outputs:
         parameters:
           - name: out-zarr

--- a/workflows/templates/distributed-regrid.yaml
+++ b/workflows/templates/distributed-regrid.yaml
@@ -19,7 +19,7 @@ spec:
       - name: regrid-method
         value: "bilinear"
       - name: domain-file
-        value: "gs://support-c23ff1a3/domain.0p25x0p25.zarr"
+        value: "gs://support-f8a48a9e/domain.0p25x0p25.zarr"
   templates:
 
     - name: main
@@ -82,7 +82,7 @@ spec:
           - name: regrid-method
           - name: domain-file
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/regridded.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/regridded.zarr"
       outputs:
         parameters:
           - name: out-zarr

--- a/workflows/templates/download-cmip6.yaml
+++ b/workflows/templates/download-cmip6.yaml
@@ -182,7 +182,7 @@ spec:
                 - name: version
                   value: "{{inputs.parameters.version}}"
                 - name: base-url
-                  value: "gs://raw-305d04da/cmip6"
+                  value: "gs://raw-957d115e/cmip6"
         - - name: download
             template: download-gcm
             arguments:

--- a/workflows/templates/qdm-preprocess.yaml
+++ b/workflows/templates/qdm-preprocess.yaml
@@ -18,11 +18,11 @@ spec:
   arguments:
     parameters:
       - name: in-zarr
-        value: "gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20180701.zarr"
+        value: "gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20180701.zarr"
       - name: regrid-method
         value: "bilinear"
       - name: domain-file
-        value: "gs://support-c23ff1a3/domain.1x1.zarr"
+        value: "gs://support-f8a48a9e/domain.1x1.zarr"
       - name: correct-wetday-frequency
         value: "false"
       - name: apply-dtr-minimum-threshold
@@ -148,7 +148,7 @@ spec:
         parameters:
           - name: in-zarr
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/wdf-corrected.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/wdf-corrected.zarr"
       outputs:
         parameters:
           - name: out-zarr
@@ -208,7 +208,7 @@ spec:
         parameters:
           - name: in-zarr
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/cyclic-added.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/cyclic-added.zarr"
           - name: add-cyclic
             value: "lon"
       outputs:
@@ -256,7 +256,7 @@ spec:
         parameters:
           - name: in-zarr
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/thresholded.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/thresholded.zarr"
       outputs:
         parameters:
           - name: out-zarr

--- a/workflows/templates/qdm.yaml
+++ b/workflows/templates/qdm.yaml
@@ -14,21 +14,21 @@ spec:
   arguments:
     parameters:
       - name: simulation-zarr
-        value: "gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20180701.zarr"
+        value: "gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20180701.zarr"
       - name: variable-id
         value: "tasmax"
       - name: training-zarr
-        value: "gs://clean-b1dbca25/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/training/r1i1p1f1/day/tasmax/gr1/v20190726.zarr"
+        value: "gs://clean-f1e04ef5/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/training/r1i1p1f1/day/tasmax/gr1/v20190726.zarr"
       - name: reference-zarr
-        value: "gs://clean-b1dbca25/reanalysis/ERA-5/F320/tasmax.1995-2015.F320.zarr"
+        value: "gs://clean-f1e04ef5/reanalysis/ERA-5/F320/tasmax.1995-2015.F320.zarr"
       - name: out-zarr
-        value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/biascorrected.zarr"
+        value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/biascorrected.zarr"
       - name: regrid-method
         value: "bilinear"
       - name: qdm-kind
         value: "additive"
       - name: domainfile1x1
-        value: "gs://support-c23ff1a3/domain.1x1.zarr"
+        value: "gs://support-f8a48a9e/domain.1x1.zarr"
       - name: correct-wetday-frequency
         value: "false"
       - name: apply-dtr-minimum-threshold
@@ -294,7 +294,7 @@ spec:
           - name: first-year
           - name: last-year
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/qdm_adjusted.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/qdm_adjusted.zarr"
         artifacts:
           - name: global-attrs-json
             path: /tmp/global_attrs.json
@@ -340,7 +340,7 @@ spec:
           - name: time-sel-stop
             value: "2015-01-15"
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/qdm_model.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/qdm_model.zarr"
       outputs:
         parameters:
           - name: out-zarr
@@ -385,7 +385,7 @@ spec:
           - name: lat-slice-min
           - name: lat-slice-max
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/qdm_adjusted.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/qdm_adjusted.zarr"
         artifacts:
           - name: global-attrs-json
             path: /tmp/global_attrs.json

--- a/workflows/templates/qplad.yaml
+++ b/workflows/templates/qplad.yaml
@@ -14,21 +14,21 @@ spec:
   arguments:
     parameters:
       - name: biascorrected-zarr
-        value: "gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20211103182935.zarr"
+        value: "gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20211103182935.zarr"
       - name: variable-id
         value: "tasmax"
       - name: reference-zarr
-        value: "gs://clean-b1dbca25/reanalysis/ERA-5/F320/tasmax.1995-2015.F320.zarr"
+        value: "gs://clean-f1e04ef5/reanalysis/ERA-5/F320/tasmax.1995-2015.F320.zarr"
       - name: out-zarr
-        value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/downscaled.zarr"
+        value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/downscaled.zarr"
       - name: regrid-method
         value: "bilinear"
       - name: qdm-kind
         value: "additive"
       - name: domainfile1x1
-        value: "gs://support-c23ff1a3/domain.1x1.zarr"
+        value: "gs://support-f8a48a9e/domain.1x1.zarr"
       - name: domainfile0p25x0p25
-        value: "gs://support-c23ff1a3/domain.0p25x0p25.zarr"
+        value: "gs://support-f8a48a9e/domain.0p25x0p25.zarr"
       - name: correct-wetday-frequency
         value: "false"
   templates:
@@ -449,7 +449,7 @@ spec:
           - name: time-sel-stop
             value: "2015-01-15"
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/qplad-model.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/qplad-model.zarr"
       outputs:
         parameters:
           - name: out-zarr
@@ -494,7 +494,7 @@ spec:
           - name: lat-slice-max
           - name: correct-wetday-frequency
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/qplad_adjusted.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/qplad_adjusted.zarr"
         artifacts:
           - name: global-attrs-json
             path: /tmp/global_attrs.json
@@ -534,7 +534,7 @@ spec:
           - name: simulation-zarr
           - name: variable
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/downscaled.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/downscaled.zarr"
         artifacts:
           - name: global-attrs-json
             path: /tmp/global_attrs.json
@@ -593,7 +593,7 @@ spec:
         parameters:
           - name: in-zarr
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/wdf-corrected.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/wdf-corrected.zarr"
       outputs:
         parameters:
           - name: out-zarr

--- a/workflows/templates/qualitycontrol-check-cmip6.yaml
+++ b/workflows/templates/qualitycontrol-check-cmip6.yaml
@@ -17,7 +17,7 @@ spec:
   arguments:
     parameters:
       - name: in-zarr
-        value: "gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20211022013318.zarr"
+        value: "gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20211022013318.zarr"
       # Must be "tasmax", "tasmin", "dtr", "pr".
       - name: variable
         value: "tasmax"

--- a/workflows/templates/rechunk.yaml
+++ b/workflows/templates/rechunk.yaml
@@ -17,7 +17,7 @@ spec:
         parameters:
           - name: in-zarr
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/rechunked.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/rechunked.zarr"
           - name: time-chunk
             value: 365
           - name: lat-chunk

--- a/workflows/templates/regrid.yaml
+++ b/workflows/templates/regrid.yaml
@@ -17,7 +17,7 @@ spec:
         parameters:
           - name: in-zarr
           - name: out-zarr
-            value: "gs://scratch-170cd6ec/{{ workflow.uid }}/{{ pod.name }}/out.zarr"
+            value: "gs://impactlab-data-scratch/{{ workflow.uid }}/{{ pod.name }}/out.zarr"
           - name: regrid-method
           - name: domain-file
       outputs:


### PR DESCRIPTION
Update Argo Workflows so they use the new storage on the west coast (from PR #638) rather than the older storage in the midwest.

Related to #640 