### PR TITLE
Update README CanESM5 license to CC-BY-4.0, remove dead sections, links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,11 +42,10 @@ Accessing the data
 
 GDPCIR data can be accessed on the Microsoft Planetary Computer: `planetarycomputer.microsoft.com/dataset/group/cil-gdpcir <https://planetarycomputer.microsoft.com/dataset/group/cil-gdpcir>`_
 
-The dataset is made of of three collections, distinguished by data license at the time of publication:
+The dataset is made of collections distinguished by data license at the time of publication:
 
 * `Public domain (CC0-1.0) collection <https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc0>`_
 * `Attribution (CC BY 4.0) collection <https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc-by>`_
-* `Attribution-ShareAlike (CC BY SA 4.0) collection <https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc-by-sa>`_ (note, the terms of use for these models have been updated and this collection is `now available under an attribution/CC BY 4.0 license <https://pcmdi.llnl.gov/CMIP6/TermsOfUse/TermsOfUse6-2.html>`_)
 
 Each modeling center with bias corrected and downscaled data in this collection falls into one of these license categories - see the `table below <#available-institutions-models-and-scenarios-by-license-collection>`_ to see which model is in each collection, and see the section below on `Citing, Licensing, and using data produced by this project <#citing-licensing-and-using-data-produced-by-this-project>`_ for citations and additional information about each license. For examples of how to browse the collections and load the data using python, see the `example use <#example-use>`_ section below.
 
@@ -89,7 +88,7 @@ EC-Earth-Consortium  EC-Earth3-AerChem ssp370                                   
 EC-Earth-Consortium  EC-Earth3-CC      ssp245 and ssp585                           `CC-BY-4.0`_
 EC-Earth-Consortium  EC-Earth3-Veg     ssp1-2.6, ssp2-4.5, ssp3-7.0, and ssp5-8.5  `CC-BY-4.0`_
 EC-Earth-Consortium  EC-Earth3-Veg-LR  ssp1-2.6, ssp2-4.5, ssp3-7.0, and ssp5-8.5  `CC-BY-4.0`_
-CCCma                CanESM5           ssp1-2.6, ssp2-4.5, ssp3-7.0, ssp5-8.5      `CC-BY-SA-4.0`_ [*]_
+CCCma                CanESM5           ssp1-2.6, ssp2-4.5, ssp3-7.0, ssp5-8.5      `CC-BY-4.0`_
 ==================== ================= ==========================================  =========================
 
 *Notes:*
@@ -97,8 +96,6 @@ CCCma                CanESM5           ssp1-2.6, ssp2-4.5, ssp3-7.0, ssp5-8.5   
 .. [*] At the time of running, no ssp1-2.6 precipitation data was available for the FGOALS-g3 model. Therefore, we provide ``tasmin`` and ``tamax`` for this model and experiment, but not ``pr``. All other model/experiment combinations in the above table include all three variables.
 
 .. [*] The institution which ran MPI-ESM1-2-HR’s historical (CMIP) simulations is `MPI-M`, while the future (ScenarioMIP) simulations were run by `DKRZ`. Therefore, the institution component of `MPI-ESM1-2-HR` filepaths differ between `historical` and `SSP` scenarios.
-
-.. [*] Downscaled data associated with the CanESM5 model is `now available under an attribution/CC BY 4.0 license <https://pcmdi.llnl.gov/CMIP6/TermsOfUse/TermsOfUse6-2.html>`_. However, the model output is still part of the CC-BY-SA collection on Planetary Computer because this is the license the data had at the time of publication.
 
 .. _Example Use:
 
@@ -269,6 +266,19 @@ The following bias corrected and downscaled model simulations are licensed under
   ScenarioMIP Citation:
 
     Xin, Xiaoge; Wu, Tongwen; Shi, Xueli; Zhang, Fang; Li, Jianglong; Chu, Min; Liu, Qianxia; Yan, Jinghui; Ma, Qiang; Wei, Min **(2019)**. *BCC BCC-CSM2MR model output prepared for CMIP6 ScenarioMIP*. SSP1-2.6 version 20190315; SSP2-4.5 version 20190318; SSP3-7.0 version 20190318; SSP5-8.5 version 20190318. Earth System Grid Federation. https://doi.org/10.22033/ESGF/CMIP6.1732
