### PR TITLE
Fix EC-Earth3-CC missing from diagnostic data

### DIFF
--- a/notebooks/downscaling_pipeline/post_processing_and_delivery/produce_paper_data.ipynb
+++ b/notebooks/downscaling_pipeline/post_processing_and_delivery/produce_paper_data.ipynb
@@ -136,6 +136,7 @@
     "    'MPI-ESM1-2-HR',\n",
     "    'EC-Earth3',\n",
     "    'EC-Earth3-AerChem',\n",
+    "    'EC-Earth3-CC',\n",
     "    'EC-Earth3-Veg',\n",
     "    'EC-Earth3-Veg-LR',\n",
     "    'HadGEM3-GC31-LL',\n",


### PR DESCRIPTION
EC-Earth3-CC was removed in PR #656 because it was not in a recent GCM inventory table, but this inventory table was incorrect and EC-Earth3-CC should have been included. This adds the GCM back.

The notebook was rerun to produce daily and clean-daily diagnostics for tasmin, tasmax, pr.