### PR TITLE
Fix paths in data_paths.yaml and dcmip6_all_paths.yaml following storage migration

### DIFF
--- a/notebooks/downscaling_pipeline/post_processing_and_delivery/data_paths.yaml
+++ b/notebooks/downscaling_pipeline/post_processing_and_delivery/data_paths.yaml
@@ -1,1855 +1,1855 @@
 ACCESS-CM2-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/gn/v20220204003921.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/gn/v20220204003921.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/gn/v20220204003921.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/gn/v20220204003921.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/gn/v20220204003921.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/gn/v20220204003921.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/gn/v20220204003921.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/gn/v20220204003921.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/gn/v20220204003921.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/gn/v20220204003921.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/gn/v20220204003921.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/gn/v20220204003921.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/v1.1.zarr
 ACCESS-CM2-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
 ACCESS-CM2-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
 ACCESS-ESM1-5-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/gn/v20220204004643.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/gn/v20191115.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/gn/v20220204004643.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/gn/v20220204004643.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/gn/v20191115.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/gn/v20220204004643.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/gn/v20220204004643.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/gn/v20191115.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/gn/v20220204004643.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/gn/v20220204004643.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/gn/v20191115.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/gn/v20220204004643.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/gn/v20220204004643.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/gn/v20191115.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/gn/v20220204004643.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/gn/v20220204004643.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/gn/v20191115.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/gn/v20220204004643.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/gn/v20220204004643.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/gn/v20191115.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/gn/v20220204004643.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/gn/v20220204004643.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/gn/v20191115.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/gn/v20220204004643.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/v1.1.zarr
 ACCESS-ESM1-5-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/gn/v20191115.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/gn/v20191115.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/gn/v20191115.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/gn/v20191115.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/gn/v20191115.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/gn/v20191115.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/gn/v20191115.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/gn/v20191115.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
 ACCESS-ESM1-5-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/gn/v20191115.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/gn/v20191115.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/gn/v20191115.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/gn/v20191115.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/gn/v20191115.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/gn/v20191115.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/gn/v20191115.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/gn/v20191115.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
 AWI-CM-1-1-MR-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/AWI/AWI-CM-1-1-MR/historical/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/AWI/AWI-CM-1-1-MR/historical/r1i1p1f1/day/tasmax/gn/v20181218.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/AWI/AWI-CM-1-1-MR/historical/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/AWI/AWI-CM-1-1-MR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/AWI/AWI-CM-1-1-MR/historical/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/AWI/AWI-CM-1-1-MR/historical/r1i1p1f1/day/tasmax/gn/v20181218.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/AWI/AWI-CM-1-1-MR/historical/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/AWI/AWI-CM-1-1-MR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20190529.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20190529.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20190529.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20190529.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20190529.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20190529.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20190529.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20190529.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20211125060137.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 BCC-CSM2-MR-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/gn/v20181126.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/gn/v20181126.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/gn/v20190315.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/gn/v20190315.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/gn/v20190318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/gn/v20190318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/gn/v20190318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/gn/v20190318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/gn/v20190318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/gn/v20190318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 BCC-CSM2-MR-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/gn/v20181126.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/gn/v20181126.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20190315.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20190315.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20190318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20190318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20190318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20190318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20190318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20190318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 BCC-CSM2-MR-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/gn/v20181126.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/gn/v20181126.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/gn/v20190315.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/gn/v20190315.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/gn/v20190318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/gn/v20190318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/gn/v20190318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/gn/v20190318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/gn/v20190318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/gn/v20190318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 CAMS-CSM1-0-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CAMS/CAMS-CSM1-0/historical/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CAMS/CAMS-CSM1-0/historical/r2i1p1f1/day/tasmax/gn/v20201022.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CAMS/CAMS-CSM1-0/historical/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CAMS/CAMS-CSM1-0/historical/r2i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CAMS/CAMS-CSM1-0/historical/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CAMS/CAMS-CSM1-0/historical/r2i1p1f1/day/tasmax/gn/v20201022.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CAMS/CAMS-CSM1-0/historical/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CAMS/CAMS-CSM1-0/historical/r2i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp126/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp126/r2i1p1f1/day/tasmax/gn/v20191106.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp126/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp126/r2i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp126/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp126/r2i1p1f1/day/tasmax/gn/v20191106.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp126/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp126/r2i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp245/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp245/r2i1p1f1/day/tasmax/gn/v20200720.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp245/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp245/r2i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp245/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp245/r2i1p1f1/day/tasmax/gn/v20200720.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp245/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp245/r2i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp370/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp370/r2i1p1f1/day/tasmax/gn/v20200720.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp370/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp370/r2i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp370/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp370/r2i1p1f1/day/tasmax/gn/v20200720.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp370/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp370/r2i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp585/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp585/r2i1p1f1/day/tasmax/gn/v20191106.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp585/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp585/r2i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp585/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp585/r2i1p1f1/day/tasmax/gn/v20191106.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp585/r2i1p1f1/day/tasmax/gn/v20211203190202.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAMS/CAMS-CSM1-0/ssp585/r2i1p1f1/day/tasmax/v1.1.zarr
 CMCC-CM2-SR5-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/gn/v20200616.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/gn/v20200616.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/gn/v20200717.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/gn/v20200717.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/gn/v20200617.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/gn/v20200617.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/gn/v20200622.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/gn/v20200622.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/gn/v20200622.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/gn/v20200622.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 CMCC-CM2-SR5-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/gn/v20200616.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/gn/v20200616.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/gn/v20200717.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/gn/v20200717.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/gn/v20200617.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/gn/v20200617.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/gn/v20200622.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/gn/v20200622.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/gn/v20200622.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/gn/v20200622.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 CMCC-CM2-SR5-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/gn/v20200616.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/gn/v20200616.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/gn/v20200717.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/gn/v20200717.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/gn/v20200617.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/gn/v20200617.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/gn/v20200622.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/gn/v20200622.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/gn/v20200622.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/gn/v20200622.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 CMCC-ESM2-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/gn/v20210114.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/gn/v20210114.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/gn/v20210126.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/gn/v20210126.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/gn/v20210129.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/gn/v20210129.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/gn/v20210202.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/gn/v20210202.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/gn/v20210126.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/gn/v20210126.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 CMCC-ESM2-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/gn/v20210114.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/gn/v20210114.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/gn/v20210126.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/gn/v20210126.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/gn/v20210129.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/gn/v20210129.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/gn/v20210202.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/gn/v20210202.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/gn/v20210126.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/gn/v20210126.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 CMCC-ESM2-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/gn/v20210114.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/gn/v20210114.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/gn/v20210126.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/gn/v20210126.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/gn/v20210129.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/gn/v20210129.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/gn/v20210202.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/gn/v20210202.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/gn/v20210126.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/gn/v20210126.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 CanESM5-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/gn/v20190429.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/gn/v20190429.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/gn/v20190429.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/gn/v20190429.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/gn/v20190429.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/gn/v20190429.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/gn/v20190429.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/gn/v20190429.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/gn/v20190429.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/gn/v20190429.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 CanESM5-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/gn/v20190429.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/gn/v20190429.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/gn/v20190429.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/gn/v20190429.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/gn/v20190429.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/gn/v20190429.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/gn/v20190429.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/gn/v20190429.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/gn/v20190429.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/gn/v20190429.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 CanESM5-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/gn/v20190429.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/gn/v20190429.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/gn/v20190429.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/gn/v20190429.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/gn/v20190429.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/gn/v20190429.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/gn/v20190429.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/gn/v20190429.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/gn/v20190429.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/gn/v20190429.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 EC-Earth3-AerChem-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/gr/v20220217012511.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/gr/v20200624.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/gr/v20220217012511.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/gr/v20220217012511.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/gr/v20200624.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/gr/v20220217012511.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/gr/v20220217012511.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/gr/v20200827.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/gr/v20220217012511.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/gr/v20220217012511.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/gr/v20200827.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/gr/v20220217012511.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/v1.1.zarr
 EC-Earth3-AerChem-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/gr/v20220216005247.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/gr/v20200624.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/gr/v20220216005247.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/gr/v20220216005247.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/gr/v20200624.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/gr/v20220216005247.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/gr/v20220216005247.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/gr/v20200827.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/gr/v20220216005247.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/gr/v20220216005247.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/gr/v20200827.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/gr/v20220216005247.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
 EC-Earth3-AerChem-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/gr/v20220216022728.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/gr/v20200624.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/gr/v20220216022728.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/gr/v20220216022728.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/gr/v20200624.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/gr/v20220216022728.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/gr/v20220216022728.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/gr/v20200827.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/gr/v20220216022728.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/gr/v20220216022728.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/gr/v20200827.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/gr/v20220216022728.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
 EC-Earth3-CC-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/gr/v20220217012508.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/gr/v20210113.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/gr/v20220217012508.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/gr/v20220217012508.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/gr/v20210113.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/gr/v20220217012508.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/gr/v20220217012508.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/gr/v20210113.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/gr/v20220217012508.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/gr/v20220217012508.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/gr/v20210113.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/gr/v20220217012508.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/gr/v20220217012508.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/gr/v20210113.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/gr/v20220217012508.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/gr/v20220217012508.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/gr/v20210113.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/gr/v20220217012508.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 EC-Earth3-CC-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/gr/v20210113.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/gr/v20210113.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/gr/v20210113.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/gr/v20210113.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/gr/v20210113.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/gr/v20210113.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 EC-Earth3-CC-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/gr/v20210113.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/gr/v20210113.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/gr/v20210113.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/gr/v20210113.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/gr/v20210113.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/gr/v20210113.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 EC-Earth3-Veg-LR-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/gr/v20200217.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/gr/v20200217.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/gr/v20201201.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/gr/v20201201.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/gr/v20201123.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/gr/v20201123.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/gr/v20201123.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/gr/v20201123.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/gr/v20201201.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/gr/v20201201.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 EC-Earth3-Veg-LR-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/gr/v20200217.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/gr/v20200217.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/gr/v20201201.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/gr/v20201201.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/gr/v20201123.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/gr/v20201123.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/gr/v20201123.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/gr/v20201123.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/gr/v20201201.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/gr/v20201201.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 EC-Earth3-Veg-LR-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/gr/v20200217.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/gr/v20200217.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/gr/v20201201.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/gr/v20201201.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/gr/v20201123.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/gr/v20201123.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/gr/v20201123.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/gr/v20201123.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/gr/v20201201.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/gr/v20201201.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 EC-Earth3-Veg-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/gr/v20200225.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/gr/v20200225.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/gr/v20200225.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/gr/v20200225.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/gr/v20200225.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/gr/v20200225.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/gr/v20200225.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/gr/v20200225.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/gr/v20200225.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/gr/v20200225.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 EC-Earth3-Veg-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/gr/v20200225.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/gr/v20200225.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/gr/v20200225.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/gr/v20200225.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/gr/v20200225.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/gr/v20200225.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/gr/v20200225.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/gr/v20200225.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/gr/v20200225.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/gr/v20200225.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 EC-Earth3-Veg-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/gr/v20200225.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/gr/v20200225.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/gr/v20200225.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/gr/v20200225.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/gr/v20200225.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/gr/v20200225.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/gr/v20200225.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/gr/v20200225.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/gr/v20200225.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/gr/v20200225.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 EC-Earth3-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/gr/v20220217012505.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/gr/v20200310.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/gr/v20220217012505.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/gr/v20220217012505.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/gr/v20200310.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/gr/v20220217012505.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/gr/v20220217012505.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/gr/v20200310.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/gr/v20220217012505.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/gr/v20220217012505.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/gr/v20200310.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/gr/v20220217012505.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/gr/v20220217012505.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/gr/v20200310.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/gr/v20220217012505.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/gr/v20220217012505.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/gr/v20200310.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/gr/v20220217012505.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/gr/v20220217012505.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/gr/v20200310.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/gr/v20220217012505.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/gr/v20220217012505.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/gr/v20200310.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/gr/v20220217012505.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/gr/v20220307025028.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/gr/v20200310.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/gr/v20220307025028.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/gr/v20220307025028.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/gr/v20200310.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/gr/v20220307025028.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 EC-Earth3-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/gr/v20200310.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/gr/v20200310.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/gr/v20200310.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/gr/v20200310.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/gr/v20200310.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/gr/v20200310.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/gr/v20200310.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/gr/v20200310.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/gr/v20200310.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/gr/v20200310.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 EC-Earth3-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/gr/v20200310.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/gr/v20200310.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/gr/v20200310.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/gr/v20200310.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/gr/v20200310.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/gr/v20200310.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/gr/v20200310.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/gr/v20200310.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/gr/v20200310.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/gr/v20200310.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 FGOALS-g3-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/gn/v20220204004649.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/gn/v20190826.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/gn/v20220204004649.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/gn/v20220204004649.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/gn/v20190826.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/gn/v20220204004649.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/gn/v20220204004649.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/gn/v20190818.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/gn/v20220204004649.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/gn/v20220204004649.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/gn/v20190818.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/gn/v20220204004649.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/gn/v20220204004649.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/gn/v20190820.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/gn/v20220204004649.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/gn/v20220204004649.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/gn/v20190820.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/gn/v20220204004649.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/gn/v20220204004649.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/gn/v20190818.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/gn/v20220204004649.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/gn/v20220204004649.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/gn/v20190818.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/gn/v20220204004649.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 FGOALS-g3-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/gn/v20190826.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/gn/v20190826.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/gn/v20190818.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/gn/v20190818.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/gn/v20190818.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/gn/v20190818.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/gn/v20190820.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/gn/v20190820.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/gn/v20190819.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/gn/v20190819.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 FGOALS-g3-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/gn/v20190826.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/gn/v20190826.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/gn/v20190818.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/gn/v20190818.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/gn/v20190818.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/gn/v20190818.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/gn/v20190820.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/gn/v20190820.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/gn/v20190819.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/gn/v20190819.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 GFDL-CM4-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 GFDL-CM4-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 GFDL-CM4-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 GFDL-ESM4-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/gr1/v20190726.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/gr1/v20190726.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 GFDL-ESM4-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20190726.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20190726.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 GFDL-ESM4-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/gr1/v20190726.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/gr1/v20190726.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 HadGEM3-GC31-LL-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/gn/v20220217031623.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/gn/v20190624.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/gn/v20220217031623.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/gn/v20220217031623.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/gn/v20190624.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/gn/v20220217031623.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/gn/v20220217031623.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/gn/v20200114.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/gn/v20220217031623.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/gn/v20220217031623.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/gn/v20200114.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/gn/v20220217031623.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/gn/v20220217031623.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/gn/v20190908.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/gn/v20220217031623.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/gn/v20220217031623.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/gn/v20190908.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/gn/v20220217031623.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/gn/v20220217031623.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/gn/v20200114.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/gn/v20220217031623.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/gn/v20220217031623.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/gn/v20200114.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/gn/v20220217031623.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/v1.1.zarr
 HadGEM3-GC31-LL-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/gn/v20190624.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/gn/v20190624.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/gn/v20200114.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/gn/v20200114.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/gn/v20190908.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/gn/v20190908.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/gn/v20200114.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/gn/v20200114.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/v1.1.zarr
 HadGEM3-GC31-LL-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/gn/v20190624.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/gn/v20190624.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/gn/v20200114.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/gn/v20200114.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/gn/v20190908.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/gn/v20190908.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/gn/v20200114.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/gn/v20200114.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/v1.1.zarr
 INM-CM4-8-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/gr1/v20190530.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/gr1/v20190530.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/gr1/v20190603.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/gr1/v20190603.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/gr1/v20190603.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/gr1/v20190603.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/gr1/v20190603.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/gr1/v20190603.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/gr1/v20190603.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/gr1/v20190603.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 INM-CM4-8-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/gr1/v20190530.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/gr1/v20190530.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/gr1/v20190603.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/gr1/v20190603.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/gr1/v20190603.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/gr1/v20190603.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/gr1/v20190603.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/gr1/v20190603.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/gr1/v20190603.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/gr1/v20190603.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 INM-CM4-8-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/gr1/v20190530.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/gr1/v20190530.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/gr1/v20190603.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/gr1/v20190603.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/gr1/v20190603.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/gr1/v20190603.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/gr1/v20190603.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/gr1/v20190603.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/gr1/v20190603.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/gr1/v20190603.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 INM-CM5-0-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/gr1/v20190610.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/gr1/v20190610.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/gr1/v20190619.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/gr1/v20190619.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/gr1/v20190619.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/gr1/v20190619.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/gr1/v20190618.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/gr1/v20190618.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/gr1/v20190724.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/gr1/v20190724.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 INM-CM5-0-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/gr1/v20190610.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/gr1/v20190610.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/gr1/v20190619.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/gr1/v20190619.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/gr1/v20190619.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/gr1/v20190619.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/gr1/v20190618.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/gr1/v20190618.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/gr1/v20190724.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/gr1/v20190724.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 INM-CM5-0-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/gr1/v20190610.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/gr1/v20190610.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/gr1/v20190619.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/gr1/v20190619.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/gr1/v20190619.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/gr1/v20190619.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/gr1/v20190618.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/gr1/v20190618.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/gr1/v20190724.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/gr1/v20190724.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 KACE-1-0-G-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NIMS-KMA/KACE-1-0-G/historical/r1i1p1f1/day/pr/gr/v20220224004011.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NIMS-KMA/KACE-1-0-G/historical/r1i1p1f1/day/pr/gr/v20190911.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NIMS-KMA/KACE-1-0-G/historical/r1i1p1f1/day/pr/gr/v20220224004011.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NIMS-KMA/KACE-1-0-G/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NIMS-KMA/KACE-1-0-G/historical/r1i1p1f1/day/pr/gr/v20220224004011.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NIMS-KMA/KACE-1-0-G/historical/r1i1p1f1/day/pr/gr/v20190911.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NIMS-KMA/KACE-1-0-G/historical/r1i1p1f1/day/pr/gr/v20220224004011.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NIMS-KMA/KACE-1-0-G/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp126/r1i1p1f1/day/pr/gr/v20220224004011.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp126/r1i1p1f1/day/pr/gr/v20191011.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp126/r1i1p1f1/day/pr/gr/v20220224004011.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp126/r1i1p1f1/day/pr/gr/v20220224004011.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp126/r1i1p1f1/day/pr/gr/v20191011.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp126/r1i1p1f1/day/pr/gr/v20220224004011.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp245/r1i1p1f1/day/pr/gr/v20220224004011.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp245/r1i1p1f1/day/pr/gr/v20191125.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp245/r1i1p1f1/day/pr/gr/v20220224004011.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp245/r1i1p1f1/day/pr/gr/v20220224004011.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp245/r1i1p1f1/day/pr/gr/v20191125.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp245/r1i1p1f1/day/pr/gr/v20220224004011.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp370/r1i1p1f1/day/pr/gr/v20220224004011.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp370/r1i1p1f1/day/pr/gr/v20191125.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp370/r1i1p1f1/day/pr/gr/v20220224004011.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp370/r1i1p1f1/day/pr/gr/v20220224004011.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp370/r1i1p1f1/day/pr/gr/v20191125.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp370/r1i1p1f1/day/pr/gr/v20220224004011.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp585/r1i1p1f1/day/pr/gr/v20220224004011.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp585/r1i1p1f1/day/pr/gr/v20190920.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp585/r1i1p1f1/day/pr/gr/v20220224004011.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp585/r1i1p1f1/day/pr/gr/v20220224004011.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp585/r1i1p1f1/day/pr/gr/v20190920.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp585/r1i1p1f1/day/pr/gr/v20220224004011.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 KACE-1-0-G-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NIMS-KMA/KACE-1-0-G/historical/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NIMS-KMA/KACE-1-0-G/historical/r1i1p1f1/day/tasmax/gr/v20200316.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NIMS-KMA/KACE-1-0-G/historical/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NIMS-KMA/KACE-1-0-G/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NIMS-KMA/KACE-1-0-G/historical/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NIMS-KMA/KACE-1-0-G/historical/r1i1p1f1/day/tasmax/gr/v20200316.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NIMS-KMA/KACE-1-0-G/historical/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NIMS-KMA/KACE-1-0-G/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp126/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp126/r1i1p1f1/day/tasmax/gr/v20200317.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp126/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp126/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp126/r1i1p1f1/day/tasmax/gr/v20200317.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp126/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp245/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp245/r1i1p1f1/day/tasmax/gr/v20200317.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp245/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp245/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp245/r1i1p1f1/day/tasmax/gr/v20200317.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp245/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp370/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp370/r1i1p1f1/day/tasmax/gr/v20200317.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp370/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp370/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp370/r1i1p1f1/day/tasmax/gr/v20200317.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp370/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp585/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp585/r1i1p1f1/day/tasmax/gr/v20200317.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp585/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp585/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp585/r1i1p1f1/day/tasmax/gr/v20200317.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp585/r1i1p1f1/day/tasmax/gr/v20220224003831.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NIMS-KMA/KACE-1-0-G/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 MIROC-ES2L-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/gn/v20191129.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/gn/v20191129.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/gn/v20200318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/gn/v20200318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/gn/v20200318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/gn/v20200318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/gn/v20200318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/gn/v20200318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/gn/v20200318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/gn/v20200318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/v1.1.zarr
 MIROC-ES2L-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/gn/v20191129.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/gn/v20191129.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/gn/v20200318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/gn/v20200318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/gn/v20200318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/gn/v20200318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/gn/v20200318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/gn/v20200318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/gn/v20200318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/gn/v20200318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/v1.1.zarr
 MIROC-ES2L-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/gn/v20191129.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/gn/v20191129.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/gn/v20200318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/gn/v20200318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/gn/v20200318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/gn/v20200318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/gn/v20200318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/gn/v20200318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/gn/v20200318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/gn/v20200318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/v1.1.zarr
 MIROC6-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/gn/v20191016.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/gn/v20191016.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/gn/v20191016.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/gn/v20191016.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/gn/v20191016.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/gn/v20191016.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/gn/v20191016.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/gn/v20191016.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/gn/v20191016.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/gn/v20191016.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 MIROC6-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/gn/v20191016.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/gn/v20191016.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/gn/v20191016.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/gn/v20191016.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/gn/v20191016.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/gn/v20191016.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/gn/v20191016.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/gn/v20191016.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/gn/v20191016.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/gn/v20191016.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 MIROC6-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/gn/v20191016.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/gn/v20191016.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/gn/v20191016.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/gn/v20191016.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/gn/v20191016.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/gn/v20191016.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/gn/v20191016.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/gn/v20191016.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/gn/v20191016.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/gn/v20191016.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 MPI-ESM1-2-HR-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/gn/v20220217124205.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/gn/v20220217124205.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/gn/v20220217124205.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/gn/v20220217124205.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/gn/v20220217124205.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/gn/v20220217124205.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/gn/v20220217124205.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/gn/v20220217124205.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/gn/v20220217124205.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/gn/v20220217124205.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/gn/v20220217124205.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/gn/v20220217124205.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 MPI-ESM1-2-HR-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 MPI-ESM1-2-HR-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 MPI-ESM1-2-LR-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 MPI-ESM1-2-LR-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 MPI-ESM1-2-LR-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/gn/v20190710.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/gn/v20190710.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 MRI-ESM2-0-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MRI/MRI-ESM2-0/historical/r1i1p1f1/day/tasmax/gn/v20211202032930.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MRI/MRI-ESM2-0/historical/r1i1p1f1/day/tasmax/gn/v20190603.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MRI/MRI-ESM2-0/historical/r1i1p1f1/day/tasmax/gn/v20211202032930.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MRI/MRI-ESM2-0/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MRI/MRI-ESM2-0/historical/r1i1p1f1/day/tasmax/gn/v20211202032930.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MRI/MRI-ESM2-0/historical/r1i1p1f1/day/tasmax/gn/v20190603.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MRI/MRI-ESM2-0/historical/r1i1p1f1/day/tasmax/gn/v20211202032930.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MRI/MRI-ESM2-0/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MRI/MRI-ESM2-0/ssp245/r1i1p1f1/day/tasmax/gn/v20211202032930.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MRI/MRI-ESM2-0/ssp245/r1i1p1f1/day/tasmax/gn/v20190603.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MRI/MRI-ESM2-0/ssp245/r1i1p1f1/day/tasmax/gn/v20211202032930.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MRI/MRI-ESM2-0/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MRI/MRI-ESM2-0/ssp245/r1i1p1f1/day/tasmax/gn/v20211202032930.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MRI/MRI-ESM2-0/ssp245/r1i1p1f1/day/tasmax/gn/v20190603.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MRI/MRI-ESM2-0/ssp245/r1i1p1f1/day/tasmax/gn/v20211202032930.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MRI/MRI-ESM2-0/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MRI/MRI-ESM2-0/ssp370/r1i1p1f1/day/tasmax/gn/v20211202032930.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MRI/MRI-ESM2-0/ssp370/r1i1p1f1/day/tasmax/gn/v20190603.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MRI/MRI-ESM2-0/ssp370/r1i1p1f1/day/tasmax/gn/v20211202032930.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MRI/MRI-ESM2-0/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MRI/MRI-ESM2-0/ssp370/r1i1p1f1/day/tasmax/gn/v20211202032930.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MRI/MRI-ESM2-0/ssp370/r1i1p1f1/day/tasmax/gn/v20190603.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MRI/MRI-ESM2-0/ssp370/r1i1p1f1/day/tasmax/gn/v20211202032930.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MRI/MRI-ESM2-0/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
 NESM3-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/gn/v20220204071020.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/gn/v20190812.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/gn/v20220204071020.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/gn/v20220204071020.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/gn/v20190812.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/gn/v20220204071020.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/gn/v20220204071020.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/gn/v20190806.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/gn/v20220204071020.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/gn/v20220204071020.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/gn/v20190806.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/gn/v20220204071020.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/gn/v20220204071020.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/gn/v20190805.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/gn/v20220204071020.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/gn/v20220204071020.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/gn/v20190805.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/gn/v20220204071020.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/gn/v20220204071020.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/gn/v20190811.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/gn/v20220204071020.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/gn/v20220204071020.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/gn/v20190811.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/gn/v20220204071020.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 NESM3-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/gn/v20190812.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/gn/v20190812.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/gn/v20190806.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/gn/v20190806.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/gn/v20190805.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/gn/v20190805.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/gn/v20190811.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/gn/v20190811.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 NESM3-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/gn/v20190812.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/gn/v20190812.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/gn/v20190806.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/gn/v20190806.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/gn/v20190805.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/gn/v20190805.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/gn/v20190811.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/gn/v20190811.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 NorESM2-LM-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/gn/v20190815.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/gn/v20190815.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 NorESM2-LM-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/gn/v20190815.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/gn/v20190815.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 NorESM2-LM-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/gn/v20190815.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/gn/v20190815.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 NorESM2-MM-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 NorESM2-MM-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 NorESM2-MM-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 UKESM1-0-LL-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/gn/v20190627.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/gn/v20190627.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/gn/v20190708.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/gn/v20190708.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/gn/v20190715.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/gn/v20190715.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/gn/v20190726.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/gn/v20190726.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/gn/v20190726.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/gn/v20190726.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/v1.1.zarr
 UKESM1-0-LL-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/gn/v20190627.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/gn/v20190627.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/gn/v20190708.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/gn/v20190708.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/gn/v20190715.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/gn/v20190715.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/gn/v20190726.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/gn/v20190726.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/gn/v20190726.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/gn/v20190726.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/v1.1.zarr
 UKESM1-0-LL-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/gn/v20190627.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/gn/v20190627.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/gn/v20190708.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/gn/v20190708.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/gn/v20190715.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/gn/v20190715.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/gn/v20190726.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/gn/v20190726.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/gn/v20190726.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/gn/v20190726.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/v1.1.zarr