+
+
+* **CanESM5**
+
+  License description: `data_licenses/CanESM5.txt <https://raw.githubusercontent.com/ClimateImpactLab/downscaleCMIP6/master/data_licenses/CanESM5.txt>`_
+
+  CMIP Citation:
+
+    Swart, Neil Cameron; Cole, Jason N.S.; Kharin, Viatcheslav V.; Lazare, Mike; Scinocca, John F.; Gillett, Nathan P.; Anstey, James; Arora, Vivek; Christian, James R.; Jiao, Yanjun; Lee, Warren G.; Majaess, Fouad; Saenko, Oleg A.; Seiler, Christian; Seinen, Clint; Shao, Andrew; Solheim, Larry; von Salzen, Knut; Yang, Duo; Winter, Barbara; Sigmond, Michael **(2019)**. *CCCma CanESM5 model output prepared for CMIP6 CMIP*. Version 20190429. Earth System Grid Federation. https://doi.org/10.22033/ESGF/CMIP6.1303
+
+  ScenarioMIP Citation:
+
+    Swart, Neil Cameron; Cole, Jason N.S.; Kharin, Viatcheslav V.; Lazare, Mike; Scinocca, John F.; Gillett, Nathan P.; Anstey, James; Arora, Vivek; Christian, James R.; Jiao, Yanjun; Lee, Warren G.; Majaess, Fouad; Saenko, Oleg A.; Seiler, Christian; Seinen, Clint; Shao, Andrew; Solheim, Larry; von Salzen, Knut; Yang, Duo; Winter, Barbara; Sigmond, Michael **(2019)**. *CCCma CanESM5 model output prepared for CMIP6 ScenarioMIP*. Version 20190429. Earth System Grid Federation. https://doi.org/10.22033/ESGF/CMIP6.1317
 
 
 * **CMCC-CM2-SR5**
@@ -504,24 +514,6 @@ The following bias corrected and downscaled model simulations are licensed under
 
     Good, Peter; Sellar, Alistair; Tang, Yongming; Rumbold, Steve; Ellis, Rich; Kelley, Douglas; Kuhlbrodt, Till; Walton, Jeremy **(2019)**. *MOHC UKESM1.0-LL model output prepared for CMIP6 ScenarioMIP*. SSP1-2.6 version 20190708; SSP2-4.5 version 20190715; SSP3-7.0 version 20190726; SSP5-8.5 version 20190726. Earth System Grid Federation. https://doi.org/10.22033/ESGF/CMIP6.1567
 
-.. _CC-BY-SA:
-
-CC-BY-SA-4.0
-~~~~~~~~~~~~
-
-The following bias corrected and downscaled model simulations were originally licensed under a `Creative Commons Attribution-ShareAlike 4.0 International License <https://creativecommons.org/licenses/by-sa/4.0/>`_, but this license has since been changed to a `Creative Commons Attribution 4.0 International License <https://creativecommons.org/licenses/by/4.0/>`_. See the `CMIP6 terms of use <https://pcmdi.llnl.gov/CMIP6/TermsOfUse/TermsOfUse6-2.html>`_ for more information. Access the collection on Planetary Computer at https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc-by-sa.
-
-* **CanESM5**
-
-  License description: `data_licenses/CanESM5.txt <https://raw.githubusercontent.com/ClimateImpactLab/downscaleCMIP6/master/data_licenses/CanESM5.txt>`_
-
-  CMIP Citation:
-
-    Swart, Neil Cameron; Cole, Jason N.S.; Kharin, Viatcheslav V.; Lazare, Mike; Scinocca, John F.; Gillett, Nathan P.; Anstey, James; Arora, Vivek; Christian, James R.; Jiao, Yanjun; Lee, Warren G.; Majaess, Fouad; Saenko, Oleg A.; Seiler, Christian; Seinen, Clint; Shao, Andrew; Solheim, Larry; von Salzen, Knut; Yang, Duo; Winter, Barbara; Sigmond, Michael **(2019)**. *CCCma CanESM5 model output prepared for CMIP6 CMIP*. Version 20190429. Earth System Grid Federation. https://doi.org/10.22033/ESGF/CMIP6.1303
-
-  ScenarioMIP Citation:
-
-    Swart, Neil Cameron; Cole, Jason N.S.; Kharin, Viatcheslav V.; Lazare, Mike; Scinocca, John F.; Gillett, Nathan P.; Anstey, James; Arora, Vivek; Christian, James R.; Jiao, Yanjun; Lee, Warren G.; Majaess, Fouad; Saenko, Oleg A.; Seiler, Christian; Seinen, Clint; Shao, Andrew; Solheim, Larry; von Salzen, Knut; Yang, Duo; Winter, Barbara; Sigmond, Michael **(2019)**. *CCCma CanESM5 model output prepared for CMIP6 ScenarioMIP*. Version 20190429. Earth System Grid Federation. https://doi.org/10.22033/ESGF/CMIP6.1317
 
 Acknowledgements
 ================


### PR DESCRIPTION

 - [x] closes #660
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 downscale tests docs``
 - [ ] entry in HISTORY.rst

Updates the README concerning licensing for CanESM5. It was CC-BY-SA-4.0 it is now CC-BY-4.0. Removed dead URLs and unused license sections as part of this.