--- a/notebooks/paper_analysis/dcmip6_all_paths.yaml
+++ b/notebooks/paper_analysis/dcmip6_all_paths.yaml
@@ -1,2067 +1,2067 @@
 ACCESS-CM2-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/gn/v20220204003921.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/gn/v20220309084314.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/gn/v20220204003921.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/gn/v20220204003921.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/gn/v20220309084314.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/gn/v20220204003921.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/gn/v20220204003921.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/gn/v20220309084314.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/gn/v20220204003921.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/gn/v20220204003921.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/gn/v20220309084314.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/gn/v20220204003921.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/gn/v20220204003921.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/gn/v20220309084314.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/gn/v20220204003921.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/gn/v20220204003921.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/gn/v20220309084314.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/gn/v20220204003921.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/pr/v1.1.zarr
 ACCESS-CM2-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/gn/v20220309073717.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/gn/v20220309073717.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220310232050.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220310232050.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073717.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073717.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010330.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
 ACCESS-CM2-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/gn/v20220309081500.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/gn/v20220309081500.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CSIRO-ARCCSS/ACCESS-CM2/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081500.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081500.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081500.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081500.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010201.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO-ARCCSS/ACCESS-CM2/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
 ACCESS-ESM1-5-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/gn/v20220204004643.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/gn/v20191115.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/gn/v20220309084318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/gn/v20220204004643.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/gn/v20220204004643.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/gn/v20191115.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/gn/v20220309084318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/gn/v20220204004643.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/gn/v20220204004643.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/gn/v20191115.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/gn/v20220309084318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/gn/v20220204004643.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/gn/v20220204004643.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/gn/v20191115.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/gn/v20220309084318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/gn/v20220204004643.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/gn/v20220204004643.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/gn/v20191115.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/gn/v20220309084318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/gn/v20220204004643.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/gn/v20220204004643.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/gn/v20191115.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/gn/v20220309084318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/gn/v20220204004643.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/gn/v20220204004643.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/gn/v20191115.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/gn/v20220309084318.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/gn/v20220204004643.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/gn/v20220204004643.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/gn/v20191115.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/gn/v20220309084318.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/gn/v20220204004643.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/pr/v1.1.zarr
 ACCESS-ESM1-5-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/gn/v20191115.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/gn/v20220309073720.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/gn/v20191115.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/gn/v20220309073720.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/gn/v20191115.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073720.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/gn/v20191115.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073720.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/gn/v20191115.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073720.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/gn/v20191115.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073720.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/gn/v20191115.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073720.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/gn/v20191115.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073720.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010332.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
 ACCESS-ESM1-5-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/gn/v20191115.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/gn/v20220309081503.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/gn/v20191115.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/gn/v20220309081503.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CSIRO/ACCESS-ESM1-5/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/gn/v20191115.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081503.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/gn/v20191115.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081503.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/gn/v20191115.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081503.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/gn/v20191115.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081503.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/gn/v20191115.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081503.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/gn/v20191115.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081503.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010203.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CSIRO/ACCESS-ESM1-5/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
 BCC-CSM2-MR-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/gn/v20181126.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/gn/v20220309084320.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/gn/v20181126.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/gn/v20220309084320.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/gn/v20190315.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/gn/v20220309084320.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/gn/v20190315.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/gn/v20220309084320.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/gn/v20190318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/gn/v20220309084320.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/gn/v20190318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/gn/v20220309084320.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/gn/v20190318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/gn/v20220309084320.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/gn/v20190318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/gn/v20220309084320.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/gn/v20190318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/gn/v20220309084320.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/gn/v20220204004646.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/gn/v20190318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/gn/v20220309084320.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/gn/v20220204004646.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 BCC-CSM2-MR-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/gn/v20181126.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/gn/v20220309073722.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/gn/v20181126.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/gn/v20220309073722.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20190315.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073722.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20190315.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073722.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20190318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073722.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20190318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073722.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20190318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073722.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20190318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073722.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20190318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073722.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20190318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073722.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010335.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 BCC-CSM2-MR-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/gn/v20181126.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/gn/v20220309081506.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/gn/v20181126.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/gn/v20220309081506.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/BCC/BCC-CSM2-MR/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/gn/v20190315.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081506.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/gn/v20190315.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081506.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/gn/v20190318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081506.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/gn/v20190318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081506.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/gn/v20190318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081506.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/gn/v20190318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081506.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/gn/v20190318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081506.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/gn/v20190318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081506.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010206.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/BCC/BCC-CSM2-MR/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 CMCC-CM2-SR5-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/gn/v20200616.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/gn/v20220309084425.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/gn/v20200616.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/gn/v20220309084425.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/gn/v20200717.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/gn/v20220309084425.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/gn/v20200717.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/gn/v20220309084425.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/gn/v20200617.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/gn/v20220309084425.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/gn/v20200617.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/gn/v20220309084425.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/gn/v20200622.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/gn/v20220309084425.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/gn/v20200622.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/gn/v20220309084425.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/gn/v20200622.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/gn/v20220309084425.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/gn/v20220216070906.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/gn/v20200622.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/gn/v20220309084425.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/gn/v20220216070906.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 CMCC-CM2-SR5-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/gn/v20200616.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/gn/v20220309073827.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/gn/v20200616.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/gn/v20220309073827.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/gn/v20200717.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073827.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/gn/v20200717.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073827.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/gn/v20200617.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073827.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/gn/v20200617.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073827.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/gn/v20200622.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073827.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/gn/v20200622.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073827.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/gn/v20200622.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073827.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/gn/v20200622.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073827.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/gn/v20220216004735.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 CMCC-CM2-SR5-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/gn/v20200616.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/gn/v20220309081607.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/gn/v20200616.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/gn/v20220309081607.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CMCC/CMCC-CM2-SR5/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/gn/v20200717.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081607.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/gn/v20200717.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081607.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/gn/v20200617.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081607.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/gn/v20200617.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081607.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/gn/v20200622.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081607.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/gn/v20200622.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081607.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/gn/v20200622.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081607.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/gn/v20200622.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081607.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/gn/v20220216055705.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-CM2-SR5/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 CMCC-ESM2-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/gn/v20210114.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/gn/v20220309084407.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/gn/v20210114.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/gn/v20220309084407.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/gn/v20210126.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/gn/v20220309084407.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/gn/v20210126.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/gn/v20220309084407.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/gn/v20210129.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/gn/v20220309084407.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/gn/v20210129.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/gn/v20220309084407.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/gn/v20210202.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/gn/v20220309084407.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/gn/v20210202.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/gn/v20220309084407.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/gn/v20210126.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/gn/v20220309084407.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/gn/v20220215232915.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/gn/v20210126.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/gn/v20220309084407.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/gn/v20220215232915.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 CMCC-ESM2-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/gn/v20210114.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/gn/v20220309073813.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/gn/v20210114.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/gn/v20220309073813.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/gn/v20210126.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073813.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/gn/v20210126.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073813.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/gn/v20210129.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073813.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/gn/v20210129.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073813.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/gn/v20210202.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073813.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/gn/v20210202.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073813.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/gn/v20210126.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073813.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/gn/v20210126.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073813.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/gn/v20220215031245.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 CMCC-ESM2-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/gn/v20210114.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/gn/v20220309081554.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/gn/v20210114.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/gn/v20220309081554.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CMCC/CMCC-ESM2/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/gn/v20210126.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081554.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/gn/v20210126.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081554.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/gn/v20210129.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081554.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/gn/v20210129.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081554.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/gn/v20210202.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081554.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/gn/v20210202.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081554.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/gn/v20210126.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081554.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/gn/v20210126.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081554.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081556.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CMCC/CMCC-ESM2/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 CanESM5-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/gn/v20190429.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/gn/v20220309084416.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/gn/v20190429.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/gn/v20220309084416.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/gn/v20190429.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/gn/v20220309084416.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/gn/v20190429.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/gn/v20220309084416.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/gn/v20190429.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/gn/v20220309084416.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/gn/v20190429.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/gn/v20220309084416.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/gn/v20190429.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/gn/v20220309084416.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/gn/v20190429.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/gn/v20220309084416.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/gn/v20190429.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/gn/v20220309084416.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/gn/v20220215232921.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/gn/v20190429.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/gn/v20220309084416.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/gn/v20220215232921.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 CanESM5-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/gn/v20190429.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/gn/v20220309073819.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/gn/v20190429.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/gn/v20220309073819.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/gn/v20190429.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073819.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/gn/v20190429.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073819.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/gn/v20190429.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073819.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/gn/v20190429.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073819.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/gn/v20190429.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073819.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/gn/v20190429.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073819.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/gn/v20190429.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073819.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/gn/v20190429.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073819.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/gn/v20220215031257.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 CanESM5-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/gn/v20190429.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/gn/v20220309081600.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/gn/v20190429.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/gn/v20220309081600.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CCCma/CanESM5/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/gn/v20190429.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081600.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/gn/v20190429.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081600.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/gn/v20190429.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081600.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/gn/v20190429.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081600.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/gn/v20190429.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081600.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/gn/v20190429.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081600.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/gn/v20190429.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081600.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/gn/v20190429.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081600.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081601.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CCCma/CanESM5/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 EC-Earth3-AerChem-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/gr/v20220217012511.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/gr/v20200624.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/gr/v20220309084423.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/gr/v20220217012511.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/gr/v20220217012511.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/gr/v20200624.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/gr/v20220309084423.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/gr/v20220217012511.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/gr/v20220217012511.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/gr/v20200827.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/gr/v20220309084423.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/gr/v20220217012511.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/gr/v20220217012511.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/gr/v20200827.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/gr/v20220309084423.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/gr/v20220217012511.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/pr/v1.1.zarr
 EC-Earth3-AerChem-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/gr/v20220216005247.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/gr/v20200624.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/gr/v20220309073824.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/gr/v20220216005247.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/gr/v20220216005247.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/gr/v20200624.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/gr/v20220309073824.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/gr/v20220216005247.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/gr/v20220216005247.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/gr/v20200827.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/gr/v20220309073824.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/gr/v20220216005247.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/gr/v20220216005247.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/gr/v20200827.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/gr/v20220309073824.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/gr/v20220216005247.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
 EC-Earth3-AerChem-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/gr/v20220216022728.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/gr/v20200624.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/gr/v20220309081605.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/gr/v20220216022728.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/gr/v20220216022728.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/gr/v20200624.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/gr/v20220309081605.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/gr/v20220216022728.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-AerChem/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/gr/v20220216022728.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/gr/v20200827.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/gr/v20220309081605.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/gr/v20220216022728.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/gr/v20220216022728.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/gr/v20200827.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/gr/v20220309081605.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/gr/v20220216022728.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-AerChem/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
 EC-Earth3-CC-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/gr/v20220217012508.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/gr/v20210113.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/gr/v20220309084420.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/gr/v20220217012508.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/gr/v20220217012508.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/gr/v20210113.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/gr/v20220309084420.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/gr/v20220217012508.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/gr/v20220217012508.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/gr/v20210113.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/gr/v20220309084420.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/gr/v20220217012508.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/gr/v20220217012508.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/gr/v20210113.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/gr/v20220309084420.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/gr/v20220217012508.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/gr/v20220217012508.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/gr/v20210113.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/gr/v20220309084420.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/gr/v20220217012508.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/gr/v20220217012508.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/gr/v20210113.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/gr/v20220309084420.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/gr/v20220217012508.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 EC-Earth3-CC-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/gr/v20210113.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/gr/v20220309073822.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/gr/v20210113.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/gr/v20220309073822.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/gr/v20210113.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/gr/v20220309073822.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/gr/v20210113.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/gr/v20220309073822.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/gr/v20210113.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/gr/v20220309073822.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/gr/v20210113.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/gr/v20220309073822.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/gr/v20220216004732.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 EC-Earth3-CC-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/gr/v20210113.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/gr/v20220309081602.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/gr/v20210113.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/gr/v20220309081602.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-CC/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/gr/v20210113.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/gr/v20220309081602.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/gr/v20210113.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/gr/v20220309081602.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/gr/v20210113.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/gr/v20220309081602.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/gr/v20210113.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/gr/v20220309081602.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/gr/v20220216022726.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-CC/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 EC-Earth3-Veg-LR-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/gr/v20200217.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/gr/v20220309084358.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/gr/v20200217.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/gr/v20220309084358.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/gr/v20201201.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/gr/v20220309084358.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/gr/v20201201.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/gr/v20220309084358.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/gr/v20201123.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/gr/v20220309084358.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/gr/v20201123.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/gr/v20220309084358.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/gr/v20201123.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/gr/v20220309084358.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/gr/v20201123.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/gr/v20220309084358.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/gr/v20201201.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/gr/v20220309084358.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/gr/v20220215232907.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/gr/v20201201.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/gr/v20220309084358.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/gr/v20220215232907.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 EC-Earth3-Veg-LR-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/gr/v20200217.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/gr/v20220309073804.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/gr/v20200217.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/gr/v20220309073804.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/gr/v20201201.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/gr/v20220309073804.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/gr/v20201201.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/gr/v20220309073804.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/gr/v20201123.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/gr/v20220309073804.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/gr/v20201123.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/gr/v20220309073804.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/gr/v20201123.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/gr/v20220309073804.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/gr/v20201123.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/gr/v20220309073804.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/gr/v20201201.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/gr/v20220309073804.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/gr/v20201201.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/gr/v20220309073804.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/gr/v20220215030028.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 EC-Earth3-Veg-LR-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/gr/v20200217.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/gr/v20220309081546.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/gr/v20200217.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/gr/v20220309081546.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/gr/v20201201.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/gr/v20220309081546.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/gr/v20201201.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/gr/v20220309081546.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/gr/v20201123.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/gr/v20220309081546.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/gr/v20201123.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/gr/v20220309081546.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/gr/v20201123.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/gr/v20220309081546.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/gr/v20201123.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/gr/v20220309081546.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/gr/v20201201.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/gr/v20220309081546.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/gr/v20201201.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/gr/v20220309081546.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081547.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg-LR/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 EC-Earth3-Veg-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/gr/v20200225.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/gr/v20220309084404.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/gr/v20200225.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/gr/v20220309084404.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/gr/v20200225.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/gr/v20220309084404.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/gr/v20200225.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/gr/v20220309084404.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/gr/v20200225.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/gr/v20220309084404.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/gr/v20200225.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/gr/v20220309084404.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/gr/v20200225.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/gr/v20220309084404.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/gr/v20200225.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/gr/v20220309084404.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/gr/v20200225.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/gr/v20220309084404.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/gr/v20220217012503.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/gr/v20200225.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/gr/v20220309084404.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/gr/v20220217012503.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 EC-Earth3-Veg-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/gr/v20200225.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/gr/v20220309073810.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/gr/v20200225.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/gr/v20220309073810.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/gr/v20200225.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/gr/v20220309073810.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/gr/v20200225.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/gr/v20220309073810.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/gr/v20200225.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/gr/v20220309073810.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/gr/v20200225.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/gr/v20220309073810.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/gr/v20200225.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/gr/v20220309073810.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/gr/v20200225.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/gr/v20220309073810.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/gr/v20200225.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/gr/v20220309073810.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/gr/v20200225.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/gr/v20220309073810.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/gr/v20220215031242.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 EC-Earth3-Veg-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/gr/v20200225.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/gr/v20220309081551.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/gr/v20200225.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/gr/v20220309081551.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3-Veg/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/gr/v20200225.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/gr/v20220309081551.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/gr/v20200225.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/gr/v20220309081551.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/gr/v20200225.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/gr/v20220309081551.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/gr/v20200225.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/gr/v20220309081551.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/gr/v20200225.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/gr/v20220309081551.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/gr/v20200225.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/gr/v20220309081551.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/gr/v20200225.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/gr/v20220309081551.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/gr/v20200225.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/gr/v20220309081551.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081553.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3-Veg/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 EC-Earth3-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/gr/v20220217012505.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/gr/v20200310.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/gr/v20220309084413.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/gr/v20220217012505.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/gr/v20220217012505.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/gr/v20200310.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/gr/v20220309084413.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/gr/v20220217012505.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/gr/v20220217012505.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/gr/v20200310.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/gr/v20220309084413.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/gr/v20220217012505.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/gr/v20220217012505.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/gr/v20200310.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/gr/v20220309084413.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/gr/v20220217012505.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/gr/v20220217012505.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/gr/v20200310.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/gr/v20220309084413.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/gr/v20220217012505.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/gr/v20220217012505.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/gr/v20200310.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/gr/v20220309084413.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/gr/v20220217012505.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/gr/v20220217012505.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/gr/v20200310.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/gr/v20220309084413.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/gr/v20220217012505.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/gr/v20220217012505.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/gr/v20200310.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/gr/v20220309084413.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/gr/v20220217012505.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/gr/v20220307025028.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/gr/v20200310.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/gr/v20220309084413.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/gr/v20220307025028.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/gr/v20220307025028.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/gr/v20200310.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/gr/v20220309084413.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/gr/v20220307025028.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 EC-Earth3-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/gr/v20200310.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/gr/v20220309073816.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/gr/v20200310.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/gr/v20220309073816.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/gr/v20200310.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/gr/v20220309073816.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/gr/v20200310.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/gr/v20220309073816.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/gr/v20200310.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/gr/v20220309073816.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/gr/v20200310.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/gr/v20220309073816.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/gr/v20200310.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/gr/v20220309073816.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/gr/v20200310.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/gr/v20220309073816.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/gr/v20200310.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/gr/v20220309073816.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/gr/v20200310.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/gr/v20220309073816.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/gr/v20220215031248.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 EC-Earth3-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/gr/v20200310.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/gr/v20220309081557.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/gr/v20200310.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/gr/v20220309081557.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/EC-Earth-Consortium/EC-Earth3/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/gr/v20200310.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/gr/v20220309081557.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/gr/v20200310.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/gr/v20220309081557.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/gr/v20200310.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/gr/v20220309081557.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/gr/v20200310.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/gr/v20220309081557.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/gr/v20200310.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/gr/v20220309081557.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/gr/v20200310.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/gr/v20220309081557.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/gr/v20200310.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/gr/v20220309081557.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/gr/v20200310.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/gr/v20220309081557.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/gr/v20220215081559.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/EC-Earth-Consortium/EC-Earth3/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 FGOALS-g3-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/gn/v20220204004649.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/gn/v20190826.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/gn/v20220309084323.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/gn/v20220204004649.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/gn/v20220204004649.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/gn/v20190826.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/gn/v20220309084323.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/gn/v20220204004649.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/gn/v20220204004649.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/gn/v20190818.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/gn/v20220309084323.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/gn/v20220204004649.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/gn/v20220204004649.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/gn/v20190818.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/gn/v20220309084323.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/gn/v20220204004649.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/gn/v20220204004649.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/gn/v20190820.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/gn/v20220309084323.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/gn/v20220204004649.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/gn/v20220204004649.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/gn/v20190820.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/gn/v20220309084323.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/gn/v20220204004649.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/gn/v20220204004649.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/gn/v20190818.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/gn/v20220309084323.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/gn/v20220204004649.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/gn/v20220204004649.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/gn/v20190818.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/gn/v20220309084323.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/gn/v20220204004649.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 FGOALS-g3-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/gn/v20190826.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/gn/v20220309073725.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/gn/v20190826.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/gn/v20220309073725.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/gn/v20190818.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073725.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/gn/v20190818.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073725.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/gn/v20190818.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073725.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/gn/v20190818.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073725.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/gn/v20190820.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073725.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/gn/v20190820.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073725.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/gn/v20190819.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073725.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/gn/v20190819.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073725.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010337.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 FGOALS-g3-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/gn/v20190826.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/gn/v20220309081508.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/gn/v20190826.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/gn/v20220309081508.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/CAS/FGOALS-g3/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/gn/v20190818.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081508.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/gn/v20190818.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081508.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/gn/v20190818.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081508.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/gn/v20190818.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081508.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/gn/v20190820.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081508.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/gn/v20190820.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081508.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/gn/v20190819.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081508.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/gn/v20190819.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081508.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010208.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/CAS/FGOALS-g3/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 GFDL-CM4-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/gr1/v20220309084326.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/gr1/v20220309084326.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/gr1/v20220309084326.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/gr1/v20220309084326.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/gr1/v20220309084326.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/gr1/v20220309084326.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/gr1/v20220204004651.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 GFDL-CM4-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/gr1/v20220309073728.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/gr1/v20220309073728.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220309073728.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220309073728.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220309073728.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220309073728.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010340.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 GFDL-CM4-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/gr1/v20220309081511.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/gr1/v20220309081511.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NOAA-GFDL/GFDL-CM4/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220309081511.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220309081511.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220309081511.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220309081511.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010211.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-CM4/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 GFDL-ESM4-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/gr1/v20190726.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/gr1/v20220309084328.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/gr1/v20190726.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/gr1/v20220309084328.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/gr1/v20220309084328.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/gr1/v20220309084328.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/gr1/v20220309084328.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/gr1/v20220309084328.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/gr1/v20220309084328.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/gr1/v20220309084328.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/gr1/v20220309084328.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/gr1/v20220309084328.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/gr1/v20220211070751.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 GFDL-ESM4-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20190726.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20220309073732.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20190726.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20220309073732.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/gr1/v20220309073732.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/gr1/v20220309073732.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220309073732.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220309073732.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20220309073732.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20220309073732.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220309073732.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220309073732.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010342.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 GFDL-ESM4-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/gr1/v20190726.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/gr1/v20220309081514.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/gr1/v20190726.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/gr1/v20220309081514.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NOAA-GFDL/GFDL-ESM4/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/gr1/v20220309081514.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/gr1/v20220309081514.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220309081514.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220309081514.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/gr1/v20220309081514.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/gr1/v20220309081514.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220309081514.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20180701.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220309081514.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010213.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NOAA-GFDL/GFDL-ESM4/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 HadGEM3-GC31-LL-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/gn/v20220217031623.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/gn/v20190624.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/gn/v20220309084356.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/gn/v20220217031623.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/gn/v20220217031623.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/gn/v20190624.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/gn/v20220309084356.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/gn/v20220217031623.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/gn/v20220217031623.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/gn/v20200114.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/gn/v20220309084356.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/gn/v20220217031623.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/gn/v20220217031623.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/gn/v20200114.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/gn/v20220309084356.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/gn/v20220217031623.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/gn/v20220217031623.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/gn/v20190908.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/gn/v20220309084356.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/gn/v20220217031623.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/gn/v20220217031623.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/gn/v20190908.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/gn/v20220309084356.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/gn/v20220217031623.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/gn/v20220217031623.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/gn/v20200114.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/gn/v20220309084356.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/gn/v20220217031623.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/gn/v20220217031623.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/gn/v20200114.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/gn/v20220309084356.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/gn/v20220217031623.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/pr/v1.1.zarr
 HadGEM3-GC31-LL-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/gn/v20190624.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/gn/v20220309073802.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/gn/v20190624.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/gn/v20220309073802.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/gn/v20200114.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/gn/v20220309073802.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/gn/v20200114.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/gn/v20220309073802.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/gn/v20190908.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/gn/v20220309073802.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/gn/v20190908.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/gn/v20220309073802.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/gn/v20200114.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/gn/v20220309073802.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/gn/v20200114.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/gn/v20220309073802.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/gn/v20220217010508.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmax/v1.1.zarr
 HadGEM3-GC31-LL-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/gn/v20190624.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/gn/v20220309081543.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/gn/v20190624.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/gn/v20220309081543.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MOHC/HadGEM3-GC31-LL/historical/r1i1p1f3/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/gn/v20200114.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/gn/v20220309081543.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/gn/v20200114.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/gn/v20220309081543.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp126/r1i1p1f3/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/gn/v20190908.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/gn/v20220309081543.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/gn/v20190908.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/gn/v20220309081543.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp245/r1i1p1f3/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/gn/v20200114.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/gn/v20220309081543.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/gn/v20200114.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/gn/v20220309081543.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/gn/v20220217031044.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/HadGEM3-GC31-LL/ssp585/r1i1p1f3/day/tasmin/v1.1.zarr
 INM-CM4-8-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/gr1/v20190530.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/gr1/v20220309084331.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/gr1/v20190530.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/gr1/v20220309084331.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/gr1/v20190603.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/gr1/v20220309084331.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/gr1/v20190603.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/gr1/v20220309084331.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/gr1/v20190603.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/gr1/v20220309084331.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/gr1/v20190603.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/gr1/v20220309084331.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/gr1/v20190603.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/gr1/v20220309084331.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/gr1/v20190603.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/gr1/v20220309084331.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/gr1/v20190603.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/gr1/v20220309084331.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/gr1/v20190603.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/gr1/v20220309084331.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/gr1/v20220204071009.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 INM-CM4-8-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/gr1/v20190530.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/gr1/v20220309073735.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/gr1/v20190530.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/gr1/v20220309073735.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/gr1/v20190603.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/gr1/v20220309073735.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/gr1/v20190603.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/gr1/v20220309073735.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/gr1/v20190603.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/gr1/v20220309073735.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/gr1/v20190603.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/gr1/v20220309073735.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/gr1/v20190603.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/gr1/v20220309073735.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/gr1/v20190603.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/gr1/v20220309073735.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/gr1/v20190603.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/gr1/v20220309073735.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/gr1/v20190603.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/gr1/v20220309073735.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010345.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 INM-CM4-8-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/gr1/v20190530.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/gr1/v20220309081517.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/gr1/v20190530.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/gr1/v20220309081517.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/INM/INM-CM4-8/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/gr1/v20190603.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/gr1/v20220309081517.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/gr1/v20190603.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/gr1/v20220309081517.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/gr1/v20190603.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/gr1/v20220309081517.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/gr1/v20190603.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/gr1/v20220309081517.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/gr1/v20190603.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/gr1/v20220309081517.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/gr1/v20190603.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/gr1/v20220309081517.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/gr1/v20190603.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/gr1/v20220309081517.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/gr1/v20190603.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/gr1/v20220309081517.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125142911.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM4-8/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 INM-CM5-0-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/gr1/v20190610.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/gr1/v20220309084334.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/gr1/v20190610.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/gr1/v20220309084334.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/gr1/v20190619.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/gr1/v20220309084334.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/gr1/v20190619.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/gr1/v20220309084334.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/gr1/v20190619.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/gr1/v20220309084334.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/gr1/v20190619.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/gr1/v20220309084334.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/gr1/v20190618.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/gr1/v20220309084334.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/gr1/v20190618.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/gr1/v20220309084334.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/gr1/v20190724.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/gr1/v20220309084334.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/gr1/v20190724.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/gr1/v20220309084334.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/gr1/v20220204071011.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 INM-CM5-0-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/gr1/v20190610.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/gr1/v20220309073738.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/gr1/v20190610.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/gr1/v20220309073738.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/gr1/v20190619.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/gr1/v20220309073738.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/gr1/v20190619.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/gr1/v20220309073738.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/gr1/v20190619.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/gr1/v20220309073738.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/gr1/v20190619.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/gr1/v20220309073738.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/gr1/v20190618.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/gr1/v20220309073738.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/gr1/v20190618.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/gr1/v20220309073738.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/gr1/v20190724.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/gr1/v20220309073738.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/gr1/v20190724.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/gr1/v20220309073738.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/gr1/v20220125010347.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 INM-CM5-0-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/gr1/v20190610.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/gr1/v20220309081521.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/gr1/v20190610.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/gr1/v20220309081521.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/INM/INM-CM5-0/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/gr1/v20190619.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/gr1/v20220309081521.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/gr1/v20190619.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/gr1/v20220309081521.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/gr1/v20190619.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/gr1/v20220309081521.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/gr1/v20190619.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/gr1/v20220309081521.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/gr1/v20190618.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/gr1/v20220309081521.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/gr1/v20190618.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/gr1/v20220309081521.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/gr1/v20190724.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/gr1/v20220309081521.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/gr1/v20190724.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/gr1/v20220309081521.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/gr1/v20220125010218.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/INM/INM-CM5-0/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 MIROC-ES2L-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/gn/v20191129.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/gn/v20220309084337.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/gn/v20191129.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/gn/v20220309084337.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/gn/v20200318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/gn/v20220309084337.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/gn/v20200318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/gn/v20220309084337.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/gn/v20200318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/gn/v20220309084337.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/gn/v20200318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/gn/v20220309084337.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/gn/v20200318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/gn/v20220309084337.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/gn/v20200318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/gn/v20220309084337.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/gn/v20200318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/gn/v20220309084337.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/gn/v20220204071014.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/gn/v20200318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/gn/v20220309084337.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/gn/v20220204071014.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/pr/v1.1.zarr
 MIROC-ES2L-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/gn/v20191129.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/gn/v20220309073741.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/gn/v20191129.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/gn/v20220309073741.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/gn/v20200318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/gn/v20220309073741.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/gn/v20200318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/gn/v20220309073741.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/gn/v20200318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/gn/v20220309073741.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/gn/v20200318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/gn/v20220309073741.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/gn/v20200318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/gn/v20220309073741.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/gn/v20200318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/gn/v20220309073741.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/gn/v20200318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/gn/v20220309073741.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/gn/v20200318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/gn/v20220309073741.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/gn/v20220125010349.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmax/v1.1.zarr
 MIROC-ES2L-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/gn/v20191129.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/gn/v20220309081524.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/gn/v20191129.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/gn/v20220309081524.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MIROC/MIROC-ES2L/historical/r1i1p1f2/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/gn/v20200318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/gn/v20220309081524.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/gn/v20200318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/gn/v20220309081524.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp126/r1i1p1f2/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/gn/v20200318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/gn/v20220309081524.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/gn/v20200318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/gn/v20220309081524.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp245/r1i1p1f2/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/gn/v20200318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/gn/v20220309081524.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/gn/v20200318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/gn/v20220309081524.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp370/r1i1p1f2/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/gn/v20200318.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/gn/v20220309081524.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/gn/v20200318.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/gn/v20220309081524.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/gn/v20220125010220.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC-ES2L/ssp585/r1i1p1f2/day/tasmin/v1.1.zarr
 MIROC6-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/gn/v20191016.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/gn/v20220309084339.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/gn/v20191016.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/gn/v20220309084339.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/gn/v20191016.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/gn/v20220309084339.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/gn/v20191016.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/gn/v20220309084339.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/gn/v20191016.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/gn/v20220309084339.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/gn/v20191016.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/gn/v20220309084339.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/gn/v20191016.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/gn/v20220309084339.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/gn/v20191016.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/gn/v20220309084339.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/gn/v20191016.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/gn/v20220309084339.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/gn/v20220204071017.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/gn/v20191016.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/gn/v20220309084339.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/gn/v20220204071017.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 MIROC6-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/gn/v20191016.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/gn/v20220309073743.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/gn/v20191016.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/gn/v20220309073743.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/gn/v20191016.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073743.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/gn/v20191016.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073743.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/gn/v20191016.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073743.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/gn/v20191016.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073743.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/gn/v20191016.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073743.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/gn/v20191016.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073743.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/gn/v20191016.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073743.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/gn/v20191016.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073743.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010352.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 MIROC6-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/gn/v20191016.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/gn/v20220309081527.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/gn/v20191016.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/gn/v20220309081527.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MIROC/MIROC6/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/gn/v20191016.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081527.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/gn/v20191016.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081527.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/gn/v20191016.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081527.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/gn/v20191016.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081527.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/gn/v20191016.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081527.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/gn/v20191016.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081527.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/gn/v20191016.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081527.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/gn/v20191016.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081527.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010223.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MIROC/MIROC6/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 MPI-ESM1-2-HR-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/gn/v20220217124205.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/gn/v20220309084350.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/gn/v20220217124205.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/gn/v20220217124205.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/gn/v20220309084350.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/gn/v20220217124205.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/gn/v20220217124205.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/gn/v20220309084350.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/gn/v20220217124205.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/gn/v20220217124205.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/gn/v20220309084350.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/gn/v20220217124205.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/gn/v20220217124205.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/gn/v20220309084350.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/gn/v20220217124205.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/gn/v20220217124205.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/gn/v20220309084350.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/gn/v20220217124205.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 MPI-ESM1-2-HR-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/gn/v20220309073756.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/gn/v20220309073756.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073756.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073756.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073756.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073756.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/gn/v20220217124151.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 MPI-ESM1-2-HR-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/gn/v20220309081538.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/gn/v20220309081538.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081538.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081538.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081538.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081538.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/gn/v20220217124158.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 MPI-ESM1-2-LR-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/gn/v20220309084402.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/gn/v20220309084402.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/gn/v20220309084402.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/gn/v20220309084402.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/gn/v20220309084402.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/gn/v20220309084402.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/gn/v20220309084402.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/gn/v20220309084402.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/gn/v20220309084402.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/gn/v20220215232910.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/gn/v20220309084402.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/gn/v20220215232910.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 MPI-ESM1-2-LR-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/gn/v20220309073807.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/gn/v20220309073807.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073807.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073807.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073807.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073807.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073807.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073807.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073807.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073807.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/gn/v20220215030031.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 MPI-ESM1-2-LR-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/gn/v20220309081549.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/gn/v20220309081549.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MPI-M/MPI-ESM1-2-LR/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081549.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081549.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081549.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081549.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081549.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081549.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/gn/v20190710.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081549.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/gn/v20190710.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081549.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/gn/v20220215081550.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MPI-M/MPI-ESM1-2-LR/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 NESM3-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/gn/v20220204071020.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/gn/v20190812.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/gn/v20220309084342.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/gn/v20220204071020.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/gn/v20220204071020.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/gn/v20190812.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/gn/v20220309084342.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/gn/v20220204071020.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/gn/v20220204071020.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/gn/v20190806.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/gn/v20220309084342.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/gn/v20220204071020.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/gn/v20220204071020.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/gn/v20190806.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/gn/v20220309084342.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/gn/v20220204071020.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/gn/v20220204071020.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/gn/v20190805.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/gn/v20220309084342.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/gn/v20220204071020.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/gn/v20220204071020.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/gn/v20190805.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/gn/v20220309084342.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/gn/v20220204071020.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/gn/v20220204071020.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/gn/v20190811.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/gn/v20220309084342.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/gn/v20220204071020.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/gn/v20220204071020.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/gn/v20190811.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/gn/v20220309084342.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/gn/v20220204071020.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 NESM3-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/gn/v20190812.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/gn/v20220309073746.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/gn/v20190812.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/gn/v20220309073746.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/gn/v20190806.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073746.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/gn/v20190806.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073746.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/gn/v20190805.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073746.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/gn/v20190805.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073746.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/gn/v20190811.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073746.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/gn/v20190811.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073746.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010354.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 NESM3-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/gn/v20190812.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/gn/v20220309081530.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/gn/v20190812.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/gn/v20220309081530.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NUIST/NESM3/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/gn/v20190806.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081530.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/gn/v20190806.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081530.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/gn/v20190805.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081530.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/gn/v20190805.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081530.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/gn/v20190811.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081530.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/gn/v20190811.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081530.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010225.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NUIST/NESM3/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 NorESM2-LM-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/gn/v20190815.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/gn/v20220309084345.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/gn/v20190815.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/gn/v20220309084345.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/gn/v20220309084345.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/gn/v20220309084345.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/gn/v20220309084345.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/gn/v20220309084345.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/gn/v20220309084345.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/gn/v20220309084345.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/gn/v20220309084345.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/gn/v20220211070815.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/gn/v20220309084345.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/gn/v20220211070815.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 NorESM2-LM-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/gn/v20190815.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/gn/v20220309073751.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/gn/v20190815.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/gn/v20220309073751.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073751.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073751.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073751.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073751.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073751.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073751.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073751.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073751.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010357.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 NorESM2-LM-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/gn/v20190815.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/gn/v20220309081532.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/gn/v20190815.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/gn/v20220309081532.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NCC/NorESM2-LM/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081532.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081532.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081532.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081532.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081532.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081532.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081532.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081532.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010228.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-LM/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 NorESM2-MM-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/gn/v20220309084348.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/gn/v20220309084348.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/gn/v20220309084348.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/gn/v20220309084348.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/gn/v20220309084348.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/gn/v20220309084348.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/gn/v20220309084348.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/gn/v20220309084348.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/gn/v20220309084348.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/gn/v20220204071025.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/gn/v20220309084348.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/gn/v20220204071025.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/pr/v1.1.zarr
 NorESM2-MM-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/gn/v20220309073753.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/gn/v20220309073753.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073753.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/gn/v20220309073753.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073753.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/gn/v20220309073753.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073753.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/gn/v20220309073753.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073753.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/gn/v20220309073753.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/gn/v20220125010359.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmax/v1.1.zarr
 NorESM2-MM-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/gn/v20220309081535.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/gn/v20220309081535.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/NCC/NorESM2-MM/historical/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081535.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/gn/v20220309081535.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp126/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081535.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/gn/v20220309081535.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp245/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081535.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/gn/v20220309081535.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp370/r1i1p1f1/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/gn/v20191108.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081535.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/gn/v20191108.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/gn/v20220309081535.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/gn/v20220125010230.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/NCC/NorESM2-MM/ssp585/r1i1p1f1/day/tasmin/v1.1.zarr
 UKESM1-0-LL-pr:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/gn/v20190627.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/gn/v20220309084353.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/gn/v20190627.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/gn/v20220309084353.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/pr/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/gn/v20190708.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/gn/v20220309084353.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/gn/v20190708.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/gn/v20220309084353.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/pr/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/gn/v20190715.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/gn/v20220309084353.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/gn/v20190715.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/gn/v20220309084353.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/pr/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/gn/v20190726.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/gn/v20220309084353.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/gn/v20190726.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/gn/v20220309084353.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/pr/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/gn/v20190726.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/gn/v20220309084353.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/gn/v20220217031621.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/gn/v20190726.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/gn/v20220309084353.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/gn/v20220217031621.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/pr/v1.1.zarr
 UKESM1-0-LL-tasmax:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/gn/v20190627.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/gn/v20220309073759.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/gn/v20190627.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/gn/v20220309073759.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmax/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/gn/v20190708.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/gn/v20220309073759.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/gn/v20190708.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/gn/v20220309073759.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmax/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/gn/v20190715.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/gn/v20220309073759.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/gn/v20190715.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/gn/v20220309073759.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmax/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/gn/v20190726.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/gn/v20220309073759.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/gn/v20190726.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/gn/v20220309073759.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmax/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/gn/v20190726.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/gn/v20220309073759.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/gn/v20190726.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/gn/v20220309073759.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/gn/v20220217010510.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmax/v1.1.zarr
 UKESM1-0-LL-tasmin:
   historical:
-    biascorrected: gs://biascorrected-492e989a/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    clean: gs://clean-b1dbca25/cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/gn/v20190627.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/gn/v20220309081541.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    clean: gs://clean-f1e04ef5/cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/gn/v20190627.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/gn/v20220309081541.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/CMIP/MOHC/UKESM1-0-LL/historical/r1i1p1f2/day/tasmin/v1.1.zarr
   ssp126:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/gn/v20190708.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/gn/v20220309081541.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/gn/v20190708.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/gn/v20220309081541.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp126/r1i1p1f2/day/tasmin/v1.1.zarr
   ssp245:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/gn/v20190715.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/gn/v20220309081541.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/gn/v20190715.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/gn/v20220309081541.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp245/r1i1p1f2/day/tasmin/v1.1.zarr
   ssp370:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/gn/v20190726.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/gn/v20220309081541.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/gn/v20190726.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/gn/v20220309081541.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp370/r1i1p1f2/day/tasmin/v1.1.zarr
   ssp585:
-    biascorrected: gs://biascorrected-492e989a/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    clean: gs://clean-b1dbca25/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/gn/v20190726.zarr
-    clean_regridded: gs://support-c23ff1a3/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/gn/v20220309081541.zarr
-    downscaled: gs://downscaled-288ec5ac/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
-    downscaled_delivered: gs://downscaled-288ec5ac/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/v1.1.zarr
+    biascorrected: gs://biascorrected-4a21ed18/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    clean: gs://clean-f1e04ef5/cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/gn/v20190726.zarr
+    clean_regridded: gs://support-f8a48a9e/regrid-cmip6/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/gn/v20220309081541.zarr
+    downscaled: gs://downscaled-48ec31ab/stage/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/gn/v20220217031041.zarr
+    downscaled_delivered: gs://downscaled-48ec31ab/outputs/ScenarioMIP/MOHC/UKESM1-0-LL/ssp585/r1i1p1f2/day/tasmin/v1.1.zarr


### PR DESCRIPTION
Changes hard-coded paths from Iowa buckets to Oregon buckets. Some ad-hoc notebook analyses use these files. The files is unusable without this update.

This was a basic "find-all/replace" on the file, replacing the stale buckets.

Related to #640.